### PR TITLE
Refactored custom scripts functionality to allow any file

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -114,8 +114,10 @@ There are a number of optional directories that may be included in the image con
   and will be included in the built image. The configurations relevant for the particular host will be identified
   and applied during the combustion phase. Check [nm-configurator](https://github.com/suse-edge/nm-configurator/)
   for more information.
-* `scripts` - If present, all the files in this directory will be included in the built image and automatically
-  executed during the combustion phase.
+* `custom` - May be included to inject files into the built image. Files are organized by subdirectory as follows:
+  * `scripts` - If present, all the files in this directory will be included in the built image and automatically
+    executed during the combustion phase.
+  * `files` - If present, all the files in this directory will be included in the built image.
 
 The following sections further describe optional directories that may be included.
 

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -42,7 +42,7 @@ func Configure(ctx *image.Context) error {
 		},
 		{
 			name:     customComponentName,
-			runnable: configureCustomScripts,
+			runnable: configureCustomFiles,
 		},
 		{
 			name:     networkComponentName,

--- a/pkg/combustion/custom.go
+++ b/pkg/combustion/custom.go
@@ -11,45 +11,75 @@ import (
 )
 
 const (
+	customDir           = "custom"
 	customScriptsDir    = "scripts"
-	customComponentName = "custom scripts"
+	customFilesDir      = "files"
+	customComponentName = "custom files"
 )
 
-func configureCustomScripts(ctx *image.Context) ([]string, error) {
-	if !isComponentConfigured(ctx, customScriptsDir) {
+func configureCustomFiles(ctx *image.Context) ([]string, error) {
+	if !isComponentConfigured(ctx, customDir) {
 		log.AuditComponentSkipped(customComponentName)
 		return nil, nil
 	}
 
-	fullScriptsDir := generateComponentPath(ctx, customScriptsDir)
-
-	dirListing, err := os.ReadDir(fullScriptsDir)
+	err := handleCustomFiles(ctx)
 	if err != nil {
 		log.AuditComponentFailed(customComponentName)
-		return nil, fmt.Errorf("reading the scripts directory at %s: %w", fullScriptsDir, err)
+		return nil, err
 	}
 
-	// If the directory exists but there's nothing in it, consider it an error case
-	if len(dirListing) == 0 {
+	scripts, err := handleCustomScripts(ctx)
+	if err != nil {
 		log.AuditComponentFailed(customComponentName)
-		return nil, fmt.Errorf("no scripts found in directory %s", fullScriptsDir)
-	}
-
-	var scripts []string
-
-	for _, scriptEntry := range dirListing {
-		copyMe := filepath.Join(fullScriptsDir, scriptEntry.Name())
-		copyTo := filepath.Join(ctx.CombustionDir, scriptEntry.Name())
-
-		err = fileio.CopyFile(copyMe, copyTo, fileio.ExecutablePerms)
-		if err != nil {
-			log.AuditComponentFailed(customComponentName)
-			return nil, fmt.Errorf("copying script to %s: %w", copyTo, err)
-		}
-
-		scripts = append(scripts, scriptEntry.Name())
+		return nil, err
 	}
 
 	log.AuditComponentSuccessful(customComponentName)
 	return scripts, nil
+}
+
+func handleCustomFiles(ctx *image.Context) error {
+	fullFilesDir := generateComponentPath(ctx, filepath.Join(customDir, customFilesDir))
+	_, err := copyCustomFiles(fullFilesDir, ctx.CombustionDir, fileio.NonExecutablePerms)
+	return err
+}
+
+func handleCustomScripts(ctx *image.Context) ([]string, error) {
+	fullScriptsDir := generateComponentPath(ctx, filepath.Join(customDir, customScriptsDir))
+	scripts, err := copyCustomFiles(fullScriptsDir, ctx.CombustionDir, fileio.ExecutablePerms)
+	return scripts, err
+}
+
+func copyCustomFiles(fromDir, combustionDir string, params os.FileMode) ([]string, error) {
+	if _, err := os.Stat(fromDir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	dirListing, err := os.ReadDir(fromDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading the custom directory at %s: %w", fromDir, err)
+	}
+
+	// If the directory exists but there's nothing in it, consider it an error case
+	if len(dirListing) == 0 {
+		return nil, fmt.Errorf("no files found in directory %s", fromDir)
+	}
+
+	var copiedFiles []string
+
+	for _, scriptEntry := range dirListing {
+		copyMe := filepath.Join(fromDir, scriptEntry.Name())
+		copyTo := filepath.Join(combustionDir, scriptEntry.Name())
+
+		err = fileio.CopyFile(copyMe, copyTo, params)
+		if err != nil {
+			return nil, fmt.Errorf("copying script to %s: %w", copyTo, err)
+		}
+
+		copiedFiles = append(copiedFiles, scriptEntry.Name())
+	}
+
+	return copiedFiles, nil
+
 }

--- a/pkg/combustion/custom_test.go
+++ b/pkg/combustion/custom_test.go
@@ -3,105 +3,108 @@ package combustion
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
-	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
 
-func TestConfigureScripts(t *testing.T) {
+func TestConfigureCustomFiles(t *testing.T) {
 	// Setup
-	// - Testing image config directory
-	tmpSrcDir, err := os.MkdirTemp("", "eib-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpSrcDir)
+	ctx, teardown := setupContext(t)
+	defer teardown()
 
-	// - scripts directory to look in
-	fullScriptsDir := filepath.Join(tmpSrcDir, customScriptsDir)
-	err = os.MkdirAll(fullScriptsDir, os.ModePerm)
+	// - scripts
+	fullScriptsDir := filepath.Join(ctx.ImageConfigDir, customDir, customScriptsDir)
+	err := os.MkdirAll(fullScriptsDir, os.ModePerm)
 	require.NoError(t, err)
 
-	// - create sample scripts to be copied
 	_, err = os.Create(filepath.Join(fullScriptsDir, "foo.sh"))
 	require.NoError(t, err)
 	_, err = os.Create(filepath.Join(fullScriptsDir, "bar.sh"))
 	require.NoError(t, err)
 
-	// - combustion directory into which the scripts should be copied
-	tmpDestDir, err := os.MkdirTemp("", "eib-")
+	// - files
+	fullFilesDir := filepath.Join(ctx.ImageConfigDir, customDir, customFilesDir)
+	err = os.MkdirAll(fullFilesDir, os.ModePerm)
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDestDir)
 
-	ctx := &image.Context{
-		ImageConfigDir: tmpSrcDir,
-		CombustionDir:  tmpDestDir,
-	}
+	_, err = os.Create(filepath.Join(fullFilesDir, "baz"))
+	require.NoError(t, err)
 
 	// Test
-	scripts, err := configureCustomScripts(ctx)
+	scripts, err := configureCustomFiles(ctx)
 
 	// Verify
 	require.NoError(t, err)
 
-	// - make sure the scripts were added to the build directory
-	foundDirListing, err := os.ReadDir(tmpDestDir)
+	// - make sure the files were added to the build directory
+	foundDirListing, err := os.ReadDir(ctx.CombustionDir)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(foundDirListing))
+	assert.Equal(t, 3, len(foundDirListing))
 
 	// - make sure the copied files have the right permissions
 	for _, entry := range foundDirListing {
 		fullEntryPath := filepath.Join(ctx.CombustionDir, entry.Name())
 		stats, err := os.Stat(fullEntryPath)
 		require.NoError(t, err)
-		assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+		if strings.HasSuffix(entry.Name(), ".sh") {
+			assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+		} else {
+			assert.Equal(t, fileio.NonExecutablePerms, stats.Mode())
+		}
 	}
 
-	// - make sure entries were added to the combustion scripts list, so they are
-	//   present in the script file that is generated
-	assert.Equal(t, 2, len(scripts))
+	// - make sure only script entries were added to the combustion scripts list
+	require.Equal(t, 2, len(scripts))
+	assert.Contains(t, scripts, "foo.sh")
+	assert.Contains(t, scripts, "bar.sh")
 }
 
-func TestConfigureScriptsNoScriptsDir(t *testing.T) {
+func TestConfigureFiles_NoCustomDir(t *testing.T) {
 	// Setup
-	tmpSrcDir, err := os.MkdirTemp("", "eib-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpSrcDir)
-
-	ctx := &image.Context{
-		ImageConfigDir: tmpSrcDir,
-	}
+	ctx, teardown := setupContext(t)
+	defer teardown()
 
 	// Test
-	scripts, err := configureCustomScripts(ctx)
+	scripts, err := configureCustomFiles(ctx)
 
 	// Verify
 	require.NoError(t, err)
 	assert.Nil(t, scripts)
 }
 
-func TestConfigureScriptsEmptyScriptsDir(t *testing.T) {
+func TestCopyCustomFiles_MissingFromDir(t *testing.T) {
 	// Setup
-	// - Testing image config directory
-	tmpSrcDir, err := os.MkdirTemp("", "eib-")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpSrcDir)
-
-	// - scripts directory to look in
-	fullScriptsDir := filepath.Join(tmpSrcDir, customScriptsDir)
-	err = os.MkdirAll(fullScriptsDir, os.ModePerm)
-	require.NoError(t, err)
-
-	ctx := &image.Context{
-		ImageConfigDir: tmpSrcDir,
-	}
+	ctx, teardown := setupContext(t)
+	defer teardown()
 
 	// Test
-	scripts, err := configureCustomScripts(ctx)
+	files, err := copyCustomFiles("missing", ctx.CombustionDir, fileio.NonExecutablePerms)
+
+	// Verify
+	assert.Nil(t, files)
+	assert.Nil(t, err)
+}
+
+func TestCopyCustomFiles_EmptyFromDir(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	// - from directory to look in
+	fullScriptsDir := filepath.Join(ctx.ImageConfigDir, customDir, customScriptsDir)
+	err := os.MkdirAll(fullScriptsDir, os.ModePerm)
+	require.NoError(t, err)
+
+	// Test
+	scripts, err := copyCustomFiles(fullScriptsDir, ctx.CombustionDir, fileio.NonExecutablePerms)
 
 	// Verify
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "no scripts found in directory")
+	assert.ErrorContains(t, err, "no files found in directory")
 	assert.Nil(t, scripts)
 }


### PR DESCRIPTION
There is now an optional `custom` directory that uses subdirectories to differentiate between scripts that combustion should automatically execute and other files that should only be copied into the directory. This still leaves us room to further differentiate handling of custom files by adding new subdirectories, without polluting the image configuration root.