### PR TITLE
Adding unattended mode and disk selection

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -37,6 +37,8 @@ The operating system configuration section is entirely optional.
 The following describes the possible options for the operating system section:
 ```yaml
 operatingSystem:
+  installDevice: /path/to/disk
+  unattended: false
   kernelArgs:
   - arg1
   - arg2
@@ -56,6 +58,11 @@ operatingSystem:
       - serviceX
 ```
 
+* `installDevice` - Optional; only for ISO images - specifies the disk that should be used as the install
+  device. This needs to be block special, and will default to automatically wipe any data found on the disk.
+* `unattended` - Optional; only for ISO images - forces GRUB override to automatically install the operating
+  system rather than prompting user to begin the installation. In combination with `installDevice` can create
+  a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -60,9 +60,11 @@ operatingSystem:
 
 * `installDevice` - Optional; only for ISO images - specifies the disk that should be used as the install
   device. This needs to be block special, and will default to automatically wipe any data found on the disk.
+  If left omitted, the user will still have to select the disk to install to (if >1 found) and confirm wipe.
 * `unattended` - Optional; only for ISO images - forces GRUB override to automatically install the operating
   system rather than prompting user to begin the installation. In combination with `installDevice` can create
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
+  If left omiitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -108,12 +108,16 @@ func (b *Builder) writeIsoScript(templateContents, outputFilename string) error 
 		IsoSource           string
 		OutputImageFilename string
 		CombustionDir       string
+		InstallDevice       string
+		Unattended          bool
 	}{
 		IsoExtractDir:       isoExtractPath,
 		RawExtractDir:       rawExtractPath,
 		IsoSource:           b.generateBaseImageFilename(),
 		OutputImageFilename: b.generateOutputImageFilename(),
 		CombustionDir:       b.context.CombustionDir,
+		InstallDevice:       b.context.ImageDefinition.OperatingSystem.InstallDevice,
+		Unattended:          b.context.ImageDefinition.OperatingSystem.Unattended,
 	}
 
 	contents, err := template.Parse("iso-script", templateContents, arguments)

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -129,6 +129,13 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 	defer teardown()
 	builder := Builder{context: ctx}
 
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			InstallDevice: "/dev/vda",
+			Unattended:    true,
+		},
+	}
+
 	// Test
 	err := builder.writeIsoScript(rebuildIsoTemplate, rebuildIsoScriptName)
 
@@ -157,6 +164,15 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 
 	expectedCombustionDir := ctx.CombustionDir
 	assert.Contains(t, found, fmt.Sprintf("COMBUSTION_DIR=%s", expectedCombustionDir))
+
+	// Make sure that unattended mode is configured for GRUB
+	assert.Contains(t, found, "set timeout=")
+
+	// Make sure that target device is set as kernel cmdline argument
+	assert.Contains(t, found, "rd.kiwi.oem.installdevice=/dev/vda")
+
+	// Make sure that the xorisso command also adds the grub.cfg mapping
+	assert.Contains(t, found, "-map ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg /boot/grub2/grub.cfg")
 }
 
 func TestCreateIsoCommand(t *testing.T) {

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -166,13 +166,13 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 	assert.Contains(t, found, fmt.Sprintf("COMBUSTION_DIR=%s", expectedCombustionDir))
 
 	// Make sure that unattended mode is configured for GRUB
-	assert.Contains(t, found, "set timeout=")
+	assert.Contains(t, found, "set timeout=", "unattended mode is not configured properly in GRUB menu")
 
 	// Make sure that target device is set as kernel cmdline argument
-	assert.Contains(t, found, "rd.kiwi.oem.installdevice=/dev/vda")
+	assert.Contains(t, found, "rd.kiwi.oem.installdevice=/dev/vda", "install device target is not configured as kernel cmdline argument")
 
 	// Make sure that the xorisso command also adds the grub.cfg mapping
-	assert.Contains(t, found, "-map ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg /boot/grub2/grub.cfg")
+	assert.Contains(t, found, "-map ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg /boot/grub2/grub.cfg", "xorisso doesn't have grub.cfg mapping")
 }
 
 func TestCreateIsoCommand(t *testing.T) {

--- a/pkg/build/templates/rebuild-iso.sh.tpl
+++ b/pkg/build/templates/rebuild-iso.sh.tpl
@@ -27,6 +27,16 @@ SQUASH_IMAGE_FILE=`find ${ISO_EXTRACT_DIR} -name "*.squashfs"`
 SQUASH_BASENAME=`basename ${SQUASH_IMAGE_FILE}`
 NEW_SQUASH_FILE=${RAW_EXTRACT_DIR}/${SQUASH_BASENAME}
 
+# Select the desired install device - assumes data destruction
+{{ if ne .InstallDevice "" -}}
+sed -i '/ignition.platform/ s|$| rd.kiwi.oem.installdevice={{.InstallDevice}} |' ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg
+{{ end -}}
+
+# Make the installation fully unattended by enabling GRUB timeout
+{{ if .Unattended -}}
+echo -e "set timeout=3\nset timeout_style=menu\n$(cat ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg)" > ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg
+{{ end }}
+
 cd ${RAW_EXTRACT_DIR}
 
 echo "Squash"
@@ -37,4 +47,7 @@ xorriso -indev ${ISO_SOURCE} \
         -outdev ${OUTPUT_IMAGE} \
         -map ${NEW_SQUASH_FILE} /${SQUASH_BASENAME} \
         -map ${COMBUSTION_DIR} /combustion \
+{{ if .InstallDevice -}}
+        -map ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg /boot/grub2/grub.cfg \
+{{ end -}}
         -boot_image any replay -changes_pending yes

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -56,11 +56,13 @@ type Image struct {
 }
 
 type OperatingSystem struct {
-	KernelArgs []string              `yaml:"kernelArgs"`
-	Users      []OperatingSystemUser `yaml:"users"`
-	Systemd    Systemd               `yaml:"systemd"`
-	Suma       Suma                  `yaml:"suma"`
-	Packages   Packages              `yaml:"packages"`
+	KernelArgs    []string              `yaml:"kernelArgs"`
+	Users         []OperatingSystemUser `yaml:"users"`
+	Systemd       Systemd               `yaml:"systemd"`
+	Suma          Suma                  `yaml:"suma"`
+	Packages      Packages              `yaml:"packages"`
+	InstallDevice string                `yaml:"installDevice"`
+	Unattended    bool                  `yaml:"unattended"`
 }
 
 type Packages struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -84,6 +84,14 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, expectedAddRepos, pkgConfig.AdditionalRepos)
 	assert.Equal(t, "INTERNAL-USE-ONLY-foo-bar", pkgConfig.RegCode)
 
