### PR TITLE
Working implementation of GRUB configuration for raw images

### DIFF
--- a/pkg/build/grub.go
+++ b/pkg/build/grub.go
@@ -1,0 +1,42 @@
+package build
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+//go:embed scripts/grub/guestfish-snippet.tpl
+var guestfishSnippet string
+
+func (b *Builder) generateGRUBGuestfishCommands() (string, error) {
+	// Nothing to do if there aren't any args. Return an empty string that will be injected
+	// into the raw image guestfish modification, effectively doing nothing but not breaking
+	// the guestfish command
+	if b.imageConfig.OperatingSystem.KernelArgs == nil {
+		return "", nil
+	}
+
+	tmpl, err := template.New("guestfish-snippet").Parse(guestfishSnippet)
+	if err != nil {
+		return "", fmt.Errorf("building template for GRUB guestfish snippet: %w", err)
+	}
+
+	argLine := strings.Join(b.imageConfig.OperatingSystem.KernelArgs, " ")
+	values := struct {
+		KernelArgs string
+	}{
+		KernelArgs: argLine,
+	}
+
+	var buff bytes.Buffer
+	err = tmpl.Execute(&buff, values)
+	if err != nil {
+		return "", fmt.Errorf("applying GRUB guestfish snippet: %w", err)
+	}
+
+	snippet := buff.String()
+	return snippet, nil
+}

