### PR TITLE
Adding support for setting timezone and chrony sources

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -39,6 +39,13 @@ The following describes the possible options for the operating system section:
 operatingSystem:
   installDevice: /path/to/disk
   unattended: false
+  time:
+    timezone: Europe/London
+    chronyPools:
+      - 1.pool.server.com
+    chronyServers:
+      - 10.0.0.1
+      - 10.0.0.2
   kernelArgs:
   - arg1
   - arg2
@@ -66,6 +73,10 @@ operatingSystem:
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
   If left omiitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
+* `time` - Optional; section where the user can provide timezone information and Chronyd configuration
+  * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`
+  * `chronyPools` - Optional; a list of pools that Chrony can use as data sources.
+  * `chronyServers` - Optional; a list of servers that Chrony can use as data sources.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:
   * `username` - Required; Username of the user to create. To set the password or SSH key for the root user,

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -45,6 +45,10 @@ func Configure(ctx *image.Context) error {
 			runnable: configureCustomFiles,
 		},
 		{
+			name:     timeComponentName,
+			runnable: configureTime,
+		},
+		{
 			name:     networkComponentName,
 			runnable: configureNetwork,
 		},

--- a/pkg/combustion/templates/09-time-setup.sh.tpl
+++ b/pkg/combustion/templates/09-time-setup.sh.tpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+{{ if .Timezone -}}
+ln -sf /usr/share/zoneinfo/{{ .Timezone }} /etc/localtime
+{{ end -}}
+
+{{ if or (gt (len .ChronyPools) 0) (gt (len .ChronyServers) 0) }}
+rm -f /etc/chrony.d/pool.conf
+{{ end -}}
+
+{{ range .ChronyPools -}}
+echo "pool {{ . }} iburst" >> /etc/chrony.d/eib-sources.conf
+{{ end -}}
+
+{{ range .ChronyServers -}}
+echo "server {{ . }} iburst" >> /etc/chrony.d/eib-sources.conf
+{{ end -}}

--- a/pkg/combustion/time.go
+++ b/pkg/combustion/time.go
@@ -1,0 +1,51 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+)
+
+const (
+	timeComponentName = "time"
+	timeScriptName    = "09-time-setup.sh"
+)
+
+//go:embed templates/09-time-setup.sh.tpl
+var timeScript string
+
+func configureTime(ctx *image.Context) ([]string, error) {
+	time := ctx.ImageDefinition.OperatingSystem.Time
+	if time.Timezone == "" {
+		log.AuditComponentSkipped(timeComponentName)
+		return nil, nil
+	}
+
+	if err := writeTimeCombustionScript(ctx); err != nil {
+		log.AuditComponentFailed(timeComponentName)
+		return nil, err
+	}
+
+	log.AuditComponentSuccessful(timeComponentName)
+	return []string{timeScriptName}, nil
+}
+
+func writeTimeCombustionScript(ctx *image.Context) error {
+	timeScriptFilename := filepath.Join(ctx.CombustionDir, timeScriptName)
+
+	data, err := template.Parse(timeScriptName, timeScript, ctx.ImageDefinition.OperatingSystem.Time)
+	if err != nil {
+		return fmt.Errorf("applying template to %s: %w", timeScriptName, err)
+	}
+
+	if err := os.WriteFile(timeScriptFilename, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing file %s: %w", timeScriptFilename, err)
+	}
+	return nil
+}

--- a/pkg/combustion/time_test.go
+++ b/pkg/combustion/time_test.go
@@ -1,0 +1,78 @@
+package combustion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestConfigureTime_NoConf(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Time: image.Time{},
+		},
+	}
+
+	// Test
+	scripts, err := configureTime(ctx)
+
+	// Verify
+	require.NoError(t, err)
+	assert.Nil(t, scripts)
+}
+
+func TestConfigureTime_FullConfiguration(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Time: image.Time{
+				Timezone:      "Europe/London",
+				ChronyPools:   []string{"2.suse.pool.ntp.org"},
+				ChronyServers: []string{"10.0.0.1", "10.0.0.2"},
+			},
+		},
+	}
+
+	// Test
+	scripts, err := configureTime(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, timeScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, timeScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the symbolic link is created with correct timezone
+	assert.Contains(t, foundContents, "ln -sf /usr/share/zoneinfo/Europe/London /etc/localtime", "symbolic link not created")
+
+	// - Ensure that we have the correct chrony pool listed in chrony sources
+	assert.Contains(t, foundContents, "pool 2.suse.pool.ntp.org iburst", "chrony pool not created")
+
+	// - Ensure that we have the correct first chrony server listed in chrony sources
+	assert.Contains(t, foundContents, "server 10.0.0.1 iburst", "first chronyServer not created")
+
+	// - Ensure that we have the correct second chrony server listed in chrony sources
+	assert.Contains(t, foundContents, "server 10.0.0.1 iburst", "second chronyServer not created")
+}

--- a/pkg/combustion/time_test.go
+++ b/pkg/combustion/time_test.go
@@ -31,7 +31,8 @@ func TestConfigureTime_NoConf(t *testing.T) {
 
 func TestConfigureTime_FullConfiguration(t *testing.T) {
 	// Setup
-	var ctx image.Context
+	ctx, teardown := setupContext(t)
+	defer teardown()
 
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
@@ -44,7 +45,7 @@ func TestConfigureTime_FullConfiguration(t *testing.T) {
 	}
 
 	// Test
-	scripts, err := configureTime(&ctx)
+	scripts, err := configureTime(ctx)
 
 	// Verify
 	require.NoError(t, err)

--- a/pkg/combustion/time_test.go
+++ b/pkg/combustion/time_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestConfigureTime_NoConf(t *testing.T) {
 	// Setup
-	ctx, teardown := setupContext(t)
-	defer teardown()
+	var ctx image.Context
 
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
@@ -23,7 +22,7 @@ func TestConfigureTime_NoConf(t *testing.T) {
 	}
 
 	// Test
-	scripts, err := configureTime(ctx)
+	scripts, err := configureTime(&ctx)
 
 	// Verify
 	require.NoError(t, err)
@@ -32,8 +31,7 @@ func TestConfigureTime_NoConf(t *testing.T) {
 
 func TestConfigureTime_FullConfiguration(t *testing.T) {
 	// Setup
-	ctx, teardown := setupContext(t)
-	defer teardown()
+	var ctx image.Context
 
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
@@ -46,7 +44,7 @@ func TestConfigureTime_FullConfiguration(t *testing.T) {
 	}
 
 	// Test
-	scripts, err := configureTime(ctx)
+	scripts, err := configureTime(&ctx)
 
 	// Verify
 	require.NoError(t, err)

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -63,6 +63,7 @@ type OperatingSystem struct {
 	Packages      Packages              `yaml:"packages"`
 	InstallDevice string                `yaml:"installDevice"`
 	Unattended    bool                  `yaml:"unattended"`
+	Time          Time                  `yaml:"time"`
 }
 
 type Packages struct {
@@ -86,6 +87,12 @@ type Suma struct {
 	Host          string `yaml:"host"`
 	ActivationKey string `yaml:"activationKey"`
 	GetSSL        bool   `yaml:"getSSL"`
+}
+
+type Time struct {
+	Timezone      string   `yaml:"timezone"`
+	ChronyPools   []string `yaml:"chronyPools"`
+	ChronyServers []string `yaml:"chronyServers"`
 }
 
 type EmbeddedArtifactRegistry struct {

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -7,6 +7,13 @@ image:
 operatingSystem:
   installDevice: /dev/sda
   unattended: true
+  time:
+    timezone: Europe/London
+    chronyPools:
+      - 2.suse.pool.ntp.org
+    chronyServers:
+      - 10.0.0.1
+      - 10.0.0.2
   kernelArgs:
     - alpha=foo
     - beta=bar


### PR DESCRIPTION
This PR adds the ability to specify the timezone you wish your system to be setup with (see `timedatectl list-timezones`) and also allows the user to specify a list of `chronyPools` and `chronyServers`, which will populate a new file `/etc/chrony.d/eib-sources.conf` (removing the out of the box default SUSE NTP pool).

The setting of the timezone and chrony sources is executed early on in the boot process to ensure there's no issues with SSL, where later stages, e.g. SUMA/Elemental registration may break.