### PR TITLE
Add arch to definition

### DIFF
--- a/cmd/eib/main.go
+++ b/cmd/eib/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/suse-edge/edge-image-builder/pkg/build"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
+	audit "github.com/suse-edge/edge-image-builder/pkg/log"
 	"github.com/suse-edge/edge-image-builder/pkg/network"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -108,8 +109,15 @@ func main() {
 		log.Fatalf("CLI arguments could not be parsed: %s", err)
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			audit.Audit("Build failed unexpectedly, check the logs under the build directory for more information.")
+			zap.S().Fatalf("Unexpected error occurred: %s", r)
+		}
+	}()
+
 	builder := build.NewBuilder(ctx)
 	if err = builder.Build(); err != nil {
-		zap.L().Fatal("An error occurred building the image", zap.Error(err))
+		zap.S().Fatalf("An error occurred building the image: %s", err)
 	}
 }

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -2,7 +2,7 @@
 
 Two things are necessary to build an image using EIB:
 1. A definition file that describes the image to build
-1. A directory that contains the base SLE Micro image to modify, along with any other custom files that
+2. A directory that contains the base SLE Micro image to modify, along with any other custom files that
    will be included in the built image
 
 ## Image Definition File
@@ -14,6 +14,7 @@ directory may be used to build multiple images by creating multiple definition f
 The following can be used as the minimum configuration required to create an image:
 ```yaml
 apiVersion: 1.0
+arch: x86_64
 image:
   imageType: iso
   baseImage: SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso
@@ -21,6 +22,7 @@ image:
 ```
 
 * `apiVersion` - Indicates the version of the definition file schema for EIB to expect
+* `arch` - Must be either `x86_64` or `aarch64`.
 * `imageType` - Must be either `iso` or `raw`.
 * `baseImage` - Indicates the name of the image file used as the base for the built image. This file must be located
   under the `images` directory of the image configuration directory (see below for more information). This image will
@@ -104,9 +106,9 @@ the structure of this directory will be better fleshed out. For now, the require
 * `eib-config-iso.yaml`, `eib-config-raw.yaml` - All image definition files should be in the root of the image
   configuration directory. Multiple definition files may be included in a single configuration directory, with
   the specific definition file specified as a CLI argument as described above.
-* `images` - This directory must exist and contains the base images from which EIB will build customized images. There
-  are no restrictions on the naming other than the image filename *must* contain the architecture, e.g. "aarch64" or
-  "x86_64". The image definition file will specify which image in this directory to use for a particular build.
+* `images` - This directory must exist and contains the base images from which EIB will build customized images.
+  There are no restrictions on the naming. The image definition file will specify which image in this directory
+  to use for a particular build.
 
 There are a number of optional directories that may be included in the image configuration directory:
 

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -2,7 +2,7 @@
 
 Two things are necessary to build an image using EIB:
 1. A definition file that describes the image to build
-2. A directory that contains the base SLE Micro image to modify, along with any other custom files that
+1. A directory that contains the base SLE Micro image to modify, along with any other custom files that
    will be included in the built image
 
 ## Image Definition File
@@ -14,16 +14,16 @@ directory may be used to build multiple images by creating multiple definition f
 The following can be used as the minimum configuration required to create an image:
 ```yaml
 apiVersion: 1.0
-arch: x86_64
 image:
   imageType: iso
+  arch: x86_64
   baseImage: SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso
   outputImageName: eib-image.iso
 ```
 
 * `apiVersion` - Indicates the version of the definition file schema for EIB to expect
-* `arch` - Must be either `x86_64` or `aarch64`.
 * `imageType` - Must be either `iso` or `raw`.
