### PR TITLE
Adding support for setting timezone and chrony sources

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -37,6 +37,8 @@ The operating system configuration section is entirely optional.
 The following describes the possible options for the operating system section:
 ```yaml
 operatingSystem:
+  installDevice: /path/to/disk
+  unattended: false
   kernelArgs:
   - arg1
   - arg2
@@ -56,6 +58,13 @@ operatingSystem:
       - serviceX
 ```
 
+* `installDevice` - Optional; only for ISO images - specifies the disk that should be used as the install
+  device. This needs to be block special, and will default to automatically wipe any data found on the disk.
+  If left omitted, the user will still have to select the disk to install to (if >1 found) and confirm wipe.
+* `unattended` - Optional; only for ISO images - forces GRUB override to automatically install the operating
+  system rather than prompting user to begin the installation. In combination with `installDevice` can create
+  a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
+  If left omiitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -39,6 +39,13 @@ The following describes the possible options for the operating system section:
 operatingSystem:
   installDevice: /path/to/disk
   unattended: false
+  time:
+    timezone: Europe/London
+  chronyPools:
+    - 1.pool.server.com
+  chronyServers:
+    - 10.0.0.1
+    - 10.0.0.2
   kernelArgs:
   - arg1
   - arg2
@@ -66,6 +73,10 @@ operatingSystem:
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
   If left omiitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
