### PR TITLE
Introduce copy file content by byte chunks logic

### DIFF
--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -69,6 +69,7 @@ func createFileWithPerms(dest string, perms os.FileMode) (*os.File, error) {
 	}
 
 	if err = file.Chmod(perms); err != nil {
+		_ = file.Close()
 		return nil, fmt.Errorf("setting up permissions: %w", err)
 	}
 

--- a/pkg/fileio/file_io_test.go
+++ b/pkg/fileio/file_io_test.go
@@ -118,7 +118,7 @@ func TestCopyFileN(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := CopyFileN(test.source, test.destination, test.perms, 4096)
+			err := CopyFileN(test.source, test.destination, test.perms, 1)
 
 			if test.expectedErr != "" {
 				assert.EqualError(t, err, test.expectedErr)


### PR DESCRIPTION
Introduce the copy file content by byte chunks logic introduced in #64 in a separate PR in order to reduce complexity of #64 