### PR TITLE
Add kubernetes definition

### DIFF
--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -10,17 +10,27 @@ import (
 const (
 	TypeISO = "iso"
 	TypeRAW = "raw"
-)
 
-const (
 	ArchTypeX86 Arch = "x86_64"
 	ArchTypeARM Arch = "aarch64"
+
+	KubernetesDistroRKE2 = "rke2"
+	KubernetesDistroK3S  = "k3s"
+
+	KubernetesNodeTypeServer = "server"
+	KubernetesNodeTypeAgent  = "agent"
+
+	CNITypeNone   = "none"
+	CNITypeCilium = "cilium"
+	CNITypeCanal  = "canal"
+	CNITypeCalico = "calico"
 )
 
 type Definition struct {
 	APIVersion      string          `yaml:"apiVersion"`
 	Image           Image           `yaml:"image"`
 	OperatingSystem OperatingSystem `yaml:"operatingSystem"`
+	Kubernetes      Kubernetes      `yaml:"kubernetes"`
 }
 
 type Arch string
@@ -66,6 +76,14 @@ type Suma struct {
 	Host          string `yaml:"host"`
 	ActivationKey string `yaml:"activationKey"`
 	GetSSL        bool   `yaml:"getSSL"`
+}
+
+type Kubernetes struct {
+	Version        string `yaml:"version"`
+	NodeType       string `yaml:"nodeType"`
+	CNI            string `yaml:"cni"`
+	MultusEnabled  bool   `yaml:"multus"`
+	VSphereEnabled bool   `yaml:"vSphere"`
 }
 
 func ParseDefinition(data []byte) (*Definition, error) {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -63,6 +63,14 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "suma.edge.suse.com", suma.Host)
 	assert.Equal(t, "slemicro55", suma.ActivationKey)
 	assert.Equal(t, false, suma.GetSSL)
+
+	// Kubernetes
+	kubernetes := definition.Kubernetes
+	assert.Equal(t, "v1.29.0+rke2r1", kubernetes.Version)
+	assert.Equal(t, "server", kubernetes.NodeType)
+	assert.Equal(t, "cilium", kubernetes.CNI)
+	assert.Equal(t, true, kubernetes.MultusEnabled)
+	assert.Equal(t, false, kubernetes.VSphereEnabled)
 }
 
 func TestParseBadConfig(t *testing.T) {

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -27,3 +27,9 @@ operatingSystem:
     host: suma.edge.suse.com
     activationKey: slemicro55
     getSSL: false
+kubernetes:
+  version: v1.29.0+rke2r1
+  nodeType: server
+  cni: cilium
+  multus: true
+  vSphere: false

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -72,6 +72,115 @@ func TestValidateImageUndefinedImageType(t *testing.T) {
 	require.ErrorContains(t, err, "imageType not defined")
 }
 
+func TestValidateKubernetes(t *testing.T) {
+	tests := []struct {
+		name        string
+		definition  *Definition
+		expectedErr string
+	}{
+		{
+			name: "Empty CNI",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version: "v1.29.0+rke2r1",
+					CNI:     "",
+				},
+			},
+			expectedErr: "CNI not specified",
+		},
+		{
+			name: "Unsupported CNI",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version: "v1.29.0+rke2r1",
+					CNI:     "flannel",
+				},
+			},
+			expectedErr: "CNI 'flannel' is not supported",
+		},
+		{
+			name: "No CNI",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version: "v1.29.0+rke2r1",
+					CNI:     "none",
+				},
+			},
+		},
+		{
+			name: "Canal CNI",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version: "v1.29.0+rke2r1",
+					CNI:     "canal",
+				},
+			},
+		},
+		{
+			name: "Calico CNI",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version: "v1.29.0+rke2r1",
+					CNI:     "calico",
+				},
+			},
+		},
+		{
+			name: "Cilium CNI",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version: "v1.29.0+rke2r1",
+					CNI:     "cilium",
+				},
+			},
+		},
+		{
+			name: "Server node type",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version:  "v1.29.0+rke2r1",
+					NodeType: "server",
+					CNI:      "cilium",
+				},
+			},
+		},
+		{
+			name: "Agent node type",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version:  "v1.29.0+rke2r1",
+					NodeType: "agent",
+					CNI:      "cilium",
+				},
+			},
+		},
+		{
+			name: "Unknown node type",
+			definition: &Definition{
+				Kubernetes: Kubernetes{
+					Version:  "v1.29.0+rke2r1",
+					NodeType: "worker",
+					CNI:      "cilium",
+				},
+			},
+			expectedErr: "unknown node type: worker",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateKubernetes(test.definition)
+
+			if test.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedErr)
+			}
+		})
+	}
+}
+
 func TestValidateImage_Arch(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
- Introduces kubernetes definition and validation
- Possible configurations are kept to a minimum
- Follow ups might introduce more options e.g. SELinux