### PR TITLE
Log raw build output

### DIFF
--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -76,7 +76,7 @@ func TestWriteModifyScript(t *testing.T) {
 	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
 
 	foundContents := string(foundBytes)
-	assert.Contains(t, foundContents, "guestfish --rw -a config-dir/output-image")
+	assert.Contains(t, foundContents, "guestfish --format=raw --rw -a config-dir/output-image")
 	assert.Contains(t, foundContents, "copy-in "+builder.context.CombustionDir)
 	assert.Contains(t, foundContents, "download /boot/grub2/grub.cfg /tmp/grub.cfg")
 }

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -90,11 +91,13 @@ func TestCreateModifyCommand(t *testing.T) {
 	}
 
 	// Test
-	cmd := builder.createModifyCommand()
+	cmd := builder.createModifyCommand(io.Discard)
 
 	// Verify
 	require.NotNil(t, cmd)
 
 	expectedPath := filepath.Join("build-dir", modifyScriptName)
 	assert.Equal(t, expectedPath, cmd.Path)
+	assert.Equal(t, io.Discard, cmd.Stdout)
+	assert.Equal(t, io.Discard, cmd.Stderr)
 }

--- a/pkg/build/templates/modify-raw-image.sh.tpl
+++ b/pkg/build/templates/modify-raw-image.sh.tpl
@@ -9,7 +9,7 @@ set -euo pipefail
 #
 # Guestfish Command Documentation: https://libguestfs.org/guestfish.1.html
 
-guestfish --rw -a {{.OutputImage}} -i <<'EOF'
+guestfish --format=raw --rw -a {{.OutputImage}} -i <<'EOF'
   # Enables write access to the read only filesystem
   sh "btrfs property set / ro false"
 


### PR DESCRIPTION
- Stores the output of guestfish modifications for raw images in a `raw-build.log` file under the build directory