+* `time` - Optional; section where the user can provide timezone information and Chronyd configuration
+  * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`
+  * `chronyPools` - Optional; a list of pools that Chrony can use as data sources.
+  * `chronyServers` - Optional; a list of servers that Chrony can use as data sources.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:
   * `username` - Required; Username of the user to create. To set the password or SSH key for the root user,

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -108,12 +108,16 @@ func (b *Builder) writeIsoScript(templateContents, outputFilename string) error 
 		IsoSource           string
 		OutputImageFilename string
 		CombustionDir       string
+		InstallDevice       string
+		Unattended          bool
 	}{
 		IsoExtractDir:       isoExtractPath,
 		RawExtractDir:       rawExtractPath,
 		IsoSource:           b.generateBaseImageFilename(),
 		OutputImageFilename: b.generateOutputImageFilename(),
 		CombustionDir:       b.context.CombustionDir,
+		InstallDevice:       b.context.ImageDefinition.OperatingSystem.InstallDevice,
+		Unattended:          b.context.ImageDefinition.OperatingSystem.Unattended,
 	}
 
 	contents, err := template.Parse("iso-script", templateContents, arguments)

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -129,6 +129,13 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 	defer teardown()
 	builder := Builder{context: ctx}
 
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			InstallDevice: "/dev/vda",
+			Unattended:    true,
+		},
+	}
+
 	// Test
 	err := builder.writeIsoScript(rebuildIsoTemplate, rebuildIsoScriptName)
 
@@ -157,6 +164,15 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 
 	expectedCombustionDir := ctx.CombustionDir
 	assert.Contains(t, found, fmt.Sprintf("COMBUSTION_DIR=%s", expectedCombustionDir))
+
+	// Make sure that unattended mode is configured for GRUB
+	assert.Contains(t, found, "set timeout=", "unattended mode is not configured properly in GRUB menu")
+
+	// Make sure that target device is set as kernel cmdline argument
+	assert.Contains(t, found, "rd.kiwi.oem.installdevice=/dev/vda", "install device target is not configured as kernel cmdline argument")
+
+	// Make sure that the xorisso command also adds the grub.cfg mapping
+	assert.Contains(t, found, "-map ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg /boot/grub2/grub.cfg", "xorisso doesn't have grub.cfg mapping")
 }
 
 func TestCreateIsoCommand(t *testing.T) {

--- a/pkg/build/templates/rebuild-iso.sh.tpl
+++ b/pkg/build/templates/rebuild-iso.sh.tpl
@@ -27,6 +27,16 @@ SQUASH_IMAGE_FILE=`find ${ISO_EXTRACT_DIR} -name "*.squashfs"`
 SQUASH_BASENAME=`basename ${SQUASH_IMAGE_FILE}`
 NEW_SQUASH_FILE=${RAW_EXTRACT_DIR}/${SQUASH_BASENAME}
 
+# Select the desired install device - assumes data destruction
+{{ if ne .InstallDevice "" -}}
+sed -i '/ignition.platform/ s|$| rd.kiwi.oem.installdevice={{.InstallDevice}} |' ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg
+{{ end -}}
+
+# Make the installation fully unattended by enabling GRUB timeout
+{{ if .Unattended -}}
+echo -e "set timeout=3\nset timeout_style=menu\n$(cat ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg)" > ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg
+{{ end }}
+
 cd ${RAW_EXTRACT_DIR}
 
 echo "Squash"
@@ -37,4 +47,7 @@ xorriso -indev ${ISO_SOURCE} \
         -outdev ${OUTPUT_IMAGE} \
         -map ${NEW_SQUASH_FILE} /${SQUASH_BASENAME} \
         -map ${COMBUSTION_DIR} /combustion \
+{{ if .InstallDevice -}}
+        -map ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg /boot/grub2/grub.cfg \
+{{ end -}}
         -boot_image any replay -changes_pending yes

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -45,6 +45,10 @@ func Configure(ctx *image.Context) error {
 			runnable: configureCustomFiles,
 		},
 		{
+			name:     timeComponentName,
+			runnable: configureTime,
+		},
+		{
 			name:     networkComponentName,
 			runnable: configureNetwork,
 		},

--- a/pkg/combustion/templates/09-time-setup.sh.tpl
+++ b/pkg/combustion/templates/09-time-setup.sh.tpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+{{ if .Timezone -}}
+ln -sf /usr/share/zoneinfo/{{ .Timezone }} /etc/localtime
+{{ end -}}
+
+{{ if or (gt (len .ChronyPools) 0) (gt (len .ChronyServers) 0) }}
+rm -f /etc/chrony.d/pool.conf
+{{ end -}}
+
+{{ range .ChronyPools -}}
+echo "pool {{ . }} iburst" >> /etc/chrony.d/eib-sources.conf
+{{ end -}}
+
+{{ range .ChronyServers -}}
+echo "server {{ . }} iburst" >> /etc/chrony.d/eib-sources.conf
+{{ end -}}

--- a/pkg/combustion/time.go
+++ b/pkg/combustion/time.go
@@ -1,0 +1,51 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+)
+
+const (
+	timeComponentName = "time"
+	timeScriptName    = "09-time-setup.sh"
+)
+
+//go:embed templates/09-time-setup.sh.tpl
+var timeScript string
+
+func configureTime(ctx *image.Context) ([]string, error) {
+	time := ctx.ImageDefinition.OperatingSystem.Time
+	if time.Timezone == "" {
+		log.AuditComponentSkipped(timeComponentName)
+		return nil, nil
+	}
+
+	if err := writeTimeCombustionScript(ctx); err != nil {
+		log.AuditComponentFailed(timeComponentName)
+		return nil, err
+	}
+
+	log.AuditComponentSuccessful(timeComponentName)
+	return []string{timeScriptName}, nil
+}
+
+func writeTimeCombustionScript(ctx *image.Context) error {
+	timeScriptFilename := filepath.Join(ctx.CombustionDir, timeScriptName)
+
+	data, err := template.Parse(timeScriptName, timeScript, ctx.ImageDefinition.OperatingSystem.Time)
+	if err != nil {
+		return fmt.Errorf("applying template to %s: %w", timeScriptName, err)
+	}
+
+	if err := os.WriteFile(timeScriptFilename, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing file %s: %w", timeScriptFilename, err)
+	}
+	return nil
+}

--- a/pkg/combustion/time_test.go
+++ b/pkg/combustion/time_test.go
@@ -1,0 +1,78 @@
+package combustion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestConfigureTime_NoConf(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Time: image.Time{},
+		},
+	}
+
+	// Test
+	scripts, err := configureTime(ctx)
+
+	// Verify
+	require.NoError(t, err)
+	assert.Nil(t, scripts)
+}
+
+func TestConfigureTime_FullConfiguration(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Time: image.Time{
+				Timezone:      "Europe/London",
+				ChronyPools:   []string{"2.suse.pool.ntp.org"},
+				ChronyServers: []string{"10.0.0.1", "10.0.0.2"},
+			},
+		},
+	}
+
+	// Test
+	scripts, err := configureTime(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, timeScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, timeScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the symbolic link is created with correct timezone
+	assert.Contains(t, foundContents, "ln -sf /usr/share/zoneinfo/Europe/London /etc/localtime", "symbolic link not created")
+
+	// - Ensure that we have the correct chrony pool listed in chrony sources
+	assert.Contains(t, foundContents, "pool 2.suse.pool.ntp.org iburst", "chrony pool not created")
+
+	// - Ensure that we have the correct first chrony server listed in chrony sources
+	assert.Contains(t, foundContents, "server 10.0.0.1 iburst", "first chronyServer not created")
+
+	// - Ensure that we have the correct second chrony server listed in chrony sources
+	assert.Contains(t, foundContents, "server 10.0.0.1 iburst", "second chronyServer not created")
+}

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -63,6 +63,7 @@ type OperatingSystem struct {
 	Packages      Packages              `yaml:"packages"`
 	InstallDevice string                `yaml:"installDevice"`
 	Unattended    bool                  `yaml:"unattended"`
+	Time       Time                  `yaml:"time"`
 }
 
 type Packages struct {
@@ -86,6 +87,12 @@ type Suma struct {
 	Host          string `yaml:"host"`
 	ActivationKey string `yaml:"activationKey"`
 	GetSSL        bool   `yaml:"getSSL"`
+}
+
+type Time struct {
+	Timezone      string   `yaml:"timezone"`
+	ChronyPools   []string `yaml:"chronyPools"`
+	ChronyServers []string `yaml:"chronyServers"`
 }
 
 type EmbeddedArtifactRegistry struct {

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -56,11 +56,13 @@ type Image struct {
 }
 
 type OperatingSystem struct {
-	KernelArgs []string              `yaml:"kernelArgs"`
-	Users      []OperatingSystemUser `yaml:"users"`
-	Systemd    Systemd               `yaml:"systemd"`
-	Suma       Suma                  `yaml:"suma"`
-	Packages   Packages              `yaml:"packages"`
+	KernelArgs    []string              `yaml:"kernelArgs"`
+	Users         []OperatingSystemUser `yaml:"users"`
+	Systemd       Systemd               `yaml:"systemd"`
+	Suma          Suma                  `yaml:"suma"`
+	Packages      Packages              `yaml:"packages"`
+	InstallDevice string                `yaml:"installDevice"`
+	Unattended    bool                  `yaml:"unattended"`
 }
 
 type Packages struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -84,6 +84,14 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, expectedAddRepos, pkgConfig.AdditionalRepos)
 	assert.Equal(t, "INTERNAL-USE-ONLY-foo-bar", pkgConfig.RegCode)
 
+	// Operating System -> InstallDevice
+	installDevice := definition.OperatingSystem.InstallDevice
+	assert.Equal(t, "/dev/sda", installDevice)
+
+	// Operating System -> Unattended
+	unattended := definition.OperatingSystem.Unattended
+	assert.Equal(t, true, unattended)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -5,6 +5,8 @@ image:
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
 operatingSystem:
+  installDevice: /dev/sda
+  unattended: true
   kernelArgs:
     - alpha=foo
     - beta=bar

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -7,6 +7,13 @@ image:
 operatingSystem:
   installDevice: /dev/sda
   unattended: true
+  time:
+    timezone: Europe/London
+    chronyPools:
+      - 2.suse.pool.ntp.org
+    chronyServers:
+      - 10.0.0.1
+      - 10.0.0.2
   kernelArgs:
     - alpha=foo
     - beta=bar

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -76,6 +76,10 @@ func validateOperatingSystem(definition *Definition) error {
 	if err != nil {
 		return fmt.Errorf("error validating packages: %w", err)
 	}
+	err = validateUnattended(definition)
+	if err != nil {
+		return fmt.Errorf("error validating unattended mode: %w", err)
+	}
 
 	return nil
 }
@@ -134,6 +138,18 @@ func validateKernelArgs(os *OperatingSystem) error {
 			return fmt.Errorf("duplicate kernel arg found: '%s'", key)
 		}
 		seenKeys[key] = true
+	}
+
+	return nil
+}
+
+func validateUnattended(definition *Definition) error {
+	if definition.Image.ImageType != TypeISO && definition.OperatingSystem.Unattended {
+		return fmt.Errorf("unattended mode can only be used with image type '%s'", TypeISO)
+	}
+
+	if definition.Image.ImageType != TypeISO && definition.OperatingSystem.InstallDevice != "" {
+		return fmt.Errorf("install device can only be selected with image type '%s'", TypeISO)
 	}
 
 	return nil

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -297,6 +297,9 @@ func TestValidateOperatingSystemEmptyButValid(t *testing.T) {
 func TestValidateOperatingSystemValid(t *testing.T) {
 	// Setup
 	def := Definition{
+		Image: Image{
+			ImageType: "iso",
+		},
 		OperatingSystem: OperatingSystem{
 			KernelArgs: []string{"key1=value1", "key2=value2", "arg1", "arg2"},
 			Systemd: Systemd{
@@ -320,6 +323,8 @@ func TestValidateOperatingSystemValid(t *testing.T) {
 				ActivationKey: "slemicro55",
 				GetSSL:        false,
 			},
+			InstallDevice: "/dev/sda",
+			Unattended:    true,
 		},
 	}
 


### PR DESCRIPTION
This PR adds the ability to specify the `timezone` you wish your system to be setup with (see `timedatectl list-timezones`) and also allows the user to specify a list of `chronyPools` and `chronyServers`, which will populate a new file `/etc/chrony.d/eib-sources.conf` (removing the out of the box default SUSE NTP pool).