### PR TITLE
Fix whitespaces in users template

### DIFF
--- a/pkg/combustion/templates/add-users.sh.tpl
+++ b/pkg/combustion/templates/add-users.sh.tpl
@@ -5,30 +5,34 @@ set -euo pipefail
 # is mounted it will hide the /home used during these user creations.
 mount /home
 
-{{ range . }}
+{{- range . }}
+{{- if (ne .Username "root") }}
 
-{{/* Non-root users */}}
-{{ if (ne .Username "root") }}
-  useradd -m {{.Username}}
-  {{ if .Password }}
-    echo '{{.Username}}:{{.Password}}' | chpasswd -e
-  {{ end }}
-  {{ if .SSHKey }}
-    mkdir -pm700 /home/{{.Username}}/.ssh/
-    echo '{{.SSHKey}}' >> /home/{{.Username}}/.ssh/authorized_keys
-    chown -R {{.Username}} /home/{{.Username}}/.ssh
-  {{ end }}
-{{ end }}
+# Non-root user
+useradd -m {{.Username}}
 
-{{/* Root */}}
-{{ if (eq .Username "root") }}
-  {{ if .Password }}
-    echo '{{.Username}}:{{.Password}}' | chpasswd -e
-  {{ end }}
-  {{ if .SSHKey }}
-    mkdir -pm700 /{{.Username}}/.ssh/
-    echo '{{.SSHKey}}' >> /{{.Username}}/.ssh/authorized_keys
-  {{ end }}
-{{ end }}
+{{- if .Password }}
+echo '{{.Username}}:{{.Password}}' | chpasswd -e
+{{- end }}
 
-{{ end }}
+{{- if .SSHKey }}
+mkdir -pm700 /home/{{.Username}}/.ssh/
+echo '{{.SSHKey}}' >> /home/{{.Username}}/.ssh/authorized_keys
+chown -R {{.Username}} /home/{{.Username}}/.ssh
+{{- end }}
+
+{{- else }}
+
+# Root user
+{{- if .Password }}
+echo '{{.Username}}:{{.Password}}' | chpasswd -e
+{{- end }}
+
+{{- if .SSHKey }}
+mkdir -pm700 /{{.Username}}/.ssh/
+echo '{{.SSHKey}}' >> /{{.Username}}/.ssh/authorized_keys
+{{- end }}
+
+{{- end }}
+
+{{- end }}


### PR DESCRIPTION
- Closes https://github.com/suse-edge/edge-image-builder/issues/66
- Using the [TestConfigureUsers](https://github.com/suse-edge/edge-image-builder/blob/main/pkg/combustion/users_test.go#L14) test to showcase the difference

**Before:**

```
#!/bin/bash
set -euo pipefail

# Without this, the script will run successfully during combustion, but when /home
# is mounted it will hide the /home used during these user creations.
mount /home





  useradd -m alpha
  
    echo 'alpha:alpha123' | chpasswd -e
  
  
    mkdir -pm700 /home/alpha/.ssh/
    echo 'alphakey' >> /home/alpha/.ssh/authorized_keys
    chown -R alpha /home/alpha/.ssh
  









  useradd -m beta
  
    echo 'beta:beta123' | chpasswd -e
  
  









  useradd -m gamma
  
  
    mkdir -pm700 /home/gamma/.ssh/
    echo 'gammakey' >> /home/gamma/.ssh/authorized_keys
    chown -R gamma /home/gamma/.ssh
  












  
    echo 'root:root123' | chpasswd -e
  
  
    mkdir -pm700 /root/.ssh/
    echo 'rootkey' >> /root/.ssh/authorized_keys
```

**After:**

```
#!/bin/bash
set -euo pipefail

# Without this, the script will run successfully during combustion, but when /home
# is mounted it will hide the /home used during these user creations.
mount /home

# Non-root user
useradd -m alpha
echo 'alpha:alpha123' | chpasswd -e
mkdir -pm700 /home/alpha/.ssh/
echo 'alphakey' >> /home/alpha/.ssh/authorized_keys
chown -R alpha /home/alpha/.ssh

# Non-root user
useradd -m beta
echo 'beta:beta123' | chpasswd -e

# Non-root user
useradd -m gamma
mkdir -pm700 /home/gamma/.ssh/
echo 'gammakey' >> /home/gamma/.ssh/authorized_keys
chown -R gamma /home/gamma/.ssh

# Root user
echo 'root:root123' | chpasswd -e
mkdir -pm700 /root/.ssh/
echo 'rootkey' >> /root/.ssh/authorized_keys
```