### PR TITLE
Split templating from file IO operations

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 
 	"github.com/suse-edge/edge-image-builder/pkg/config"
-	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 //go:embed scripts/script_base.sh
@@ -94,14 +93,12 @@ func (b *Builder) generateCombustionScript() error {
 	return nil
 }
 
-func (b *Builder) writeBuildDirFile(filename string, contents string, templateData any) (string, error) {
-	destFilename := filepath.Join(b.context.BuildDir, filename)
-	return destFilename, fileio.WriteFile(destFilename, contents, templateData)
+func (b *Builder) generateBuildDirFilename(filename string) string {
+	return filepath.Join(b.context.BuildDir, filename)
 }
 
-func (b *Builder) writeCombustionFile(filename string, contents string, templateData any) (string, error) {
-	destFilename := filepath.Join(b.context.CombustionDir, filename)
-	return destFilename, fileio.WriteFile(destFilename, contents, templateData)
+func (b *Builder) generateCombustionDirFilename(filename string) string {
+	return filepath.Join(b.context.CombustionDir, filename)
 }
 
 func (b *Builder) registerCombustionScript(scriptName string) {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -42,7 +42,7 @@ func TestGenerateCombustionScript(t *testing.T) {
 	assert.Equal(t, "foo.sh", builder.combustionScripts[1])
 }
 
-func TestWriteCombustionFile(t *testing.T) {
+func TestGenerateCombustionDirFilename(t *testing.T) {
 	// Setup
 	context, err := NewContext("", "", true)
 	require.NoError(t, err)
@@ -54,26 +54,17 @@ func TestWriteCombustionFile(t *testing.T) {
 		context: context,
 	}
 
-	testData := "Edge Image Builder"
 	testFilename := "combustion-file.sh"
 
 	// Test
-	writtenFilename, err := builder.writeCombustionFile(testFilename, testData, nil)
+	filename := builder.generateCombustionDirFilename(testFilename)
 
 	// Verify
-	require.NoError(t, err)
-
 	expectedFilename := filepath.Join(context.CombustionDir, testFilename)
-	foundData, err := os.ReadFile(expectedFilename)
-	require.NoError(t, err)
-	assert.Equal(t, expectedFilename, writtenFilename)
-	assert.Equal(t, testData, string(foundData))
-
-	// Make sure the file isn't automatically added to the combustion scripts list
-	require.Equal(t, 0, len(builder.combustionScripts))
+	assert.Equal(t, expectedFilename, filename)
 }
 
-func TestWriteBuildDirFile(t *testing.T) {
+func TestGenerateBuildDirFilename(t *testing.T) {
 	// Setup
 	context, err := NewContext("", "", true)
 	require.NoError(t, err)
@@ -85,18 +76,12 @@ func TestWriteBuildDirFile(t *testing.T) {
 		context: context,
 	}
 
-	testData := "Edge Image Builder"
 	testFilename := "build-dir-file.sh"
 
 	// Test
-	writtenFilename, err := builder.writeBuildDirFile(testFilename, testData, nil)
+	filename := builder.generateBuildDirFilename(testFilename)
 
 	// Verify
-	require.NoError(t, err)
-
 	expectedFilename := filepath.Join(context.BuildDir, testFilename)
-	require.Equal(t, expectedFilename, writtenFilename)
-	foundData, err := os.ReadFile(expectedFilename)
-	require.NoError(t, err)
-	assert.Equal(t, testData, string(foundData))
+	require.Equal(t, expectedFilename, filename)
 }

--- a/pkg/build/grub.go
+++ b/pkg/build/grub.go
@@ -28,7 +28,7 @@ func (b *Builder) generateGRUBGuestfishCommands() (string, error) {
 
 	snippet, err := template.Parse("guestfish-snippet", guestfishSnippet, values)
 	if err != nil {
-		return "", fmt.Errorf("parsing guestfish template: %w", err)
+		return "", fmt.Errorf("parsing GRUB guestfish snippet: %w", err)
 	}
 
 	return snippet, nil

--- a/pkg/build/grub.go
+++ b/pkg/build/grub.go
@@ -1,11 +1,11 @@
 package build
 
 import (
-	"bytes"
 	_ "embed"
 	"fmt"
 	"strings"
-	"text/template"
+
+	"github.com/suse-edge/edge-image-builder/pkg/template"
 )
 
 //go:embed scripts/grub/guestfish-snippet.tpl
@@ -19,11 +19,6 @@ func (b *Builder) generateGRUBGuestfishCommands() (string, error) {
 		return "", nil
 	}
 
-	tmpl, err := template.New("guestfish-snippet").Parse(guestfishSnippet)
-	if err != nil {
-		return "", fmt.Errorf("building template for GRUB guestfish snippet: %w", err)
-	}
-
 	argLine := strings.Join(b.imageConfig.OperatingSystem.KernelArgs, " ")
 	values := struct {
 		KernelArgs string
@@ -31,12 +26,10 @@ func (b *Builder) generateGRUBGuestfishCommands() (string, error) {
 		KernelArgs: argLine,
 	}
 
-	var buff bytes.Buffer
-	err = tmpl.Execute(&buff, values)
+	snippet, err := template.Parse("guestfish-snippet", guestfishSnippet, values)
 	if err != nil {
-		return "", fmt.Errorf("applying GRUB guestfish snippet: %w", err)
+		return "", fmt.Errorf("parsing guestfish template: %w", err)
 	}
 
-	snippet := buff.String()
 	return snippet, nil
 }

--- a/pkg/build/message.go
+++ b/pkg/build/message.go
@@ -17,7 +17,7 @@ var messageScript string
 func (b *Builder) configureMessage() error {
 	filename := b.generateCombustionDirFilename(messageScriptName)
 
-	if err := fileio.WriteFile(filename, messageScript, nil); err != nil {
+	if err := fileio.WriteFile(filename, messageScript); err != nil {
 		return fmt.Errorf("copying script %s: %w", messageScriptName, err)
 	}
 	b.registerCombustionScript(messageScriptName)

--- a/pkg/build/message.go
+++ b/pkg/build/message.go
@@ -3,6 +3,7 @@ package build
 import (
 	_ "embed"
 	"fmt"
+	"os"
 
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
@@ -17,7 +18,7 @@ var messageScript string
 func (b *Builder) configureMessage() error {
 	filename := b.generateCombustionDirFilename(messageScriptName)
 
-	if err := fileio.WriteFile(filename, messageScript); err != nil {
+	if err := os.WriteFile(filename, []byte(messageScript), fileio.ExecutablePerms); err != nil {
 		return fmt.Errorf("copying script %s: %w", messageScriptName, err)
 	}
 	b.registerCombustionScript(messageScriptName)

--- a/pkg/build/message.go
+++ b/pkg/build/message.go
@@ -3,6 +3,8 @@ package build
 import (
 	_ "embed"
 	"fmt"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 const (
@@ -13,8 +15,9 @@ const (
 var messageScript string
 
 func (b *Builder) configureMessage() error {
-	_, err := b.writeCombustionFile(messageScriptName, messageScript, nil)
-	if err != nil {
+	filename := b.generateCombustionDirFilename(messageScriptName)
+
+	if err := fileio.WriteFile(filename, messageScript, nil); err != nil {
 		return fmt.Errorf("copying script %s: %w", messageScriptName, err)
 	}
 	b.registerCombustionScript(messageScriptName)

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -3,7 +3,6 @@ package build
 import (
 	_ "embed"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -13,7 +12,6 @@ import (
 const (
 	copyExec         = "/bin/cp"
 	modifyScriptName = "modify-raw-image.sh"
-	modifyScriptMode = 0o744
 )
 
 //go:embed scripts/modify-raw-image.sh.tpl
@@ -70,12 +68,8 @@ func (b *Builder) writeModifyScript() error {
 
 	filename := b.generateBuildDirFilename(modifyScriptName)
 
-	if err := fileio.WriteFile(filename, modifyRawImageScript, &values); err != nil {
+	if err := fileio.WriteTemplate(filename, modifyRawImageScript, &values); err != nil {
 		return fmt.Errorf("writing modification script %s: %w", modifyScriptName, err)
-	}
-	err = os.Chmod(filename, modifyScriptMode)
-	if err != nil {
-		return fmt.Errorf("changing permissions on the modification script %s: %w", modifyScriptName, err)
 	}
 
 	return nil

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 const (
@@ -66,11 +68,12 @@ func (b *Builder) writeModifyScript() error {
 		ConfigureGRUB: grubConfiguration,
 	}
 
-	writtenFilename, err := b.writeBuildDirFile(modifyScriptName, modifyRawImageScript, &values)
-	if err != nil {
+	filename := b.generateBuildDirFilename(modifyScriptName)
+
+	if err := fileio.WriteFile(filename, modifyRawImageScript, &values); err != nil {
 		return fmt.Errorf("writing modification script %s: %w", modifyScriptName, err)
 	}
-	err = os.Chmod(writtenFilename, modifyScriptMode)
+	err = os.Chmod(filename, modifyScriptMode)
 	if err != nil {
 		return fmt.Errorf("changing permissions on the modification script %s: %w", modifyScriptName, err)
 	}

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -70,12 +70,12 @@ func (b *Builder) writeModifyScript() error {
 
 	data, err := template.Parse(modifyScriptName, modifyRawImageTemplate, &values)
 	if err != nil {
-		return fmt.Errorf("parsing template: %w", err)
+		return fmt.Errorf("parsing %s template: %w", modifyScriptName, err)
 	}
 
 	filename := b.generateBuildDirFilename(modifyScriptName)
 	if err = os.WriteFile(filename, []byte(data), fileio.ExecutablePerms); err != nil {
-		return fmt.Errorf("writing modification script: %w", err)
+		return fmt.Errorf("writing modification script %s: %w", modifyScriptName, err)
 	}
 
 	return nil

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/config"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 func TestCreateRawImageCopyCommand(t *testing.T) {
@@ -70,7 +70,7 @@ func TestWriteModifyScript(t *testing.T) {
 
 	stats, err := os.Stat(expectedFilename)
 	require.NoError(t, err)
-	assert.Equal(t, fs.FileMode(0o744), stats.Mode())
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
 
 	foundContents := string(foundBytes)
 	assert.Contains(t, foundContents, "guestfish --rw -a config-dir/output-image")

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -70,7 +70,7 @@ func TestWriteModifyScript(t *testing.T) {
 
 	stats, err := os.Stat(expectedFilename)
 	require.NoError(t, err)
-	assert.Equal(t, fs.FileMode(modifyScriptMode), stats.Mode())
+	assert.Equal(t, fs.FileMode(0o744), stats.Mode())
 
 	foundContents := string(foundBytes)
 	assert.Contains(t, foundContents, "guestfish --rw -a config-dir/output-image")

--- a/pkg/build/rpm.go
+++ b/pkg/build/rpm.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
 	"strings"
 
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
 )
 
 const (
@@ -75,7 +75,7 @@ func copyRPMs(rpmSourceDir string, rpmDestDir string, rpmFileNames []string) err
 		sourcePath := filepath.Join(rpmSourceDir, rpm)
 		destPath := filepath.Join(rpmDestDir, rpm)
 
-		err := fileio.CopyFile(sourcePath, destPath, fileio.NonExecutablePerms))
+		err := fileio.CopyFile(sourcePath, destPath, fileio.NonExecutablePerms)
 		if err != nil {
 			return fmt.Errorf("copying file %s: %w", sourcePath, err)
 		}
@@ -91,13 +91,15 @@ func (b *Builder) writeRPMScript(rpmFileNames []string) error {
 		RPMs: strings.Join(rpmFileNames, " "),
 	}
 
-	writtenFilename, err := b.writeCombustionFile(modifyRPMScriptName, modifyRPMScript, &values)
+	data, err := template.Parse(modifyRPMScriptName, modifyRPMScript, &values)
+	if err != nil {
+		return fmt.Errorf("parsing RPM script template: %w", err)
+	}
+
+	filename := b.generateCombustionDirFilename(modifyRPMScriptName)
+	err = os.WriteFile(filename, []byte(data), fileio.ExecutablePerms)
 	if err != nil {
 		return fmt.Errorf("writing RPM script: %w", err)
-	}
-	err = os.Chmod(writtenFilename, modifyScriptMode)
-	if err != nil {
-		return fmt.Errorf("adjusting permissions: %w", err)
 	}
 
 	b.registerCombustionScript(modifyRPMScriptName)

--- a/pkg/build/rpm.go
+++ b/pkg/build/rpm.go
@@ -75,7 +75,7 @@ func copyRPMs(rpmSourceDir string, rpmDestDir string, rpmFileNames []string) err
 		sourcePath := filepath.Join(rpmSourceDir, rpm)
 		destPath := filepath.Join(rpmDestDir, rpm)
 
-		err := fileio.CopyFile(sourcePath, destPath)
+		err := fileio.CopyFile(sourcePath, destPath, fileio.NonExecutablePerms))
 		if err != nil {
 			return fmt.Errorf("copying file %s: %w", sourcePath, err)
 		}

--- a/pkg/build/rpm_test.go
+++ b/pkg/build/rpm_test.go
@@ -1,13 +1,13 @@
 package build
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 func setupRPMSourceDir(t *testing.T, addFiles bool) (tmpDir string, rpmSourceDir string, teardown func()) {
@@ -136,7 +136,7 @@ func TestWriteRPMScript(t *testing.T) {
 
 	stats, err := os.Stat(expectedFilename)
 	require.NoError(t, err)
-	assert.Equal(t, fs.FileMode(modifyScriptMode), stats.Mode())
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
 
 	foundContents := string(foundBytes)
 	assert.Contains(t, foundContents, "rpm1.rpm")

--- a/pkg/build/scripts.go
+++ b/pkg/build/scripts.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	scriptsDir = "scripts"
-	scriptMode = 0o744
 )
 
 func (b *Builder) configureScripts() error {
@@ -39,13 +38,9 @@ func (b *Builder) configureScripts() error {
 		copyMe := filepath.Join(fullScriptsDir, scriptEntry.Name())
 		copyTo := filepath.Join(b.context.CombustionDir, scriptEntry.Name())
 
-		err = fileio.CopyFile(copyMe, copyTo)
+		err = fileio.CopyFile(copyMe, copyTo, fileio.ExecutablePerms)
 		if err != nil {
 			return fmt.Errorf("copying script to %s: %w", copyTo, err)
-		}
-		err = os.Chmod(copyTo, scriptMode)
-		if err != nil {
-			return fmt.Errorf("modifying permissions for script %s: %w", copyTo, err)
 		}
 
 		// Make sure the combustion main script will execute the newly copied script

--- a/pkg/build/scripts_test.go
+++ b/pkg/build/scripts_test.go
@@ -1,13 +1,13 @@
 package build
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 func TestConfigureScripts(t *testing.T) {
@@ -56,7 +56,7 @@ func TestConfigureScripts(t *testing.T) {
 		fullEntryPath := filepath.Join(builder.context.CombustionDir, entry.Name())
 		stats, err := os.Stat(fullEntryPath)
 		require.NoError(t, err)
-		assert.Equal(t, fs.FileMode(0o744), stats.Mode())
+		assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
 	}
 
 	// - make sure entries were added to the combustion scripts list, so they are

--- a/pkg/build/scripts_test.go
+++ b/pkg/build/scripts_test.go
@@ -56,7 +56,7 @@ func TestConfigureScripts(t *testing.T) {
 		fullEntryPath := filepath.Join(builder.context.CombustionDir, entry.Name())
 		stats, err := os.Stat(fullEntryPath)
 		require.NoError(t, err)
-		assert.Equal(t, fs.FileMode(scriptMode), stats.Mode())
+		assert.Equal(t, fs.FileMode(0o744), stats.Mode())
 	}
 
 	// - make sure entries were added to the combustion scripts list, so they are

--- a/pkg/build/users_test.go
+++ b/pkg/build/users_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/config"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 func TestConfigureUsers(t *testing.T) {
@@ -61,7 +61,7 @@ func TestConfigureUsers(t *testing.T) {
 
 	stats, err := os.Stat(expectedFilename)
 	require.NoError(t, err)
-	assert.Equal(t, fs.FileMode(userScriptMode), stats.Mode())
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
 
 	foundContents := string(foundBytes)
 

--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -7,6 +7,13 @@ import (
 	"text/template"
 )
 
+const (
+	// ExecutablePerms are Linux permissions (rwxr--r--) for executable files (scripts, binaries, etc.)
+	ExecutablePerms os.FileMode = 0o744
+	// NonExecutablePerms are Linux permissions (rw-r--r--) for non-executable files (configs, RPMs, etc.):
+	NonExecutablePerms os.FileMode = 0o644
+)
+
 func WriteFile(filename string, contents string, templateData any) error {
 	if templateData == nil {
 		if err := os.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {

--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -4,44 +4,14 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"text/template"
 )
 
 const (
 	// ExecutablePerms are Linux permissions (rwxr--r--) for executable files (scripts, binaries, etc.)
 	ExecutablePerms os.FileMode = 0o744
-	// NonExecutablePerms are Linux permissions (rw-r--r--) for non-executable files (configs, RPMs, etc.):
+	// NonExecutablePerms are Linux permissions (rw-r--r--) for non-executable files (configs, RPMs, etc.)
 	NonExecutablePerms os.FileMode = 0o644
 )
-
-func WriteTemplate(filename string, contents string, templateData any) error {
-	if templateData == nil {
-		return fmt.Errorf("template data not provided")
-	}
-
-	tmpl, err := template.New(filename).Parse(contents)
-	if err != nil {
-		return fmt.Errorf("parsing template: %w", err)
-	}
-
-	file, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("creating file: %w", err)
-	}
-	defer func() {
-		_ = file.Close()
-	}()
-
-	if err = file.Chmod(ExecutablePerms); err != nil {
-		return fmt.Errorf("applying executable permissions: %w", err)
-	}
-
-	if err = tmpl.Execute(file, templateData); err != nil {
-		return fmt.Errorf("applying template: %w", err)
-	}
-
-	return nil
-}
 
 func CopyFile(src string, dest string, perms os.FileMode) error {
 	sourceFile, err := os.Open(src)

--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -14,14 +14,6 @@ const (
 	NonExecutablePerms os.FileMode = 0o644
 )
 
-func WriteFile(filename string, contents string) error {
-	if err := os.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
-		return fmt.Errorf("writing file: %w", err)
-	}
-
-	return nil
-}
-
 func WriteTemplate(filename string, contents string, templateData any) error {
 	if templateData == nil {
 		return fmt.Errorf("template data not provided")

--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -14,13 +14,17 @@ const (
 	NonExecutablePerms os.FileMode = 0o644
 )
 
-func WriteFile(filename string, contents string, templateData any) error {
-	if templateData == nil {
-		if err := os.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
-			return fmt.Errorf("writing file: %w", err)
-		}
+func WriteFile(filename string, contents string) error {
+	if err := os.WriteFile(filename, []byte(contents), os.ModePerm); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
 
-		return nil
+	return nil
+}
+
+func WriteTemplate(filename string, contents string, templateData any) error {
+	if templateData == nil {
+		return fmt.Errorf("template data not provided")
 	}
 
 	tmpl, err := template.New(filename).Parse(contents)
@@ -35,6 +39,10 @@ func WriteFile(filename string, contents string, templateData any) error {
 	defer func() {
 		_ = file.Close()
 	}()
+
+	if err = file.Chmod(ExecutablePerms); err != nil {
+		return fmt.Errorf("applying executable permissions: %w", err)
+	}
 
 	if err = tmpl.Execute(file, templateData); err != nil {
 		return fmt.Errorf("applying template: %w", err)

--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -43,7 +43,7 @@ func WriteTemplate(filename string, contents string, templateData any) error {
 	return nil
 }
 
-func CopyFile(src string, dest string) error {
+func CopyFile(src string, dest string, perms os.FileMode) error {
 	sourceFile, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("opening source file: %w", err)
@@ -59,6 +59,10 @@ func CopyFile(src string, dest string) error {
 	defer func() {
 		_ = destFile.Close()
 	}()
+
+	if err = destFile.Chmod(perms); err != nil {
+		return fmt.Errorf("adjusting permissions: %w", err)
+	}
 
 	if _, err = io.Copy(destFile, sourceFile); err != nil {
 		return fmt.Errorf("copying file: %w", err)

--- a/pkg/fileio/file_io_test.go
+++ b/pkg/fileio/file_io_test.go
@@ -103,6 +103,7 @@ func TestCopyFile(t *testing.T) {
 		name        string
 		source      string
 		destination string
+		perms       os.FileMode
 		expectedErr string
 	}{
 		{
@@ -126,12 +127,13 @@ func TestCopyFile(t *testing.T) {
 			name:        "File is successfully copied",
 			source:      source,
 			destination: fmt.Sprintf("%s/copy.go", tmpDir),
+			perms:       NonExecutablePerms,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := CopyFile(test.source, test.destination)
+			err := CopyFile(test.source, test.destination, test.perms)
 
 			if test.expectedErr != "" {
 				assert.EqualError(t, err, test.expectedErr)
@@ -143,8 +145,11 @@ func TestCopyFile(t *testing.T) {
 
 				dest, err := os.ReadFile(test.destination)
 				require.NoError(t, err)
-
 				assert.Equal(t, src, dest)
+
+				info, err := os.Stat(test.destination)
+				require.NoError(t, err)
+				assert.Equal(t, test.perms, info.Mode())
 			}
 		})
 	}

--- a/pkg/fileio/file_io_test.go
+++ b/pkg/fileio/file_io_test.go
@@ -11,49 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWriteFile(t *testing.T) {
-	const tmpDirPrefix = "eib-write-file-test-"
-
-	tmpDir, err := os.MkdirTemp("", tmpDirPrefix)
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	tests := []struct {
-		name             string
-		filename         string
-		contents         string
-		templateData     any
-		expectedContents string
-		expectedErr      string
-	}{
-		{
-			name:             "Standard file is successfully written",
-			filename:         "standard",
-			contents:         "this is a non-templated file",
-			expectedContents: "this is a non-templated file",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			filename := filepath.Join(tmpDir, test.filename)
-
-			err := WriteFile(filename, test.contents)
-
-			if test.expectedErr != "" {
-				assert.EqualError(t, err, test.expectedErr)
-			} else {
-				require.Nil(t, err)
-
-				contents, err := os.ReadFile(filename)
-				require.NoError(t, err)
-
-				assert.Equal(t, test.expectedContents, string(contents))
-			}
-		})
-	}
-}
-
 func TestWriteTemplate(t *testing.T) {
 	const tmpDirPrefix = "eib-write-template-test-"
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,0 +1,25 @@
+package template
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+func Parse(name string, contents string, templateData any) (string, error) {
+	if templateData == nil {
+		return "", fmt.Errorf("template data not provided")
+	}
+
+	tmpl, err := template.New(name).Parse(contents)
+	if err != nil {
+		return "", fmt.Errorf("parsing contents: %w", err)
+	}
+
+	var buff bytes.Buffer
+	if err = tmpl.Execute(&buff, templateData); err != nil {
+		return "", fmt.Errorf("applying template: %w", err)
+	}
+
+	return buff.String(), nil
+}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,0 +1,72 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name           string
+		templateName   string
+		contents       string
+		templateData   any
+		expectedOutput string
+		expectedErr    string
+	}{
+		{
+			name:         "Template is successfully processed",
+			templateName: "valid-template",
+			contents:     "{{.Foo}} and {{.Bar}}",
+			templateData: struct {
+				Foo string
+				Bar string
+			}{
+				Foo: "ooF",
+				Bar: "raB",
+			},
+			expectedOutput: "ooF and raB",
+		},
+		{
+			name:         "Templating fails due to missing data",
+			templateName: "missing-data",
+			contents:     "{{.Foo}} and {{.Bar}}",
+			expectedErr:  "template data not provided",
+		},
+		{
+			name:         "Templating fails due to invalid syntax",
+			templateName: "invalid-syntax",
+			contents:     "{{.Foo and ",
+			templateData: struct{}{},
+			expectedErr:  "parsing contents: template: invalid-syntax:1: unclosed action",
+		},
+		{
+			name:         "Templating fails due to missing field",
+			templateName: "invalid-data",
+			contents:     "{{.Foo}} and {{.Bar}}",
+			templateData: struct {
+				Foo string
+			}{
+				Foo: "ooF",
+			},
+			expectedErr: "applying template: template: invalid-data:1:15: " +
+				"executing \"invalid-data\" at <.Bar>: can't evaluate field Bar in type struct { Foo string }",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := Parse(test.templateName, test.contents, test.templateData)
+
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
+				assert.Equal(t, "", data)
+			} else {
+				require.Nil(t, err)
+				assert.Equal(t, test.expectedOutput, data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Initially aimed to add perms to `fileio` functions in order to drop unnecessary and prone to missing additional `Chmod()` calls
- Led to splitting up the initial `WriteFile` implementation to two separate parts `WriteFile` for non-templated files and `WriteTemplate` for templated ones
- `WriteFile` at that point was just a wrapper around `os.WriteFile` and `WriteTemplate` was doing too many things for a single function
- As a result, the `template` package was extracted and reused where applicable and `WriteFile` was removed. This decouples templating from IO ops and further simplifies combustion components structure and testing