### PR TITLE
Introduce 'package' definition and validation

### DIFF
--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -64,9 +64,9 @@ type OperatingSystem struct {
 }
 
 type Packages struct {
-	PKGList  []string `yaml:"packageList"`
-	AddRepos []string `yaml:"additionalRepos"`
-	RegCode  string   `yaml:"registrationCode"`
+	PKGList         []string `yaml:"packageList"`
+	AdditionalRepos []string `yaml:"additionalRepos"`
+	RegCode         string   `yaml:"registrationCode"`
 }
 
 type OperatingSystemUser struct {

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -60,6 +60,13 @@ type OperatingSystem struct {
 	Users      []OperatingSystemUser `yaml:"users"`
 	Systemd    Systemd               `yaml:"systemd"`
 	Suma       Suma                  `yaml:"suma"`
+	Packages   Packages              `yaml:"packages"`
+}
+
+type Packages struct {
+	PKGList  []string `yaml:"packageList"`
+	AddRepos []string `yaml:"additionalRepos"`
+	RegCode  string   `yaml:"registrationCode"`
 }
 
 type OperatingSystemUser struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -64,6 +64,26 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "slemicro55", suma.ActivationKey)
 	assert.Equal(t, false, suma.GetSSL)
 
+	// Operating System -> Packages
+	pkgConfig := definition.OperatingSystem.Packages
+	require.Len(t, pkgConfig.PKGList, 6)
+	require.Len(t, pkgConfig.AddRepos, 2)
+	expectedPKGList := []string{
+		"wget2",
+		"dpdk22",
+		"dpdk22-tools",
+		"libdpdk-23",
+		"libatomic1",
+		"libbpf0",
+	}
+	assert.Equal(t, expectedPKGList, pkgConfig.PKGList)
+	expectedAddRepos := []string{
+		"https://download.nvidia.com/suse/sle15sp5/",
+		"https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/",
+	}
+	assert.Equal(t, expectedAddRepos, pkgConfig.AddRepos)
+	assert.Equal(t, "INTERNAL-USE-ONLY-foo-bar", pkgConfig.RegCode)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -67,7 +67,7 @@ func TestParse(t *testing.T) {
 	// Operating System -> Packages
 	pkgConfig := definition.OperatingSystem.Packages
 	require.Len(t, pkgConfig.PKGList, 6)
-	require.Len(t, pkgConfig.AddRepos, 2)
+	require.Len(t, pkgConfig.AdditionalRepos, 2)
 	expectedPKGList := []string{
 		"wget2",
 		"dpdk22",
@@ -81,7 +81,7 @@ func TestParse(t *testing.T) {
 		"https://download.nvidia.com/suse/sle15sp5/",
 		"https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/",
 	}
-	assert.Equal(t, expectedAddRepos, pkgConfig.AddRepos)
+	assert.Equal(t, expectedAddRepos, pkgConfig.AdditionalRepos)
 	assert.Equal(t, "INTERNAL-USE-ONLY-foo-bar", pkgConfig.RegCode)
 
 	// EmbeddedArtifactRegistry

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -27,6 +27,18 @@ operatingSystem:
     host: suma.edge.suse.com
     activationKey: slemicro55
     getSSL: false
+  packages:
+    packageList:
+    - wget2
+    - dpdk22
+    - dpdk22-tools
+    - libdpdk-23
+    - libatomic1
+    - libbpf0
+    additionalRepos:
+    - https://download.nvidia.com/suse/sle15sp5/
+    - https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
+    registrationCode: INTERNAL-USE-ONLY-foo-bar
 embeddedArtifactRegistry:
   images:
     - name: hello-world:latest
@@ -42,4 +54,3 @@ kubernetes:
   cni: cilium
   multus: true
   vSphere: false
-

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -277,11 +277,11 @@ func validatePackages(os *OperatingSystem) error {
 		return fmt.Errorf("package list contains duplicate: %s", duplicate)
 	}
 
-	if duplicate := checkForDuplicates(os.Packages.AddRepos); duplicate != "" {
+	if duplicate := checkForDuplicates(os.Packages.AdditionalRepos); duplicate != "" {
 		return fmt.Errorf("additional repository list contains duplicate: %s", duplicate)
 	}
 
-	if len(os.Packages.PKGList) > 0 && len(os.Packages.AddRepos) == 0 && os.Packages.RegCode == "" {
+	if len(os.Packages.PKGList) > 0 && len(os.Packages.AdditionalRepos) == 0 && os.Packages.RegCode == "" {
 		return fmt.Errorf("package list configured without providing additional repository or registration code")
 	}
 

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -72,6 +72,10 @@ func validateOperatingSystem(definition *Definition) error {
 	if err != nil {
 		return fmt.Errorf("error validating suma: %w", err)
 	}
+	err = validatePackages(&definition.OperatingSystem)
+	if err != nil {
+		return fmt.Errorf("error validating packages: %w", err)
+	}
 
 	return nil
 }
@@ -263,6 +267,22 @@ func validateHelmCharts(charts []HelmChart) error {
 			return fmt.Errorf("duplicate chart found: '%s'", chart.Name)
 		}
 		seenCharts[chart.Name] = true
+	}
+
+	return nil
+}
+
+func validatePackages(os *OperatingSystem) error {
+	if duplicate := checkForDuplicates(os.Packages.PKGList); duplicate != "" {
+		return fmt.Errorf("package list contains duplicate: %s", duplicate)
+	}
+
+	if duplicate := checkForDuplicates(os.Packages.AddRepos); duplicate != "" {
+		return fmt.Errorf("additional repository list contains duplicate: %s", duplicate)
+	}
+
+	if len(os.Packages.PKGList) > 0 && len(os.Packages.AddRepos) == 0 && os.Packages.RegCode == "" {
+		return fmt.Errorf("package list configured without providing additional repository or registration code")
 	}
 
 	return nil

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -970,7 +970,7 @@ func TestValidatePackages(t *testing.T) {
 			name: "Additional repository with duplicate",
 			os: &OperatingSystem{
 				Packages: Packages{
-					AddRepos: []string{"https://foo.bar", "https://bar.foo", "https://foo.bar"},
+					AdditionalRepos: []string{"https://foo.bar", "https://bar.foo", "https://foo.bar"},
 				},
 			},
 			expectedErr: "additional repository list contains duplicate: https://foo.bar",
@@ -997,8 +997,8 @@ func TestValidatePackages(t *testing.T) {
 			name: "Configuring package from third party repo",
 			os: &OperatingSystem{
 				Packages: Packages{
-					PKGList:  []string{"foo", "bar"},
-					AddRepos: []string{"https://foo.bar"},
+					PKGList:         []string{"foo", "bar"},
+					AdditionalRepos: []string{"https://foo.bar"},
 				},
 			},
 		},


### PR DESCRIPTION
Introduces the 'package' definition and validation that #64 requires for its RPM resolution logic. This is introduced in a separate PR in order to reduce the complexity of #64. 