### PR TITLE
Added logic to unsquash/resquash the raw image inside of the ISO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM opensuse/leap:15.5
 # 1. ISO image building
 # 2. RAW image modification on x86_64
 RUN zypper install -y \
-    xorriso  \
+    xorriso squashfs  \
     libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs
 
 # TODO: Install nmc via zypper once an RPM package is available

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -56,7 +56,7 @@ func (b *Builder) extractIso() error {
 	}
 	defer func() {
 		if err = extractLog.Close(); err != nil {
-			zap.L().Warn("failed to close ISO extraction log file properly", zap.Error(err))
+			zap.S().Warn("failed to close ISO extraction log file properly", zap.Error(err))
 		}
 	}()
 
@@ -78,7 +78,7 @@ func (b *Builder) rebuildIso() error {
 	}
 	defer func() {
 		if err = rebuildLog.Close(); err != nil {
-			zap.L().Warn("failed to close ISO rebuild log file properly", zap.Error(err))
+			zap.S().Warn("failed to close ISO rebuild log file properly", zap.Error(err))
 		}
 	}()
 

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -1,12 +1,42 @@
 package build
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
+
+func setupContext(t *testing.T) (ctx *image.Context, teardown func()) {
+	// Copied from combustion_test due to time. This should eventually be refactored
+	// to something cleaner.
+
+	configDir, err := os.MkdirTemp("", "eib-config-")
+	require.NoError(t, err)
+
+	buildDir, err := os.MkdirTemp("", "eib-build-")
+	require.NoError(t, err)
+
+	combustionDir, err := os.MkdirTemp("", "eib-combustion-")
+	require.NoError(t, err)
+
+	ctx = &image.Context{
+		ImageConfigDir:  configDir,
+		BuildDir:        buildDir,
+		CombustionDir:   combustionDir,
+		ImageDefinition: &image.Definition{},
+	}
+
+	return ctx, func() {
+		assert.NoError(t, os.RemoveAll(combustionDir))
+		assert.NoError(t, os.RemoveAll(buildDir))
+		assert.NoError(t, os.RemoveAll(configDir))
+	}
+}
 
 func TestDeleteNoExistingImage(t *testing.T) {
 	// Setup
@@ -61,4 +91,70 @@ func TestDeleteExistingImage(t *testing.T) {
 	_, err = os.Stat(builder.generateOutputImageFilename())
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
+}
+
+func TestWriteIsoScript_Extract(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+	builder := Builder{context: ctx}
+
+	// Test
+	err := builder.writeIsoScript(extractIsoTemplate, extractIsoScriptName)
+
+	// Verify
+	require.NoError(t, err)
+
+	expectedFilename := filepath.Join(ctx.BuildDir, extractIsoScriptName)
+	_, err = os.Stat(expectedFilename)
+	require.NoError(t, err)
+
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+	found := string(foundBytes)
+
+	expectedIsoExtractDir := filepath.Join(ctx.BuildDir, isoExtractDir)
+	assert.Contains(t, found, fmt.Sprintf("ISO_EXTRACT_DIR=%s", expectedIsoExtractDir))
+
+	expectedRawExtractDir := filepath.Join(ctx.BuildDir, rawExtractDir)
+	assert.Contains(t, found, fmt.Sprintf("RAW_EXTRACT_DIR=%s", expectedRawExtractDir))
+
+	expectedIsoPath := builder.generateBaseImageFilename()
+	assert.Contains(t, found, fmt.Sprintf("ISO_SOURCE=%s", expectedIsoPath))
+}
+
+func TestWriteIsoScript_Rebuild(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+	builder := Builder{context: ctx}
+
+	// Test
+	err := builder.writeIsoScript(rebuildIsoTemplate, rebuildIsoScriptName)
+
+	// Verify
+	require.NoError(t, err)
+
+	expectedFilename := filepath.Join(ctx.BuildDir, rebuildIsoScriptName)
+	_, err = os.Stat(expectedFilename)
+	require.NoError(t, err)
+
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+	found := string(foundBytes)
+
+	expectedIsoExtractDir := filepath.Join(ctx.BuildDir, isoExtractDir)
+	assert.Contains(t, found, fmt.Sprintf("ISO_EXTRACT_DIR=%s", expectedIsoExtractDir))
+
+	expectedRawExtractDir := filepath.Join(ctx.BuildDir, rawExtractDir)
+	assert.Contains(t, found, fmt.Sprintf("RAW_EXTRACT_DIR=%s", expectedRawExtractDir))
+
+	expectedIsoPath := builder.generateBaseImageFilename()
+	assert.Contains(t, found, fmt.Sprintf("ISO_SOURCE=%s", expectedIsoPath))
+
+	expectedOutputImage := builder.generateOutputImageFilename()
+	assert.Contains(t, found, fmt.Sprintf("OUTPUT_IMAGE=%s", expectedOutputImage))
+
+	expectedCombustionDir := ctx.CombustionDir
+	assert.Contains(t, found, fmt.Sprintf("COMBUSTION_DIR=%s", expectedCombustionDir))
 }

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -2,10 +2,8 @@ package build
 
 import (
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
@@ -63,44 +61,4 @@ func TestDeleteExistingImage(t *testing.T) {
 	_, err = os.Stat(builder.generateOutputImageFilename())
 	require.Error(t, err)
 	require.True(t, os.IsNotExist(err))
-}
-
-func TestCreateXorrisoCommand(t *testing.T) {
-	// Setup
-	builder := Builder{
-		context: &image.Context{
-			ImageConfigDir: "config-dir",
-			CombustionDir:  "combustion",
-			ImageDefinition: &image.Definition{
-				Image: image.Image{
-					BaseImage:       "base-image",
-					OutputImageName: "build-image",
-				},
-			},
-		},
-	}
-
-	// Test
-	cmd, logfile, err := builder.createXorrisoCommand()
-
-	// Verify
-	require.NoError(t, err)
-
-	defer func() {
-		assert.NoError(t, os.Remove(logfile.Name()))
-	}()
-
-	assert.Equal(t, xorrisoExec, cmd.Path)
-
-	expectedString := "/usr/bin/xorriso " +
-		"-indev config-dir/images/base-image " +
-		"-outdev config-dir/build-image " +
-		"-map combustion /combustion " +
-		"-boot_image any replay -changes_pending yes"
-	expected := strings.Split(expectedString, " ")
-	assert.Equal(t, expected, cmd.Args)
-
-	assert.NotNil(t, logfile)
-	assert.Equal(t, logfile, cmd.Stdout)
-	assert.Equal(t, logfile, cmd.Stderr)
 }

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -170,6 +170,7 @@ func TestCreateIsoCommand(t *testing.T) {
 
 	// Verify
 	require.NoError(t, err)
+	require.NotNil(t, cmd)
 
 	expectedCommandPath := filepath.Join(ctx.BuildDir, "test-script")
 	assert.Equal(t, expectedCommandPath, cmd.Path)

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -158,3 +158,21 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 	expectedCombustionDir := ctx.CombustionDir
 	assert.Contains(t, found, fmt.Sprintf("COMBUSTION_DIR=%s", expectedCombustionDir))
 }
+
+func TestCreateIsoCommand(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+	builder := Builder{context: ctx}
+
+	// Test
+	cmd, logFile, err := builder.createIsoCommand("test-log", "test-script")
+
+	// Verify
+	require.NoError(t, err)
+
+	expectedCommandPath := filepath.Join(ctx.BuildDir, "test-script")
+	assert.Equal(t, expectedCommandPath, cmd.Path)
+	assert.Equal(t, logFile, cmd.Stdout)
+	assert.Equal(t, logFile, cmd.Stderr)
+}

--- a/pkg/build/templates/extract-iso.sh.tpl
+++ b/pkg/build/templates/extract-iso.sh.tpl
@@ -9,13 +9,13 @@ set -euo pipefail
 
 ISO_EXTRACT_DIR={{.IsoExtractDir}}
 RAW_EXTRACT_DIR={{.RawExtractDir}}
-ISO_PATH={{.IsoSource}}
+ISO_SOURCE={{.IsoSource}}
 
 # Create the extract directories
 mkdir -p ${ISO_EXTRACT_DIR} ${RAW_EXTRACT_DIR}
 
 # Extract the contents of the ISO to the build directory
-xorriso -osirrox on -indev ${ISO_PATH} extract / ${ISO_EXTRACT_DIR}
+xorriso -osirrox on -indev ${ISO_SOURCE} extract / ${ISO_EXTRACT_DIR}
 
 # Unsquash the raw image
 SQUASHED_IMAGE_NAME=`find ${ISO_EXTRACT_DIR} -name "*.squashfs"`

--- a/pkg/build/templates/extract-iso.sh.tpl
+++ b/pkg/build/templates/extract-iso.sh.tpl
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+#  Template Fields
+#  IsoExtractDir - Full path to the directory (under the build directory) where the ISO should be extracted
+#  RawExtractDir - Full path to the directory (under the build directory) where the RAW image should be
+#                  unsquashed
+#  IsoSource - Full path to the ISO to extract
+
+ISO_EXTRACT_DIR={{.IsoExtractDir}}
+RAW_EXTRACT_DIR={{.RawExtractDir}}
+ISO_PATH={{.IsoSource}}
+
+# Create the extract directories
+mkdir -p ${ISO_EXTRACT_DIR} ${RAW_EXTRACT_DIR}
+
+# Extract the contents of the ISO to the build directory
+xorriso -osirrox on -indev ${ISO_PATH} extract / ${ISO_EXTRACT_DIR}
+
+# Unsquash the raw image
+SQUASHED_IMAGE_NAME=`find ${ISO_EXTRACT_DIR} -name "*.squashfs"`
+unsquashfs -d ${RAW_EXTRACT_DIR} ${SQUASHED_IMAGE_NAME}

--- a/pkg/build/templates/rebuild-iso.sh.tpl
+++ b/pkg/build/templates/rebuild-iso.sh.tpl
@@ -6,11 +6,13 @@ set -euo pipefail
 #  RawExtractDir - Full path to the directory where the RAW image was extracted
 #  IsoSource - Full path to the original ISO that was extracted
 #  OutputImageFilename - Full path and name of the ISO to create
+#  CombustionDir - Full path to the combustion directory to include in the new ISO
 
 ISO_EXTRACT_DIR={{.IsoExtractDir}}
 RAW_EXTRACT_DIR={{.RawExtractDir}}
 ISO_SOURCE={{.IsoSource}}
 OUTPUT_IMAGE={{.OutputImageFilename}}
+COMBUSTION_DIR={{.CombustionDir}}
 
 cd ${ISO_EXTRACT_DIR}
 
@@ -25,10 +27,13 @@ SQUASH_BASENAME=`basename ${SQUASH_IMAGE_FILE}`
 NEW_SQUASH_FILE=${RAW_EXTRACT_DIR}/${SQUASH_BASENAME}
 
 cd ${RAW_EXTRACT_DIR}
+
+echo "Squash"
 mksquashfs ${RAW_IMAGE_FILE} ${CHECKSUM_FILE} ${NEW_SQUASH_FILE}
 
 # Rebuild the previously extracted ISO with the new squashed raw image
 xorriso -indev ${ISO_SOURCE} \
         -outdev ${OUTPUT_IMAGE} \
-        -map ${NEW_SQUASH_FILE} /${SQUASH_BASENAME}
+        -map ${NEW_SQUASH_FILE} /${SQUASH_BASENAME} \
+        -map ${COMBUSTION_DIR} /combustion \
         -boot_image any replay -changes_pending yes

--- a/pkg/build/templates/rebuild-iso.sh.tpl
+++ b/pkg/build/templates/rebuild-iso.sh.tpl
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+#  Template Fields
+#  IsoExtractDir - Full path to the directory where the ISO was extracted
+#  RawExtractDir - Full path to the directory where the RAW image was extracted
+#  IsoSource - Full path to the original ISO that was extracted
+#  OutputImageFilename - Full path and name of the ISO to create
+
+ISO_EXTRACT_DIR={{.IsoExtractDir}}
+RAW_EXTRACT_DIR={{.RawExtractDir}}
+ISO_SOURCE={{.IsoSource}}
+OUTPUT_IMAGE={{.OutputImageFilename}}
+
+cd ${ISO_EXTRACT_DIR}
+
+# Regenerate the checksum, overwriting the existing one that was unsquashed
+RAW_IMAGE_FILE=`find ${RAW_EXTRACT_DIR} -name "*.raw"`
+CHECKSUM_FILE=`find ${RAW_EXTRACT_DIR} -name "*.md5"`
+echo "$(md5sum ${RAW_IMAGE_FILE} | awk '{print $1;}') 280064 8192" > ${CHECKSUM_FILE}
+
+# Resquash the raw image
+SQUASH_IMAGE_FILE=`find ${ISO_EXTRACT_DIR} -name "*.squashfs"`
+SQUASH_BASENAME=`basename ${SQUASH_IMAGE_FILE}`
+NEW_SQUASH_FILE=${RAW_EXTRACT_DIR}/${SQUASH_BASENAME}
+
+cd ${RAW_EXTRACT_DIR}
+mksquashfs ${RAW_IMAGE_FILE} ${CHECKSUM_FILE} ${NEW_SQUASH_FILE}
+
+# Rebuild the previously extracted ISO with the new squashed raw image
+xorriso -indev ${ISO_SOURCE} \
+        -outdev ${OUTPUT_IMAGE} \
+        -map ${NEW_SQUASH_FILE} /${SQUASH_BASENAME}
+        -boot_image any replay -changes_pending yes


### PR DESCRIPTION
This has no net new functionality, but lays the groundwork to refactor the raw image modifications to be done for ISOs as well.

I do want to (eventually) add a test ISO (obviously a custom built one and not a GB-sized one) to actually run the scripts against, but for now the tests prove that the correct values are passed into the templates.