+	// Operating System -> InstallDevice
+	installDevice := definition.OperatingSystem.InstallDevice
+	assert.Equal(t, "/dev/sda", installDevice)
+
+	// Operating System -> Unattended
+	unattended := definition.OperatingSystem.Unattended
+	assert.Equal(t, true, unattended)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -5,6 +5,8 @@ image:
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
 operatingSystem:
+  installDevice: /dev/sda
+  unattended: true
   kernelArgs:
     - alpha=foo
     - beta=bar

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -76,6 +76,10 @@ func validateOperatingSystem(definition *Definition) error {
 	if err != nil {
 		return fmt.Errorf("error validating packages: %w", err)
 	}
+	err = validateUnattended(definition)
+	if err != nil {
+		return fmt.Errorf("error validating unattended mode: %w", err)
+	}
 
 	return nil
 }
@@ -134,6 +138,18 @@ func validateKernelArgs(os *OperatingSystem) error {
 			return fmt.Errorf("duplicate kernel arg found: '%s'", key)
 		}
 		seenKeys[key] = true
+	}
+
+	return nil
+}
+
+func validateUnattended(definition *Definition) error {
+	if definition.Image.ImageType != TypeISO && definition.OperatingSystem.Unattended == true {
+		return fmt.Errorf("unattended mode can only be used with image type '%s'", TypeISO)
+	}
+
+	if definition.Image.ImageType != TypeISO && definition.OperatingSystem.InstallDevice != "" {
+		return fmt.Errorf("install device can only be selected with image type '%s'", TypeISO)
 	}
 
 	return nil

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -144,7 +144,7 @@ func validateKernelArgs(os *OperatingSystem) error {
 }
 
 func validateUnattended(definition *Definition) error {
-	if definition.Image.ImageType != TypeISO && definition.OperatingSystem.Unattended == true {
+	if definition.Image.ImageType != TypeISO && definition.OperatingSystem.Unattended {
 		return fmt.Errorf("unattended mode can only be used with image type '%s'", TypeISO)
 	}
 

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -297,6 +297,9 @@ func TestValidateOperatingSystemEmptyButValid(t *testing.T) {
 func TestValidateOperatingSystemValid(t *testing.T) {
 	// Setup
 	def := Definition{
+		Image: Image{
+			ImageType: "iso",
+		},
 		OperatingSystem: OperatingSystem{
 			KernelArgs: []string{"key1=value1", "key2=value2", "arg1", "arg2"},
 			Systemd: Systemd{
@@ -320,6 +323,8 @@ func TestValidateOperatingSystemValid(t *testing.T) {
 				ActivationKey: "slemicro55",
 				GetSSL:        false,
 			},
+			InstallDevice: "/dev/sda",
+			Unattended:    true,
 		},
 	}
 


### PR DESCRIPTION
This PR adds two new features:

1.  Unattended mode, where we skip the GRUB selection of install or boot from disk and automatically run the installation after 3 seconds (we may want to make this larger to enable users to override this). The default behaviour is to wait at the GRUB prompt to avoid data loss. For fully automated installs we need a way of overriding this.

2. Disk selection, where the user can tell the installer which disk to target (needs to be block special, e.g. /dev/sda), which has two primary benefits - firstly, if the system has more than one disk it allows the user to make this choice outside at image build time, not at boot time, and secondly, if the user has selected a disk to install to it forces the confirmation of wiping anything found on the target disk.

With these two options we can enable fully unattended and automated provisioning via EIB, this requires no user intervention.  Important note, (1) above works today with the default SLE Micro SelfInstall ISO, but (2) requires https://github.com/SUSE/kiwi_sle15/pull/6 to land first. However, this code can land without impacting existing images without this patch, as the kernel cmdline argument will just be ignored.