### PR TITLE
modify platform openstack

### DIFF
--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -51,9 +51,11 @@ func (b *Builder) writeModifyScript() error {
 	values := struct {
 		OutputImage   string
 		CombustionDir string
+		Platform      string
 	}{
 		OutputImage:   b.generateOutputImageFilename(),
 		CombustionDir: b.combustionDir,
+		Platform:      b.imageConfig.OperatingSystem.Platform,
 	}
 
 	writtenFilename, err := b.writeBuildDirFile(modifyScriptName, modifyRawImageScript, &values)

--- a/pkg/build/scripts/modify-raw-image.sh.tpl
+++ b/pkg/build/scripts/modify-raw-image.sh.tpl
@@ -24,7 +24,10 @@ set -euo pipefail
 #  - Resets the filesystem to read only
 
 guestfish --rw -a {{.OutputImage}} -i <<'EOF'
+  download /boot/grub2/grub.cfg /tmp/grub.cfg
+  ! sed -i 's/ignition.platform.id=metal/ignition.platform.id={{.Platform}}/' /tmp/grub.cfg
   sh "btrfs property set / ro false"
+  upload /tmp/grub.cfg /boot/grub2/grub.cfg
   copy-in {{.CombustionDir}} /
   sh "btrfs filesystem label / INSTALL"
   sh "btrfs property set / ro true"

--- a/pkg/config/image.go
+++ b/pkg/config/image.go
@@ -12,8 +12,13 @@ const (
 )
 
 type ImageConfig struct {
-	APIVersion string `yaml:"apiVersion"`
-	Image      Image  `yaml:"image"`
+	APIVersion      string          `yaml:"apiVersion"`
+	Image           Image           `yaml:"image"`
+	OperatingSystem OperatingSystem `yaml:"operatingSystem"`
+}
+
+type OperatingSystem struct {
+	Platform string `yaml:"platform"`
 }
 
 type Image struct {

--- a/pkg/config/image_test.go
+++ b/pkg/config/image_test.go
@@ -22,6 +22,7 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "1.0", imageConfig.APIVersion)
 	assert.Equal(t, "iso", imageConfig.Image.ImageType)
 	assert.Equal(t, "slemicro5.5.iso", imageConfig.Image.BaseImage)
+	assert.Equal(t, "openstack", imageConfig.OperatingSystem.Platform)
 	assert.Equal(t, "eibimage.iso", imageConfig.Image.OutputImageName)
 }
 

--- a/pkg/config/testdata/valid_example.yaml
+++ b/pkg/config/testdata/valid_example.yaml
@@ -3,3 +3,5 @@ image:
   imageType: iso
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
+operatingSystem:
+  platform: openstack


### PR DESCRIPTION
add the platform to operating system in order to enable on grub.cfg the kernel args platform.id=openstack required for metal3 workflow