### PR TITLE
Raw image modification implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,14 @@ RUN go build ./cmd/eib
 
 
 # ----- Deliverable Image -----
-FROM registry.suse.com/bci/bci-base:15.5
+FROM opensuse/leap:15.5
 
-RUN zypper install -y xorriso
+# Dependency uses by line
+# 1. ISO image building
+# 2. RAW image modification on x86
+RUN zypper install -y \
+    xorriso  \
+    libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs
 
 COPY --from=0 /src/eib /bin/eib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM opensuse/leap:15.5
 
 # Dependency uses by line
 # 1. ISO image building
-# 2. RAW image modification on x86
+# 2. RAW image modification on x86_64
 RUN zypper install -y \
     xorriso  \
     libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -48,21 +48,18 @@ func (b *Builder) Build() error {
 		return fmt.Errorf("generating combustion script: %w", err)
 	}
 
-	if b.imageConfig.Image.ImageType == config.ImageTypeISO {
+	switch b.imageConfig.Image.ImageType {
+	case config.ImageTypeISO:
 		err = b.buildIsoImage()
-		if err != nil {
-			return fmt.Errorf("error building modified ISO: %w", err)
-		}
-	} else if b.imageConfig.Image.ImageType == config.ImageTypeRAW {
+	case config.ImageTypeRAW:
 		err = b.buildRawImage()
-		if err != nil {
-			return fmt.Errorf("error building modified raw image: %w", err)
-		}
-	} else {
-		// This is temporary until we have validation in place that will ensure the config
-		// is valid well before we hit this point
-		return fmt.Errorf("invalid imageType value specified, must be either \"%s\" or \"%s\"",
+	default:
+		fmt.Errorf("invalid imageType value specified, must be either \"%s\" or \"%s\"",
 			config.ImageTypeISO, config.ImageTypeRAW)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	// Temporarily disabling; will add a flag to control this next

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -48,9 +48,21 @@ func (b *Builder) Build() error {
 		return fmt.Errorf("generating combustion script: %w", err)
 	}
 
-	err = b.buildIsoImage()
-	if err != nil {
-		return fmt.Errorf("error building modified ISO: %w", err)
+	if b.imageConfig.Image.ImageType == config.ImageTypeISO {
+		err = b.buildIsoImage()
+		if err != nil {
+			return fmt.Errorf("error building modified ISO: %w", err)
+		}
+	} else if b.imageConfig.Image.ImageType == config.ImageTypeRAW {
+		err = b.buildRawImage()
+		if err != nil {
+			return fmt.Errorf("error building modified raw image: %w", err)
+		}
+	} else {
+		// This is temporary until we have validation in place that will ensure the config
+		// is valid well before we hit this point
+		return fmt.Errorf("invalid imageType value specified, must be either \"%s\" or \"%s\"",
+			config.ImageTypeISO, config.ImageTypeRAW)
 	}
 
 	// Temporarily disabling; will add a flag to control this next
@@ -156,5 +168,10 @@ func (b *Builder) registerCombustionScript(scriptName string) {
 
 func (b *Builder) generateOutputImageFilename() string {
 	filename := filepath.Join(b.buildConfig.ImageConfigDir, b.imageConfig.Image.OutputImageName)
+	return filename
+}
+
+func (b *Builder) generateBaseImageFilename() string {
+	filename := filepath.Join(b.buildConfig.ImageConfigDir, "images", b.imageConfig.Image.BaseImage)
 	return filename
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -153,3 +153,8 @@ func (b *Builder) registerCombustionScript(scriptName string) {
 
 	b.combustionScripts = append(b.combustionScripts, scriptName)
 }
+
+func (b *Builder) generateOutputImageFilename() string {
+	filename := filepath.Join(b.buildConfig.ImageConfigDir, b.imageConfig.Image.OutputImageName)
+	return filename
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -54,7 +54,7 @@ func (b *Builder) Build() error {
 	case config.ImageTypeRAW:
 		err = b.buildRawImage()
 	default:
-		fmt.Errorf("invalid imageType value specified, must be either \"%s\" or \"%s\"",
+		err = fmt.Errorf("invalid imageType value specified, must be either \"%s\" or \"%s\"",
 			config.ImageTypeISO, config.ImageTypeRAW)
 	}
 

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -38,7 +38,7 @@ func (b *Builder) buildIsoImage() error {
 }
 
 func (b *Builder) deleteExistingOutputIso() error {
-	outputFilename := b.generateOutputIsoFilename()
+	outputFilename := b.generateOutputImageFilename()
 	err := os.Remove(outputFilename)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("error deleting file %s: %w", outputFilename, err)
@@ -77,9 +77,4 @@ func (b *Builder) generateIsoLogFilename() string {
 	filename := fmt.Sprintf(xorrisoLogFile, timestamp)
 	logFilename := filepath.Join(b.eibBuildDir, filename)
 	return logFilename
-}
-
-func (b *Builder) generateOutputIsoFilename() string {
-	filename := filepath.Join(b.buildConfig.ImageConfigDir, b.imageConfig.Image.OutputImageName)
-	return filename
 }

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -63,8 +63,8 @@ func (b *Builder) createXorrisoCommand() (*exec.Cmd, *os.File, error) {
 }
 
 func (b *Builder) generateXorrisoArgs() []string {
-	indevPath := filepath.Join(b.buildConfig.ImageConfigDir, "images", b.imageConfig.Image.BaseImage)
-	outdevPath := filepath.Join(b.buildConfig.ImageConfigDir, b.imageConfig.Image.OutputImageName)
+	indevPath := b.generateBaseImageFilename()
+	outdevPath := b.generateOutputImageFilename()
 	mapDir := b.combustionDir
 
 	args := fmt.Sprintf(xorrisoArgsBase, indevPath, outdevPath, mapDir)

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -49,7 +49,7 @@ func TestDeleteExistingImage(t *testing.T) {
 	}
 	builder := New(&imageConfig, &buildConfig)
 
-	_, err = os.Create(builder.generateOutputIsoFilename())
+	_, err = os.Create(builder.generateOutputImageFilename())
 	require.NoError(t, err)
 
 	// Test
@@ -58,7 +58,7 @@ func TestDeleteExistingImage(t *testing.T) {
 	// Verify
 	require.NoError(t, err)
 
-	_, err = os.Stat(builder.generateOutputIsoFilename())
+	_, err = os.Stat(builder.generateOutputImageFilename())
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
 }

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -1,0 +1,66 @@
+package build
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	copyExec = "/bin/cp"
+	modifyScriptName = "modify-raw-image.sh"
+)
+
+//go:embed scripts/modify-raw-image.sh
+var modifyRawImageScript string
+
+func (b *Builder) buildRawImage() error {
+	cmd := b.createRawImageCopyCommand()
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("copying the base image %s to the output image location %s: %w",
+			b.imageConfig.Image.BaseImage, b.generateOutputImageFilename(), err)
+	}
+
+	err = b.writeModifyScript()
+	if err != nil {
+		return fmt.Errorf("writing the image modification script: %w", err)
+	}
+
+	cmd = b.createModifyCommand()
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("running the image modification script: %w", err)
+	}
+
+	return nil
+}
+
+func (b *Builder) createRawImageCopyCommand() *exec.Cmd {
+	baseImagePath := b.generateBaseImageFilename()
+	outputImagePath := b.generateOutputImageFilename()
+
+	cmd := exec.Command(copyExec, baseImagePath, outputImagePath)
+	return cmd
+}
+
+func (b *Builder) writeModifyScript() error {
+	imageToModify := b.generateOutputImageFilename()
+	contents := fmt.Sprintf(modifyRawImageScript, imageToModify, b.combustionDir)
+
+	scriptPath := filepath.Join(b.buildConfig.BuildDir, modifyScriptName)
+	err := os.WriteFile(scriptPath, []byte(contents), os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("writing file %s: %w", scriptPath, err)
+	}
+
+	return nil
+}
+
+func (b *Builder) createModifyCommand() *exec.Cmd {
+	scriptPath := filepath.Join(b.buildConfig.BuildDir, modifyScriptName)
+	cmd := exec.Command(scriptPath)
+	return cmd
+}

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -1,0 +1,89 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/config"
+)
+
+func TestCreateRawImageCopyCommand(t *testing.T) {
+	// Setup
+	imageConfig := config.ImageConfig{
+		Image: config.Image{
+			BaseImage:       "base-image",
+			OutputImageName: "build-image",
+		},
+	}
+	buildConfig := config.BuildConfig{
+		ImageConfigDir: "config-dir",
+	}
+	builder := New(&imageConfig, &buildConfig)
+
+	// Test
+	cmd := builder.createRawImageCopyCommand()
+
+	// Verify
+	require.NotNil(t, cmd)
+
+	assert.Equal(t, copyExec, cmd.Path)
+	expectedArgs := []string {
+		copyExec,
+		builder.generateBaseImageFilename(),
+		builder.generateOutputImageFilename(),
+	}
+	assert.Equal(t, expectedArgs, cmd.Args)
+}
+
+func TestWriteModifyScript(t *testing.T) {
+	// Setup
+	tmpDir, err := os.MkdirTemp("", "eib-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	imageConfig := config.ImageConfig{
+		Image: config.Image{
+			OutputImageName: "output-image",
+		},
+	}
+	buildConfig := config.BuildConfig{
+		ImageConfigDir: "config-dir",
+		BuildDir: tmpDir,
+	}
+	builder := New(&imageConfig, &buildConfig)
+	builder.combustionDir = "combustion-dir"
+
+	// Test
+	err = builder.writeModifyScript()
+
+	// Verify
+	require.NoError(t, err)
+
+	expectedFilename := filepath.Join(tmpDir, modifyScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	foundContents := string(foundBytes)
+	assert.Contains(t, foundContents, "guestfish --rw -a config-dir/output-image")
+	assert.Contains(t, foundContents, "copy-in combustion-dir")
+}
+
+func TestCreateModifyCommand(t *testing.T) {
+	// Setup
+	buildConfig := config.BuildConfig{
+		BuildDir: "build-dir",
+	}
+	builder := New(nil, &buildConfig)
+
+	// Test
+	cmd := builder.createModifyCommand()
+
+	// Verify
+	require.NotNil(t, cmd)
+
+	expectedPath := filepath.Join("build-dir", modifyScriptName)
+	assert.Equal(t, expectedPath, cmd.Path)
+}

--- a/pkg/build/scripts/modify-raw-image.sh
+++ b/pkg/build/scripts/modify-raw-image.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+#  Substitution Fields
+#  1. Full path to the image to modify
+#  2. Full path to the combustion directory
+
+#  Guestfish Commands Explanation
+#
+#  sh "btrfs property set / ro false"
+#  - Enables write access to the read only filesystem
+#
+#  copy-in _s /
+#  - Copies the combustion directory into the root of the image
+#  - _s should be populated with the full path to the built combustion directory
+#
+#  sh "btrfs filesystem label / INSTALL"
+#  - As of Oct 25, 2023, combustion only checks volumes of certain names for the
+#    /combustion directory. The SLE Micro raw image sets the root partition name to
+#    "ROOT", which isn't one of the checked volume names. This line changes the
+#    label to "INSTALL" (the same as the ISO installer uses) so it's picked up
+#    when combustion runs.
+#
+#  sh "btrfs property set / ro true"
+#  - Resets the filesystem to read only
+
+guestfish --rw -a %s -i <<'EOF'
+  sh "btrfs property set / ro false"
+  copy-in %s /
+  sh "btrfs filesystem label / INSTALL"
+  sh "btrfs property set / ro true"
+EOF

--- a/pkg/config/image.go
+++ b/pkg/config/image.go
@@ -6,6 +6,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	ImageTypeISO = "iso"
+	ImageTypeRAW = "raw"
+)
+
 type ImageConfig struct {
 	APIVersion string `yaml:"apiVersion"`
 	Image	   Image  `yaml:"image"`


### PR DESCRIPTION
Uses libguestfs inside of the container. This implementation currently only works on x86 (fails on aarch64) due to differences in the containers. Due to package availability, the EIB container image was changed to Leap. We may be able to readdress this in the future.
