### PR TITLE
Docs: Ensure that all image filenames contain the architecture

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -105,8 +105,8 @@ the structure of this directory will be better fleshed out. For now, the require
   configuration directory. Multiple definition files may be included in a single configuration directory, with
   the specific definition file specified as a CLI argument as described above.
 * `images` - This directory must exist and contains the base images from which EIB will build customized images. There
-  are no restrictions on the naming; the image definition file will specify which image in this directory to use
-  for a particular build.
+  are no restrictions on the naming other than the image filename *must* contain the architecture, e.g. "aarch64" or
+  "x86_64". The image definition file will specify which image in this directory to use for a particular build.
 
 There are a number of optional directories that may be included in the image configuration directory:
 


### PR DESCRIPTION
In the existing documentation we state that there are "no restrictions on the naming" of the input image that is specified in the EIB configuration, therefore the following should _always_ work just fine:

```
rdo@woden:~/work/eib% cat eib-config-iso.yaml 
apiVersion: 1.0
image:
  imageType: iso
  baseImage: slemicro5.5.iso
  outputImageName: eibimage.iso
```

However, if you're utilising `nmc` to do static networking configuration, the EIB run fails with an error suggesting that it could not determine the architecture of the image:

```
2023-12-19T16:08:03.649Z	DEBUG	build/iso.go:55	ISO log file created: /eib/_build/iso-build-Dec19_16-08-03.log
rdo@woden:/tmp/eib/_build% cat eib-build-Dec19_15-58-09.log
2023-12-19T15:58:09.311Z	INFO	combustion/network.go:51	Configuring network component...
2023-12-19T15:58:09.312Z	FATAL	eib/main.go:120	An error occurred building the image	{"error": "configuring combustion: configuring component \"network\": installing configurator: failed to determine arch of image slemicro5.5.iso"}
main.main
	/src/cmd/eib/main.go:120
runtime.main
	/usr/lib64/go/1.21/src/runtime/proc.go:267
```

It seems that the architecture is detected based on the explicit presence of a string in the filename of the input image, which will, in turn, tell EIB whether to use the `nmc` binary for aarch64 or x86_64 respectively. Here's the code snippet:

```
func (ConfiguratorInstaller) InstallConfigurator(imageName, sourcePath, installPath string) error {
        const (
                amdArch = "x86_64"
                armArch = "aarch64"
        )

        var arch string

        switch {
        case strings.Contains(imageName, amdArch):
                arch = amdArch
        case strings.Contains(imageName, armArch):
                arch = armArch
        default:
                return fmt.Errorf("failed to determine arch of image %s", imageName)
        }
```

Therefore, this documentation fix simply ensures that the user supplies a filename with the architecture included, e.g:

```
rdo@woden:/tmp/eib% grep baseImage eib-config-iso.yaml 
  baseImage: slemicro5.5-x86_64.iso
```

Or alternatively, simply uses the standard naming convention, e.g. `SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso`.