--- a/pkg/build/grub_test.go
+++ b/pkg/build/grub_test.go
@@ -1,0 +1,47 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/config"
+)
+
+func TestGenerateGRUBGuestfishCommands(t *testing.T) {
+	// Setup
+	imageConfig := config.ImageConfig{
+		OperatingSystem: config.OperatingSystem{
+			KernelArgs: []string{"alpha", "beta"},
+		},
+	}
+	builder := New(&imageConfig, nil)
+
+	// Test
+	commandString, err := builder.generateGRUBGuestfishCommands()
+
+	// Verify
+	require.NoError(t, err)
+	require.NotNil(t, commandString)
+
+	expectedFirstBoot := "sed -i '/ignition.platform/ s/$/ alpha beta /' /tmp/grub.cfg"
+	assert.Contains(t, commandString, expectedFirstBoot)
+
+	expectedDefault := "sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=\"/ s/\"$/ alpha beta \"/' /tmp/grub"
+	assert.Contains(t, commandString, expectedDefault)
+}
+
+func TestGenerateGRUBGuestfishCommandsNoArgs(t *testing.T) {
+	// Setup
+	imageConfig := config.ImageConfig{
+		OperatingSystem: config.OperatingSystem{},
+	}
+	builder := New(&imageConfig, nil)
+
+	// Test
+	commandString, err := builder.generateGRUBGuestfishCommands()
+
+	// Verify
+	require.NoError(t, err)
+	assert.Equal(t, "", commandString)
+}

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -48,12 +48,22 @@ func (b *Builder) createRawImageCopyCommand() *exec.Cmd {
 }
 
 func (b *Builder) writeModifyScript() error {
+	// There is no need to check the returned results from this call. If there is no configuration,
+	// it will be an empty string, which is safe to pass into the template.
+	grubConfiguration, err := b.generateGRUBGuestfishCommands()
+	if err != nil {
+		return fmt.Errorf("generating the GRUB configuration commands: %w", err)
+	}
+
+	// Assemble the template values
 	values := struct {
 		OutputImage   string
 		CombustionDir string
+		ConfigureGRUB string
 	}{
 		OutputImage:   b.generateOutputImageFilename(),
 		CombustionDir: b.combustionDir,
+		ConfigureGRUB: grubConfiguration,
 	}
 
 	writtenFilename, err := b.writeBuildDirFile(modifyScriptName, modifyRawImageScript, &values)

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -49,6 +49,9 @@ func TestWriteModifyScript(t *testing.T) {
 		Image: config.Image{
 			OutputImageName: "output-image",
 		},
+		OperatingSystem: config.OperatingSystem{
+			KernelArgs: []string{"alpha", "beta"},
+		},
 	}
 	buildConfig := config.BuildConfig{
 		ImageConfigDir: "config-dir",
@@ -74,6 +77,7 @@ func TestWriteModifyScript(t *testing.T) {
 	foundContents := string(foundBytes)
 	assert.Contains(t, foundContents, "guestfish --rw -a config-dir/output-image")
 	assert.Contains(t, foundContents, "copy-in "+builder.combustionDir)
+	assert.Contains(t, foundContents, "download /boot/grub2/grub.cfg /tmp/grub.cfg")
 }
 
 func TestCreateModifyCommand(t *testing.T) {

--- a/pkg/build/scripts/grub/guestfish-snippet.tpl
+++ b/pkg/build/scripts/grub/guestfish-snippet.tpl
@@ -1,0 +1,13 @@
+# Configure GRUB for first boot
+# - Without this, the values wouldn't be used until after the first time the
+#   grub configuration is regenerated
+download /boot/grub2/grub.cfg /tmp/grub.cfg
+! sed -i '/ignition.platform/ s/$/ {{.KernelArgs}} /' /tmp/grub.cfg
+upload /tmp/grub.cfg /boot/grub2/grub.cfg
+
+# Configure GRUB defaults
+# - Without this, when `transactional-update grub.cfg` is run it will overwrite
+#   settings used in the above change
+download /etc/default/grub /tmp/grub
+! sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT="/ s/"$/ {{.KernelArgs}} "/' /tmp/grub
+upload /tmp/grub /etc/default/grub

--- a/pkg/build/scripts/modify-raw-image.sh.tpl
+++ b/pkg/build/scripts/modify-raw-image.sh.tpl
@@ -13,8 +13,10 @@ guestfish --rw -a {{.OutputImage}} -i <<'EOF'
   # Enables write access to the read only filesystem
   sh "btrfs property set / ro false"
 
-  # GRUB configuration (if specified)
-  {{.ConfigureGRUB}}
+  {{ if ne .ConfigureGRUB "" }}
+      # GRUB configuration
+      {{ .ConfigureGRUB }}
+  {{ end }}
 
   # Copies the combustion directory into the root of the image
   copy-in {{.CombustionDir}} /

--- a/pkg/build/scripts/modify-raw-image.sh.tpl
+++ b/pkg/build/scripts/modify-raw-image.sh.tpl
@@ -4,28 +4,28 @@ set -euo pipefail
 #  Template Fields
 #  OutputImage   - Full path to the image to modify
 #  CombustionDir - Full path to the combustion directory
-
-#  Guestfish Commands Explanation
+#  ConfigureGRUB - Contains the guestfish command lines to run to manipulate GRUB configuration.
+#                  If there is no specific GRUB configuration to do, this will be an empty string.
 #
-#  sh "btrfs property set / ro false"
-#  - Enables write access to the read only filesystem
-#
-#  copy-in __.CombustionDir__ /
-#  - Copies the combustion directory into the root of the image
-#
-#  sh "btrfs filesystem label / INSTALL"
-#  - As of Oct 25, 2023, combustion only checks volumes of certain names for the
-#    /combustion directory. The SLE Micro raw image sets the root partition name to
-#    "ROOT", which isn't one of the checked volume names. This line changes the
-#    label to "INSTALL" (the same as the ISO installer uses) so it's picked up
-#    when combustion runs.
-#
-#  sh "btrfs property set / ro true"
-#  - Resets the filesystem to read only
+# Guestfish Command Documentation: https://libguestfs.org/guestfish.1.html
 
 guestfish --rw -a {{.OutputImage}} -i <<'EOF'
+  # Enables write access to the read only filesystem
   sh "btrfs property set / ro false"
+
+  # GRUB configuration (if specified)
+  {{.ConfigureGRUB}}
+
+  # Copies the combustion directory into the root of the image
   copy-in {{.CombustionDir}} /
+
+  # As of Oct 25, 2023, combustion only checks volumes of certain names for the
+  # /combustion directory. The SLE Micro raw image sets the root partition name to
+  # "ROOT", which isn't one of the checked volume names. This line changes the
+  # label to "INSTALL" (the same as the ISO installer uses) so it's picked up
+  # when combustion runs.
   sh "btrfs filesystem label / INSTALL"
+
+  # Resets the filesystem to read only
   sh "btrfs property set / ro true"
 EOF

--- a/pkg/config/image.go
+++ b/pkg/config/image.go
@@ -12,14 +12,19 @@ const (
 )
 
 type ImageConfig struct {
-	APIVersion string `yaml:"apiVersion"`
-	Image      Image  `yaml:"image"`
+	APIVersion      string          `yaml:"apiVersion"`
+	Image           Image           `yaml:"image"`
+	OperatingSystem OperatingSystem `yaml:"operatingSystem"`
 }
 
 type Image struct {
 	ImageType       string `yaml:"imageType"`
 	BaseImage       string `yaml:"baseImage"`
 	OutputImageName string `yaml:"outputImageName"`
+}
+
+type OperatingSystem struct {
+	KernelArgs []string `yaml:"kernelArgs"`
 }
 
 func Parse(data []byte) (*ImageConfig, error) {

--- a/pkg/config/image_test.go
+++ b/pkg/config/image_test.go
@@ -23,6 +23,12 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "iso", imageConfig.Image.ImageType)
 	assert.Equal(t, "slemicro5.5.iso", imageConfig.Image.BaseImage)
 	assert.Equal(t, "eibimage.iso", imageConfig.Image.OutputImageName)
+
+	expectedKernelArgs := []string{
+		"alpha=foo",
+		"beta=bar",
+	}
+	assert.Equal(t, expectedKernelArgs, imageConfig.OperatingSystem.KernelArgs)
 }
 
 func TestParseBadConfig(t *testing.T) {

--- a/pkg/config/testdata/valid_example.yaml
+++ b/pkg/config/testdata/valid_example.yaml
@@ -3,3 +3,7 @@ image:
   imageType: iso
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
+operatingSystem:
+  kernelArgs:
+    - alpha=foo
+    - beta=bar


### PR DESCRIPTION
We may have to revisit the actual sed commands once we more thoroughly test this, but this does currently work. Hopefully, those sorts of changes should have a minimal footprint and the rest of the structure used in this PR will remain.

We also may have to revisit how we get things into the modify-raw-image.sh template. That'll be affected by both the need to do this for manipulating the squashed raw image inside of an ISO (that's coming up soon on my todo list) as well as a refactoring if we end up jamming a lot into the guestfish command. But for now, this should be a reasonable start to build on and readdress when we have a clearer picture of what everything looks like.