+* `arch` - Must be either `x86_64` or `aarch64`.
 * `baseImage` - Indicates the name of the image file used as the base for the built image. This file must be located
   under the `images` directory of the image configuration directory (see below for more information). This image will
   **not** directly be modified by EIB; a new image will be created each time EIB is run.

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -29,6 +29,7 @@ func (b *Builder) Build() error {
 	log.Audit("Generating image customization components...")
 
 	if err := b.configureCombustion(b.context); err != nil {
+		log.Audit("Error configuring customization components, check the logs under the build directory for more information.")
 		return fmt.Errorf("configuring combustion: %w", err)
 	}
 

--- a/pkg/combustion/network.go
+++ b/pkg/combustion/network.go
@@ -102,7 +102,7 @@ func installNetworkConfigurator(ctx *image.Context) error {
 	sourcePath := "/" // root level of the container image
 	installPath := filepath.Join(ctx.CombustionDir, nmcExecutable)
 
-	return ctx.NetworkConfiguratorInstaller.InstallConfigurator(ctx.ImageDefinition.Image.BaseImage, sourcePath, installPath)
+	return ctx.NetworkConfiguratorInstaller.InstallConfigurator(ctx.ImageDefinition.Arch, sourcePath, installPath)
 }
 
 func writeNetworkConfigurationScript(ctx *image.Context) (string, error) {

--- a/pkg/combustion/network.go
+++ b/pkg/combustion/network.go
@@ -102,7 +102,7 @@ func installNetworkConfigurator(ctx *image.Context) error {
 	sourcePath := "/" // root level of the container image
 	installPath := filepath.Join(ctx.CombustionDir, nmcExecutable)
 
-	return ctx.NetworkConfiguratorInstaller.InstallConfigurator(ctx.ImageDefinition.Arch, sourcePath, installPath)
+	return ctx.NetworkConfiguratorInstaller.InstallConfigurator(ctx.ImageDefinition.Image.Arch, sourcePath, installPath)
 }
 
 func writeNetworkConfigurationScript(ctx *image.Context) (string, error) {

--- a/pkg/combustion/network_test.go
+++ b/pkg/combustion/network_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
 
 type mockNetworkConfigGenerator struct {
@@ -25,12 +26,12 @@ func (m mockNetworkConfigGenerator) GenerateNetworkConfig(configDir, outputDir s
 }
 
 type mockNetworkConfiguratorInstaller struct {
-	installConfiguratorFunc func(imageName, sourcePath, installPath string) error
+	installConfiguratorFunc func(arch image.Arch, sourcePath, installPath string) error
 }
 
-func (m mockNetworkConfiguratorInstaller) InstallConfigurator(imageName, sourcePath, installPath string) error {
+func (m mockNetworkConfiguratorInstaller) InstallConfigurator(arch image.Arch, sourcePath, installPath string) error {
 	if m.installConfiguratorFunc != nil {
-		return m.installConfiguratorFunc(imageName, sourcePath, installPath)
+		return m.installConfiguratorFunc(arch, sourcePath, installPath)
 	}
 
 	panic("not implemented")
@@ -80,7 +81,7 @@ func TestConfigureNetwork(t *testing.T) {
 				},
 			},
 			configuratorInstaller: mockNetworkConfiguratorInstaller{
-				installConfiguratorFunc: func(imageName, sourcePath, installPath string) error {
+				installConfiguratorFunc: func(arch image.Arch, sourcePath, installPath string) error {
 					return fmt.Errorf("no installer for you")
 				},
 			},
@@ -94,7 +95,7 @@ func TestConfigureNetwork(t *testing.T) {
 				},
 			},
 			configuratorInstaller: mockNetworkConfiguratorInstaller{
-				installConfiguratorFunc: func(imageName, sourcePath, installPath string) error {
+				installConfiguratorFunc: func(arch image.Arch, sourcePath, installPath string) error {
 					return nil
 				},
 			},

--- a/pkg/image/context.go
+++ b/pkg/image/context.go
@@ -9,7 +9,7 @@ type NetworkConfigGenerator interface {
 }
 
 type NetworkConfiguratorInstaller interface {
-	InstallConfigurator(imageName, sourcePath, installPath string) error
+	InstallConfigurator(arch Arch, sourcePath, installPath string) error
 }
 
 type Context struct {

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -32,7 +32,8 @@ func (a Arch) Short() string {
 	case ArchTypeARM:
 		return "arm64"
 	default:
-		return ""
+		message := fmt.Sprintf("unknown arch: %s", a)
+		panic(message)
 	}
 }
 

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -12,8 +12,8 @@ const (
 )
 
 const (
-	ArchTypeIntel Arch = "x86_64"
-	ArchTypeARM   Arch = "aarch64"
+	ArchTypeX86 Arch = "x86_64"
+	ArchTypeARM Arch = "aarch64"
 )
 
 type Definition struct {
@@ -27,7 +27,7 @@ type Arch string
 
 func (a Arch) Short() string {
 	switch a {
-	case ArchTypeIntel:
+	case ArchTypeX86:
 		return "amd64"
 	case ArchTypeARM:
 		return "arm64"

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -19,7 +19,6 @@ const (
 
 type Definition struct {
 	APIVersion      string          `yaml:"apiVersion"`
-	Arch            Arch            `yaml:"arch"`
 	Image           Image           `yaml:"image"`
 	OperatingSystem OperatingSystem `yaml:"operatingSystem"`
 }
@@ -40,6 +39,7 @@ func (a Arch) Short() string {
 
 type Image struct {
 	ImageType       string `yaml:"imageType"`
+	Arch            Arch   `yaml:"arch"`
 	BaseImage       string `yaml:"baseImage"`
 	OutputImageName string `yaml:"outputImageName"`
 }

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -11,10 +11,29 @@ const (
 	TypeRAW = "raw"
 )
 
+const (
+	ArchTypeIntel Arch = "x86_64"
+	ArchTypeARM   Arch = "aarch64"
+)
+
 type Definition struct {
 	APIVersion      string          `yaml:"apiVersion"`
+	Arch            Arch            `yaml:"arch"`
 	Image           Image           `yaml:"image"`
 	OperatingSystem OperatingSystem `yaml:"operatingSystem"`
+}
+
+type Arch string
+
+func (a Arch) Short() string {
+	switch a {
+	case ArchTypeIntel:
+		return "amd64"
+	case ArchTypeARM:
+		return "arm64"
+	default:
+		return ""
+	}
 }
 
 type Image struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -75,3 +75,12 @@ func TestParseBadConfig(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "could not parse the image definition")
 }
+
+func TestArch_Short(t *testing.T) {
+	assert.Equal(t, "amd64", ArchTypeIntel.Short())
+	assert.Equal(t, "arm64", ArchTypeARM.Short())
+	assert.PanicsWithValue(t, "unknown arch: abc", func() {
+		arch := Arch("abc")
+		arch.Short()
+	})
+}

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -22,6 +22,7 @@ func TestParse(t *testing.T) {
 
 	// - Definition
 	assert.Equal(t, "1.0", definition.APIVersion)
+	assert.EqualValues(t, "x86_64", definition.Arch)
 	assert.Equal(t, "iso", definition.Image.ImageType)
 
 	// - Image

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -22,7 +22,7 @@ func TestParse(t *testing.T) {
 
 	// - Definition
 	assert.Equal(t, "1.0", definition.APIVersion)
-	assert.EqualValues(t, "x86_64", definition.Arch)
+	assert.EqualValues(t, "x86_64", definition.Image.Arch)
 	assert.Equal(t, "iso", definition.Image.ImageType)
 
 	// - Image

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -77,7 +77,7 @@ func TestParseBadConfig(t *testing.T) {
 }
 
 func TestArch_Short(t *testing.T) {
-	assert.Equal(t, "amd64", ArchTypeIntel.Short())
+	assert.Equal(t, "amd64", ArchTypeX86.Short())
 	assert.Equal(t, "arm64", ArchTypeARM.Short())
 	assert.PanicsWithValue(t, "unknown arch: abc", func() {
 		arch := Arch("abc")

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -1,4 +1,5 @@
 apiVersion: 1.0
+arch: x86_64
 image:
   imageType: iso
   baseImage: slemicro5.5.iso

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -1,7 +1,7 @@
 apiVersion: 1.0
-arch: x86_64
 image:
   imageType: ISO
+  arch: x86_64
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
 operatingSystem:

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -24,8 +24,13 @@ func validateImage(definition *Definition) error {
 	}
 	if definition.Image.ImageType == "" {
 		return fmt.Errorf("imageType not defined")
-	} else if definition.Image.ImageType != "iso" && definition.Image.ImageType != "raw" {
-		return fmt.Errorf("invalid imageType, should be 'iso' or 'raw'")
+	} else if definition.Image.ImageType != TypeISO && definition.Image.ImageType != TypeRAW {
+		return fmt.Errorf("imageType must be '%s' or '%s'", TypeISO, TypeRAW)
+	}
+	if definition.Image.Arch == "" {
+		return fmt.Errorf("arch not defined")
+	} else if definition.Image.Arch != ArchTypeX86 && definition.Image.Arch != ArchTypeARM {
+		return fmt.Errorf("arch must be '%s' or '%s'", ArchTypeX86, ArchTypeARM)
 	}
 	if definition.Image.BaseImage == "" {
 		return fmt.Errorf("baseImage not defined")

--- a/pkg/network/configurator_installer.go
+++ b/pkg/network/configurator_installer.go
@@ -3,30 +3,14 @@ package network
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
 
 type ConfiguratorInstaller struct{}
 
-func (ConfiguratorInstaller) InstallConfigurator(imageName, sourcePath, installPath string) error {
-	const (
-		amdArch = "x86_64"
-		armArch = "aarch64"
-	)
-
-	var arch string
-
-	switch {
-	case strings.Contains(imageName, amdArch):
-		arch = amdArch
-	case strings.Contains(imageName, armArch):
-		arch = armArch
-	default:
-		return fmt.Errorf("failed to determine arch of image %s", imageName)
-	}
-
+func (ConfiguratorInstaller) InstallConfigurator(arch image.Arch, sourcePath, installPath string) error {
 	const nmcExecutable = "nmc-%s"
 	sourcePath = filepath.Join(sourcePath, fmt.Sprintf(nmcExecutable, arch))
 

--- a/pkg/network/configurator_installer_test.go
+++ b/pkg/network/configurator_installer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
 
 func TestConfiguratorInstaller_InstallConfigurator(t *testing.T) {
@@ -34,33 +35,28 @@ func TestConfiguratorInstaller_InstallConfigurator(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		imageName        string
+		arch             image.Arch
 		sourcePath       string
 		installPath      string
 		expectedContents []byte
 		expectedError    string
 	}{
 		{
-			name:          "Failure to detect architecture from image name",
-			imageName:     "abc",
-			expectedError: "failed to determine arch of image abc",
-		},
-		{
 			name:          "Failure to copy non-existing binary",
-			imageName:     "abc-x86_64",
+			arch:          image.ArchTypeIntel,
 			sourcePath:    "",
 			expectedError: "copying file: opening source file: open nmc-x86_64: no such file or directory",
 		},
 		{
 			name:             "Successfully installed x86_64 binary",
-			imageName:        "abc-x86_64",
+			arch:             image.ArchTypeIntel,
 			sourcePath:       srcDir,
 			installPath:      fmt.Sprintf("%s/nmc-amd", destDir),
 			expectedContents: amdBinaryContents,
 		},
 		{
 			name:             "Successfully installed aarch64 binary",
-			imageName:        "abc-aarch64",
+			arch:             image.ArchTypeARM,
 			sourcePath:       srcDir,
 			installPath:      fmt.Sprintf("%s/nmc-arm", destDir),
 			expectedContents: armBinaryContents,
@@ -71,7 +67,7 @@ func TestConfiguratorInstaller_InstallConfigurator(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err = installer.InstallConfigurator(test.imageName, test.sourcePath, test.installPath)
+			err = installer.InstallConfigurator(test.arch, test.sourcePath, test.installPath)
 
 			if test.expectedError != "" {
 				require.Error(t, err)

--- a/pkg/network/configurator_installer_test.go
+++ b/pkg/network/configurator_installer_test.go
@@ -43,13 +43,13 @@ func TestConfiguratorInstaller_InstallConfigurator(t *testing.T) {
 	}{
 		{
 			name:          "Failure to copy non-existing binary",
-			arch:          image.ArchTypeIntel,
+			arch:          image.ArchTypeX86,
 			sourcePath:    "",
 			expectedError: "copying file: opening source file: open nmc-x86_64: no such file or directory",
 		},
 		{
 			name:             "Successfully installed x86_64 binary",
-			arch:             image.ArchTypeIntel,
+			arch:             image.ArchTypeX86,
 			sourcePath:       srcDir,
 			installPath:      fmt.Sprintf("%s/nmc-amd", destDir),
 			expectedContents: amdBinaryContents,


### PR DESCRIPTION
- Adds a new `arch` field to the image definition file
- Includes validation for the new field
- Drops image name requirements for network component
- Sets up a graceful recovery from runtime errors / panics