### PR TITLE
SUMA: venv-salt-minion needs to be enabled not restarted

### DIFF
--- a/pkg/combustion/templates/12-suma-register.sh.tpl
+++ b/pkg/combustion/templates/12-suma-register.sh.tpl
@@ -21,4 +21,4 @@ enable_fqdns_grains: False
 
 EOF
 
-systemctl restart venv-salt-minion || true
+systemctl enable venv-salt-minion || true


### PR DESCRIPTION
In the previous version, at bootup the service was restarted, which wouldn't work properly during combustion, it simply needed to be enabled.