### PR TITLE
Add kubernetes installer package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN curl -o nmc-aarch64 -L https://github.com/suse-edge/nm-configurator/releases
     chmod +x nmc-x86_64 && \
     cp nmc-$(uname -m) /usr/local/bin/nmc
 
+RUN curl -o rke2_installer.sh -L https://get.rke2.io
+
 COPY --from=0 /src/eib /bin/eib
 
 CMD ["/bin/eib"]

--- a/cmd/eib/main.go
+++ b/cmd/eib/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/suse-edge/edge-image-builder/pkg/build"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/kubernetes"
 	audit "github.com/suse-edge/edge-image-builder/pkg/log"
 	"github.com/suse-edge/edge-image-builder/pkg/network"
 	"go.uber.org/zap"
@@ -57,6 +58,8 @@ func processArgs() (*image.Context, error) {
 		ImageDefinition:              imageDefinition,
 		NetworkConfigGenerator:       network.ConfigGenerator{},
 		NetworkConfiguratorInstaller: network.ConfiguratorInstaller{},
+		KubernetesScriptInstaller:    kubernetes.ScriptInstaller{},
+		KubernetesArtefactDownloader: kubernetes.ArtefactDownloader{},
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/containers/podman/v4 v4.8.3
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
+	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -125,7 +126,6 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
-	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1132,8 +1132,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
-golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/image/context.go
+++ b/pkg/image/context.go
@@ -4,12 +4,20 @@ import (
 	"io"
 )
 
-type NetworkConfigGenerator interface {
+type networkConfigGenerator interface {
 	GenerateNetworkConfig(configDir, outputDir string, outputWriter io.Writer) error
 }
 
-type NetworkConfiguratorInstaller interface {
+type networkConfiguratorInstaller interface {
 	InstallConfigurator(arch Arch, sourcePath, installPath string) error
+}
+
+type kubernetesScriptInstaller interface {
+	InstallScript(distribution, sourcePath, destinationPath string) error
+}
+
+type kubernetesArtefactDownloader interface {
+	DownloadArtefacts(kubernetes Kubernetes, arch Arch, destinationPath string) error
 }
 
 type Context struct {
@@ -21,6 +29,8 @@ type Context struct {
 	CombustionDir string
 	// ImageDefinition contains the image definition properties.
 	ImageDefinition              *Definition
-	NetworkConfigGenerator       NetworkConfigGenerator
-	NetworkConfiguratorInstaller NetworkConfiguratorInstaller
+	NetworkConfigGenerator       networkConfigGenerator
+	NetworkConfiguratorInstaller networkConfiguratorInstaller
+	KubernetesScriptInstaller    kubernetesScriptInstaller
+	KubernetesArtefactDownloader kubernetesArtefactDownloader
 }

--- a/pkg/kubernetes/artefact_downloader.go
+++ b/pkg/kubernetes/artefact_downloader.go
@@ -1,0 +1,128 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/suse-edge/edge-image-builder/pkg/http"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	kubernetesDir = "kubernetes"
+
+	rke2ReleaseURL = "https://github.com/rancher/rke2/releases/download/%s/%s"
+
+	rke2Binary     = "rke2.linux-%s.tar.gz"
+	rke2CoreImages = "rke2-images-core.linux-%s.tar.zst"
+	rke2Checksums  = "sha256sum-%s.txt"
+
+	rke2CalicoImages = "rke2-images-calico.linux-%s.tar.zst"
+	rke2CanalImages  = "rke2-images-canal.linux-%s.tar.zst"
+	rke2CiliumImages = "rke2-images-cilium.linux-%s.tar.zst"
+	rke2MultusImages = "rke2-images-multus.linux-%s.tar.zst"
+
+	rke2VSphereImages = "rke2-images-vsphere.linux-%s.tar.zst"
+)
+
+type ArtefactDownloader struct{}
+
+func (d ArtefactDownloader) DownloadArtefacts(kubernetes image.Kubernetes, arch image.Arch, destinationPath string) error {
+	if !strings.Contains(kubernetes.Version, image.KubernetesDistroRKE2) {
+		return fmt.Errorf("kubernetes version '%s' is not supported", kubernetes.Version)
+	}
+
+	path := filepath.Join(destinationPath, kubernetesDir)
+
+	if err := os.Mkdir(path, os.ModePerm); err != nil {
+		return fmt.Errorf("creating kubernetes dir: %w", err)
+	}
+
+	artefacts, err := gatherArtefacts(kubernetes, arch)
+	if err != nil {
+		return fmt.Errorf("gathering RKE2 artefacts: %w", err)
+	}
+
+	if err = downloadArtefacts(artefacts, rke2ReleaseURL, kubernetes.Version, destinationPath); err != nil {
+		return fmt.Errorf("downloading RKE2 artefacts: %w", err)
+	}
+
+	return nil
+}
+
+func gatherArtefacts(kubernetes image.Kubernetes, arch image.Arch) ([]string, error) {
+	if arch == image.ArchTypeARM {
+		log.Audit("WARNING: RKE2 support for aarch64 platforms is limited and experimental")
+	}
+
+	artefactArch := arch.Short()
+
+	var artefacts []string
+
+	artefacts = append(artefacts,
+		fmt.Sprintf(rke2Binary, artefactArch),
+		fmt.Sprintf(rke2CoreImages, artefactArch),
+		fmt.Sprintf(rke2Checksums, artefactArch))
+
+	switch kubernetes.CNI {
+	case "":
+		return nil, fmt.Errorf("CNI not specified")
+	case image.CNITypeNone:
+	case image.CNITypeCanal:
+		artefacts = append(artefacts, fmt.Sprintf(rke2CanalImages, artefactArch))
+	case image.CNITypeCalico:
+		if arch == image.ArchTypeARM {
+			return nil, fmt.Errorf("calico is not supported on %s platforms", arch)
+		}
+		artefacts = append(artefacts, fmt.Sprintf(rke2CalicoImages, artefactArch))
+	case image.CNITypeCilium:
+		if arch == image.ArchTypeARM {
+			return nil, fmt.Errorf("cilium is not supported on %s platforms", arch)
+		}
+		artefacts = append(artefacts, fmt.Sprintf(rke2CiliumImages, artefactArch))
+	default:
+		return nil, fmt.Errorf("unsupported CNI: %s", kubernetes.CNI)
+	}
+
+	if kubernetes.MultusEnabled {
+		if arch == image.ArchTypeARM {
+			return nil, fmt.Errorf("multus is not supported on %s platforms", arch)
+		}
+		artefacts = append(artefacts, fmt.Sprintf(rke2MultusImages, artefactArch))
+	}
+
+	if kubernetes.VSphereEnabled {
+		if arch == image.ArchTypeARM {
+			return nil, fmt.Errorf("vSphere is not supported on %s platforms", arch)
+		}
+		artefacts = append(artefacts, fmt.Sprintf(rke2VSphereImages, artefactArch))
+	}
+
+	return artefacts, nil
+}
+
+func downloadArtefacts(artefacts []string, releaseURL, version, destinationPath string) error {
+	errGroup, ctx := errgroup.WithContext(context.Background())
+
+	for _, artefact := range artefacts {
+		func(artefact string) {
+			errGroup.Go(func() error {
+				url := fmt.Sprintf(releaseURL, version, artefact)
+				path := filepath.Join(destinationPath, artefact)
+
+				if err := http.DownloadFile(ctx, url, path); err != nil {
+					return fmt.Errorf("downloading artefact '%s': %w", artefact, err)
+				}
+
+				return nil
+			})
+		}(artefact)
+	}
+
+	return errGroup.Wait()
+}

--- a/pkg/kubernetes/artefact_downloader.go
+++ b/pkg/kubernetes/artefact_downloader.go
@@ -38,7 +38,6 @@ func (d ArtefactDownloader) DownloadArtefacts(kubernetes image.Kubernetes, arch 
 	}
 
 	path := filepath.Join(destinationPath, kubernetesDir)
-
 	if err := os.Mkdir(path, os.ModePerm); err != nil {
 		return fmt.Errorf("creating kubernetes dir: %w", err)
 	}
@@ -48,7 +47,7 @@ func (d ArtefactDownloader) DownloadArtefacts(kubernetes image.Kubernetes, arch 
 		return fmt.Errorf("gathering RKE2 artefacts: %w", err)
 	}
 
-	if err = downloadArtefacts(artefacts, rke2ReleaseURL, kubernetes.Version, destinationPath); err != nil {
+	if err = downloadArtefacts(artefacts, rke2ReleaseURL, kubernetes.Version, path); err != nil {
 		return fmt.Errorf("downloading RKE2 artefacts: %w", err)
 	}
 

--- a/pkg/kubernetes/artefact_downloader_test.go
+++ b/pkg/kubernetes/artefact_downloader_test.go
@@ -1,0 +1,175 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestGatherArtefacts(t *testing.T) {
+	tests := []struct {
+		name              string
+		kubernetes        image.Kubernetes
+		arch              image.Arch
+		expectedArtefacts []string
+		expectedError     string
+	}{
+		{
+			name:          "CNI not specified",
+			kubernetes:    image.Kubernetes{},
+			arch:          image.ArchTypeX86,
+			expectedError: "CNI not specified",
+		},
+		{
+			name: "CNI not supported",
+			kubernetes: image.Kubernetes{
+				CNI: "flannel",
+			},
+			arch:          image.ArchTypeX86,
+			expectedError: "unsupported CNI: flannel",
+		},
+		{
+			name: "x86_64 artefacts without CNI",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeNone,
+			},
+			arch: image.ArchTypeX86,
+			expectedArtefacts: []string{
+				"rke2.linux-amd64.tar.gz",
+				"rke2-images-core.linux-amd64.tar.zst",
+				"sha256sum-amd64.txt",
+			},
+		},
+		{
+			name: "x86_64 artefacts with canal CNI",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeCanal,
+			},
+			arch: image.ArchTypeX86,
+			expectedArtefacts: []string{
+				"rke2.linux-amd64.tar.gz",
+				"rke2-images-core.linux-amd64.tar.zst",
+				"sha256sum-amd64.txt",
+				"rke2-images-canal.linux-amd64.tar.zst",
+			},
+		},
+		{
+			name: "x86_64 artefacts with calico CNI",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeCalico,
+			},
+			arch: image.ArchTypeX86,
+			expectedArtefacts: []string{
+				"rke2.linux-amd64.tar.gz",
+				"rke2-images-core.linux-amd64.tar.zst",
+				"sha256sum-amd64.txt",
+				"rke2-images-calico.linux-amd64.tar.zst",
+			},
+		},
+		{
+			name: "x86_64 artefacts with cilium CNI",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeCilium,
+			},
+			arch: image.ArchTypeX86,
+			expectedArtefacts: []string{
+				"rke2.linux-amd64.tar.gz",
+				"rke2-images-core.linux-amd64.tar.zst",
+				"sha256sum-amd64.txt",
+				"rke2-images-cilium.linux-amd64.tar.zst",
+			},
+		},
+		{
+			name: "x86_64 artefacts with cilium CNI + multus + vSphere",
+			kubernetes: image.Kubernetes{
+				CNI:            image.CNITypeCilium,
+				MultusEnabled:  true,
+				VSphereEnabled: true,
+			},
+			arch: image.ArchTypeX86,
+			expectedArtefacts: []string{
+				"rke2.linux-amd64.tar.gz",
+				"rke2-images-core.linux-amd64.tar.zst",
+				"sha256sum-amd64.txt",
+				"rke2-images-cilium.linux-amd64.tar.zst",
+				"rke2-images-multus.linux-amd64.tar.zst",
+				"rke2-images-vsphere.linux-amd64.tar.zst",
+			},
+		},
+		{
+			name: "aarch64 artefacts for CNI none",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeNone,
+			},
+			arch: image.ArchTypeARM,
+			expectedArtefacts: []string{
+				"rke2.linux-arm64.tar.gz",
+				"rke2-images-core.linux-arm64.tar.zst",
+				"sha256sum-arm64.txt",
+			},
+		},
+		{
+			name: "aarch64 artefacts with canal CNI",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeCanal,
+			},
+			arch: image.ArchTypeARM,
+			expectedArtefacts: []string{
+				"rke2.linux-arm64.tar.gz",
+				"rke2-images-core.linux-arm64.tar.zst",
+				"sha256sum-arm64.txt",
+				"rke2-images-canal.linux-arm64.tar.zst",
+			},
+		},
+		{
+			name: "aarch64 artefacts with calico CNI",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeCalico,
+			},
+			arch:          image.ArchTypeARM,
+			expectedError: "calico is not supported on aarch64 platforms",
+		},
+		{
+			name: "aarch64 artefacts with cilium CNI",
+			kubernetes: image.Kubernetes{
+				CNI: image.CNITypeCilium,
+			},
+			arch:          image.ArchTypeARM,
+			expectedError: "cilium is not supported on aarch64 platforms",
+		},
+		{
+			name: "aarch64 artefacts with canal CNI + multus",
+			kubernetes: image.Kubernetes{
+				CNI:           image.CNITypeCanal,
+				MultusEnabled: true,
+			},
+			arch:          image.ArchTypeARM,
+			expectedError: "multus is not supported on aarch64 platforms",
+		},
+		{
+			name: "aarch64 artefacts with canal CNI + vSphere",
+			kubernetes: image.Kubernetes{
+				CNI:            image.CNITypeCanal,
+				VSphereEnabled: true,
+			},
+			arch:          image.ArchTypeARM,
+			expectedError: "vSphere is not supported on aarch64 platforms",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			artefacts, err := gatherArtefacts(test.kubernetes, test.arch)
+
+			if test.expectedError != "" {
+				require.EqualError(t, err, test.expectedError)
+				assert.Nil(t, artefacts)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedArtefacts, artefacts)
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/script_installer.go
+++ b/pkg/kubernetes/script_installer.go
@@ -1,0 +1,20 @@
+package kubernetes
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+)
+
+type ScriptInstaller struct{}
+
+func (i ScriptInstaller) InstallScript(distribution, sourcePath, destinationPath string) error {
+	const rke2InstallerScript = "%s_installer.sh"
+	installer := fmt.Sprintf(rke2InstallerScript, distribution)
+
+	sourcePath = filepath.Join(sourcePath, installer)
+	destinationPath = filepath.Join(destinationPath, installer)
+
+	return fileio.CopyFile(sourcePath, destinationPath, fileio.ExecutablePerms)
+}


### PR DESCRIPTION
- Downloads RKE2 installer script at build time
- Introduces an easily mockable ScriptInstaller type which installs the script to the combustion directory
- Introduces an ArtefactDownloader type downloading the necessary files from Github release assets
- Adds basic support matrix validation of the RKE2 components