### PR TITLE
Fixed issue where the modify script for raw images could not be executed

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -138,14 +138,14 @@ func (b *Builder) generateCombustionScript() error {
 	return nil
 }
 
-func (b *Builder) writeBuildDirFile(filename string, contents string, templateData any) error {
+func (b *Builder) writeBuildDirFile(filename string, contents string, templateData any) (string, error) {
 	destFilename := filepath.Join(b.eibBuildDir, filename)
-	return b.writeFile(destFilename, contents, templateData)
+	return destFilename, b.writeFile(destFilename, contents, templateData)
 }
 
-func (b *Builder) writeCombustionFile(filename string, contents string, templateData any) error {
+func (b *Builder) writeCombustionFile(filename string, contents string, templateData any) (string, error) {
 	destFilename := filepath.Join(b.combustionDir, filename)
-	return b.writeFile(destFilename, contents, templateData)
+	return destFilename, b.writeFile(destFilename, contents, templateData)
 }
 
 func (b *Builder) writeFile(filename string, contents string, templateData any) error {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -122,7 +122,7 @@ func TestWriteCombustionFile(t *testing.T) {
 	testFilename := "combustion-file.sh"
 
 	// Test
-	err = builder.writeCombustionFile(testFilename, testData, nil)
+	writtenFilename, err := builder.writeCombustionFile(testFilename, testData, nil)
 
 	// Verify
 	require.NoError(t, err)
@@ -130,6 +130,7 @@ func TestWriteCombustionFile(t *testing.T) {
 	expectedFilename := filepath.Join(builder.combustionDir, testFilename)
 	foundData, err := os.ReadFile(expectedFilename)
 	require.NoError(t, err)
+	assert.Equal(t, expectedFilename, writtenFilename)
 	assert.Equal(t, testData, string(foundData))
 
 	// Make sure the file isn't automatically added to the combustion scripts list
@@ -147,12 +148,13 @@ func TestWriteBuildDirFile(t *testing.T) {
 	testFilename := "build-dir-file.sh"
 
 	// Test
-	err = builder.writeBuildDirFile(testFilename, testData, nil)
+	writtenFilename, err := builder.writeBuildDirFile(testFilename, testData, nil)
 
 	// Verify
 	require.NoError(t, err)
 
 	expectedFilename := filepath.Join(builder.eibBuildDir, testFilename)
+	require.Equal(t, expectedFilename, writtenFilename)
 	foundData, err := os.ReadFile(expectedFilename)
 	require.NoError(t, err)
 	assert.Equal(t, testData, string(foundData))

--- a/pkg/build/message.go
+++ b/pkg/build/message.go
@@ -13,7 +13,7 @@ const (
 var messageScript string
 
 func (b *Builder) configureMessage() error {
-	err := b.writeCombustionFile(messageScriptName, messageScript, nil)
+	_, err := b.writeCombustionFile(messageScriptName, messageScript, nil)
 	if err != nil {
 		return fmt.Errorf("copying script %s: %w", messageScriptName, err)
 	}

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -3,6 +3,7 @@ package build
 import (
 	_ "embed"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 )
@@ -10,6 +11,7 @@ import (
 const (
 	copyExec         = "/bin/cp"
 	modifyScriptName = "modify-raw-image.sh"
+	modifyScriptMode = 0o744
 )
 
 //go:embed scripts/modify-raw-image.sh.tpl
@@ -54,9 +56,13 @@ func (b *Builder) writeModifyScript() error {
 		CombustionDir: b.combustionDir,
 	}
 
-	err := b.writeBuildDirFile(modifyScriptName, modifyRawImageScript, &values)
+	writtenFilename, err := b.writeBuildDirFile(modifyScriptName, modifyRawImageScript, &values)
 	if err != nil {
 		return fmt.Errorf("writing modification script %s: %w", modifyScriptName, err)
+	}
+	err = os.Chmod(writtenFilename, modifyScriptMode)
+	if err != nil {
+		return fmt.Errorf("changing permissions on the modification script %s: %w", modifyScriptName, err)
 	}
 
 	return nil

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -65,6 +66,10 @@ func TestWriteModifyScript(t *testing.T) {
 	expectedFilename := filepath.Join(tmpDir, modifyScriptName)
 	foundBytes, err := os.ReadFile(expectedFilename)
 	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(modifyScriptMode), stats.Mode())
 
 	foundContents := string(foundBytes)
 	assert.Contains(t, foundContents, "guestfish --rw -a config-dir/output-image")


### PR DESCRIPTION
As part of this, I refactored the writeBuildDirFile and writeCombustionDirFile methods to return the full name of the file written. They are meant to be utility functions to prevent the caller from having to manually assemble the full paths to common locations, and it makes sense that these calls would also tell the user what the filename ended up being.

closes #29 