### PR TITLE
Introduced new validation runner and ported image validations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,12 @@ FROM opensuse/leap:15.5
 # 1. ISO image building
 # 2. RAW image modification on x86_64
 # 3. Podman EIB library
+# 4. RPM resolution logic
 RUN zypper install -y \
     xorriso squashfs  \
     libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs \
-    podman
+    podman \
+    createrepo_c
 
 # TODO: Install nmc via zypper once an RPM package is available
 RUN curl -o nmc-aarch64 -L https://github.com/suse-edge/nm-configurator/releases/download/v0.2.0/nmc-linux-aarch64 && \

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -46,6 +46,10 @@ operatingSystem:
     chronyServers:
       - 10.0.0.1
       - 10.0.0.2
+  proxy:
+    httpProxy: http://10.0.0.1:3128
+    httpsProxy: http://10.0.0.1:3128
+    noProxy: localhost, 127.0.0.1, edge.suse.com
   kernelArgs:
   - arg1
   - arg2
@@ -72,11 +76,16 @@ operatingSystem:
   system rather than prompting user to begin the installation. In combination with `installDevice` can create
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
   If left omitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
-* `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `time` - Optional; section where the user can provide timezone information and Chronyd configuration.
   * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`.
   * `chronyPools` - Optional; a list of pools that Chrony can use as data sources.
   * `chronyServers` - Optional; a list of servers that Chrony can use as data sources.
+* `proxy` - Optional; section where the user can provide system-wide proxy information
+  * `httpProxy` - Optional; set the system-wide http proxy settings
+  * `httpsProxy` - Optional; set the system-wide https proxy settings
+  * `noProxy` - Optional; override the default `NO_PROXY` list. By default this is "localhost, 127.0.0.1" if parameter is omitted, but
+  if you set this flag, make sure you add these into your list if they're required.
+* `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:
   * `username` - Required; Username of the user to create. To set the password or SSH key for the root user,

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -71,10 +71,10 @@ operatingSystem:
 * `unattended` - Optional; only for ISO images - forces GRUB override to automatically install the operating
   system rather than prompting user to begin the installation. In combination with `installDevice` can create
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
-  If left omiitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
+  If left omitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
-* `time` - Optional; section where the user can provide timezone information and Chronyd configuration
-  * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`
+* `time` - Optional; section where the user can provide timezone information and Chronyd configuration.
+  * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`.
   * `chronyPools` - Optional; a list of pools that Chrony can use as data sources.
   * `chronyServers` - Optional; a list of servers that Chrony can use as data sources.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -67,6 +67,7 @@ operatingSystem:
       - service1
     disable:
       - serviceX
+  keymap: us
 ```
 
 * `installDevice` - Optional; only for ISO images - specifies the disk that should be used as the install
@@ -97,6 +98,8 @@ operatingSystem:
   be included; if neither are provided, this section is ignored.
   * `enable` - Optional; List of systemd services to enable.
   * `disable` - Optional; List of systemd services to disable.
+* `keymap` - Optional; sets the virtual console (VC) keymap, full list via `localectl list-keymaps`. If unset, we default to
+  `us`.
 
 ## SUSE Manager (SUMA)
 

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	// podman mod file https://github.com/containers/podman/blob/v4.8.3/go.mod#L14
 	github.com/containers/buildah v1.33.2
 	github.com/containers/podman/v4 v4.8.3
+	github.com/schollz/progressbar/v3 v3.14.1
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
-	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -84,6 +84,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.18 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mistifyio/go-zfs/v3 v3.0.1 // indirect
+	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
@@ -126,8 +127,9 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/term v0.15.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/grpc v1.58.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -606,6 +606,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -656,6 +657,7 @@ github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kN
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -677,6 +679,8 @@ github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go
 github.com/mistifyio/go-zfs/v3 v3.0.0/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
 github.com/mistifyio/go-zfs/v3 v3.0.1 h1:YaoXgBePoMA12+S1u/ddkv+QqxcfiZK4prI6HPnkFiU=
 github.com/mistifyio/go-zfs/v3 v3.0.1/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -846,6 +850,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/schollz/progressbar/v3 v3.14.1 h1:VD+MJPCr4s3wdhTc7OEJ/Z3dAeBzJ7yKH/P4lC5yRTI=
+github.com/schollz/progressbar/v3 v3.14.1/go.mod h1:Zc9xXneTzWXF81TGoqL71u0sBPjULtEHYtj/WVgVy8E=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
@@ -1132,8 +1138,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1219,13 +1225,16 @@ golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
+golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
+golang.org/x/term v0.16.0 h1:m+B6fahuftsE9qjo0VWp2FW0mB3MTJvR0BaMQrq0pmE=
+golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -57,6 +57,10 @@ func Configure(ctx *image.Context) error {
 			runnable: configureUsers,
 		},
 		{
+			name:     proxyComponentName,
+			runnable: configureProxy,
+		},
+		{
 			name:     rpmComponentName,
 			runnable: configureRPMs,
 		},

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -76,6 +76,10 @@ func Configure(ctx *image.Context) error {
 			name:     sumaComponentName,
 			runnable: configureSuma,
 		},
+		{
+			name:     keymapComponentName,
+			runnable: configureKeymap,
+		},
 	}
 
 	for _, component := range combustionComponents {

--- a/pkg/combustion/keymap.go
+++ b/pkg/combustion/keymap.go
@@ -1,0 +1,45 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+)
+
+const (
+	keymapComponentName = "keymap"
+	keymapScriptName    = "13-keymap-setup.sh"
+)
+
+//go:embed templates/13-keymap-setup.sh.tpl
+var keymapScript string
+
+func configureKeymap(ctx *image.Context) ([]string, error) {
+	if err := writeKeymapCombustionScript(ctx); err != nil {
+		log.AuditComponentFailed(keymapComponentName)
+		return nil, err
+	}
+
+	log.AuditComponentSuccessful(keymapComponentName)
+	return []string{keymapScriptName}, nil
+}
+
+func writeKeymapCombustionScript(ctx *image.Context) error {
+	keymapScriptFilename := filepath.Join(ctx.CombustionDir, keymapScriptName)
+
+	data, err := template.Parse(keymapScriptName, keymapScript, ctx.ImageDefinition.OperatingSystem)
+	if err != nil {
+		return fmt.Errorf("applying template to %s: %w", keymapScriptName, err)
+	}
+
+	if err := os.WriteFile(keymapScriptFilename, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing file %s: %w", keymapScriptFilename, err)
+	}
+	return nil
+}

--- a/pkg/combustion/keymap_test.go
+++ b/pkg/combustion/keymap_test.go
@@ -1,0 +1,78 @@
+package combustion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestConfigureKeymap(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Keymap: "gb",
+		},
+	}
+
+	// Test
+	scripts, err := configureKeymap(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, keymapScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, keymapScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the keymap is set correctly
+	assert.Contains(t, foundContents, "echo \"KEYMAP=gb\" >> /etc/vconsole.conf", "keymap not correctly set")
+}
+
+func TestConfigureKeymap_NoConf(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{},
+	}
+
+	// Test
+	scripts, err := configureKeymap(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, keymapScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, keymapScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the keymap is set correctly
+	assert.Contains(t, foundContents, "echo \"KEYMAP=us\" >> /etc/vconsole.conf", "keymap not correctly set")
+}

--- a/pkg/combustion/proxy.go
+++ b/pkg/combustion/proxy.go
@@ -1,0 +1,51 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+)
+
+const (
+	proxyComponentName = "proxy"
+	proxyScriptName    = "08-proxy-setup.sh"
+)
+
+//go:embed templates/08-proxy-setup.sh.tpl
+var proxyScript string
+
+func configureProxy(ctx *image.Context) ([]string, error) {
+	proxy := ctx.ImageDefinition.OperatingSystem.Proxy
+	if proxy.HTTPProxy == "" && proxy.HTTPSProxy == "" {
+		log.AuditComponentSkipped(proxyComponentName)
+		return nil, nil
+	}
+
+	if err := writeProxyCombustionScript(ctx); err != nil {
+		log.AuditComponentFailed(proxyComponentName)
+		return nil, err
+	}
+
+	log.AuditComponentSuccessful(proxyComponentName)
+	return []string{proxyScriptName}, nil
+}
+
+func writeProxyCombustionScript(ctx *image.Context) error {
+	proxyScriptFilename := filepath.Join(ctx.CombustionDir, proxyScriptName)
+
+	data, err := template.Parse(proxyScriptName, proxyScript, ctx.ImageDefinition.OperatingSystem.Proxy)
+	if err != nil {
+		return fmt.Errorf("applying template to %s: %w", proxyScriptName, err)
+	}
+
+	if err := os.WriteFile(proxyScriptFilename, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing file %s: %w", proxyScriptFilename, err)
+	}
+	return nil
+}

--- a/pkg/combustion/proxy_test.go
+++ b/pkg/combustion/proxy_test.go
@@ -1,0 +1,77 @@
+package combustion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestConfigureProxy_NoConf(t *testing.T) {
+	// Setup
+	var ctx image.Context
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Proxy: image.Proxy{},
+		},
+	}
+
+	// Test
+	scripts, err := configureProxy(&ctx)
+
+	// Verify
+	require.NoError(t, err)
+	assert.Nil(t, scripts)
+}
+
+func TestConfigureProxy_FullConfiguration(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Proxy: image.Proxy{
+				HTTPProxy:  "http://10.0.0.1:3128",
+				HTTPSProxy: "http://10.0.0.1:3128",
+				NoProxy:    "localhost, 127.0.0.1, edge.suse.com",
+			},
+		},
+	}
+
+	// Test
+	scripts, err := configureProxy(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, proxyScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, proxyScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the global PROXY_ENABLED="yes" flag is set because either http/https proxy is set
+	assert.Contains(t, foundContents, "s|PROXY_ENABLED=.*|PROXY_ENABLED=\"yes\"|g", "global proxy has not been enabled")
+
+	// - Ensure that we have the HTTP_PROXY set correctly
+	assert.Contains(t, foundContents, "s|HTTP_PROXY=.*|HTTP_PROXY=\"http://10.0.0.1:3128\"|g", "HTTP_PROXY not set correctly")
+
+	// - Ensure that we have the HTTPS_PROXY set correctly
+	assert.Contains(t, foundContents, "s|HTTPS_PROXY=.*|HTTPS_PROXY=\"http://10.0.0.1:3128\"|g", "HTTPS_PROXY not set correctly")
+
+	// - Ensure that we have the NO_PROXY list overridden
+	assert.Contains(t, foundContents, "s|NO_PROXY=.*|NO_PROXY=\"localhost, 127.0.0.1, edge.suse.com\"|g", "NO_PROXY not set correctly")
+}

--- a/pkg/combustion/templates/08-proxy-setup.sh.tpl
+++ b/pkg/combustion/templates/08-proxy-setup.sh.tpl
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+{{ if or ( .HTTPProxy ) ( .HTTPSProxy ) }}
+sed -i 's|PROXY_ENABLED=.*|PROXY_ENABLED="yes"|g' /etc/sysconfig/proxy
+{{ end -}}
+
+{{ if .HTTPProxy -}}
+sed -i 's|HTTP_PROXY=.*|HTTP_PROXY="{{ .HTTPProxy }}"|g' /etc/sysconfig/proxy
+{{ end -}}
+
+{{ if .HTTPSProxy -}}
+sed -i 's|HTTPS_PROXY=.*|HTTPS_PROXY="{{ .HTTPSProxy }}"|g' /etc/sysconfig/proxy
+{{ end -}}
+
+{{ if .NoProxy -}}
+sed -i 's|NO_PROXY=.*|NO_PROXY="{{ .NoProxy }}"|g' /etc/sysconfig/proxy
+{{ end -}}
+

--- a/pkg/combustion/templates/10-rpm-install.sh.tpl
+++ b/pkg/combustion/templates/10-rpm-install.sh.tpl
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 #  Template Fields
-#  RPMs - A string that contains all of the RPMs present in the user created config directory, separated by spaces.
+#  RepoName - name of the air-gapped repository that was created by the RPM resovler
+#  PKGList  - list of packages that will be installed
 
-rpm -ivh --nosignature {{.RPMs}}
+zypper ar file:///dev/shm/combustion/config/{{.RepoName}} {{.RepoName}}
+zypper --no-gpg-checks install -r {{.RepoName}} -y --force-resolution --auto-agree-with-licenses {{.PKGList}}
+zypper rr {{.RepoName}}

--- a/pkg/combustion/templates/13-keymap-setup.sh.tpl
+++ b/pkg/combustion/templates/13-keymap-setup.sh.tpl
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "KEYMAP={{ or .Keymap "us" }}" >> /etc/vconsole.conf

--- a/pkg/image/context.go
+++ b/pkg/image/context.go
@@ -20,6 +20,14 @@ type kubernetesArtefactDownloader interface {
 	DownloadArtefacts(kubernetes Kubernetes, arch Arch, destinationPath string) (installPath, imagesPath string, err error)
 }
 
+type rpmResolver interface {
+	Resolve(packages *Packages, localPackagesPath, outputDir string) (rpmDirPath string, pkgList []string, err error)
+}
+
+type rpmRepoCreator interface {
+	Create(path string) error
+}
+
 type Context struct {
 	// ImageConfigDir is the root directory storing all configuration files.
 	ImageConfigDir string
@@ -33,4 +41,7 @@ type Context struct {
 	NetworkConfiguratorInstaller networkConfiguratorInstaller
 	KubernetesScriptInstaller    kubernetesScriptInstaller
 	KubernetesArtefactDownloader kubernetesArtefactDownloader
+	// RPMResolver responsible for resolving rpm/package dependencies
+	RPMResolver    rpmResolver
+	RPMRepoCreator rpmRepoCreator
 }

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -64,6 +64,7 @@ type OperatingSystem struct {
 	InstallDevice string                `yaml:"installDevice"`
 	Unattended    bool                  `yaml:"unattended"`
 	Time          Time                  `yaml:"time"`
+	Proxy         Proxy                 `yaml:"proxy"`
 }
 
 type Packages struct {
@@ -93,6 +94,12 @@ type Time struct {
 	Timezone      string   `yaml:"timezone"`
 	ChronyPools   []string `yaml:"chronyPools"`
 	ChronyServers []string `yaml:"chronyServers"`
+}
+
+type Proxy struct {
+	HTTPProxy  string `yaml:"httpProxy"`
+	HTTPSProxy string `yaml:"httpsProxy"`
+	NoProxy    string `yaml:"noProxy"`
 }
 
 type EmbeddedArtifactRegistry struct {

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -65,6 +65,7 @@ type OperatingSystem struct {
 	Unattended    bool                  `yaml:"unattended"`
 	Time          Time                  `yaml:"time"`
 	Proxy         Proxy                 `yaml:"proxy"`
+	Keymap        string                `yaml:"keymap"`
 }
 
 type Packages struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -105,6 +105,18 @@ func TestParse(t *testing.T) {
 	}
 	assert.Equal(t, expectedChronyServers, time.ChronyServers)
 
+	// Operating System -> Proxy -> HTTPProxy
+	httpProxy := definition.OperatingSystem.Proxy.HTTPProxy
+	assert.Equal(t, "http://10.0.0.1:3128", httpProxy)
+
+	// Operating System -> Proxy -> HTTPSProxy
+	httpsProxy := definition.OperatingSystem.Proxy.HTTPSProxy
+	assert.Equal(t, "http://10.0.0.1:3128", httpsProxy)
+
+	// Operating System -> Proxy -> NoProxy
+	noProxy := definition.OperatingSystem.Proxy.NoProxy
+	assert.Equal(t, "localhost, 127.0.0.1, edge.suse.com", noProxy)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -117,6 +117,10 @@ func TestParse(t *testing.T) {
 	noProxy := definition.OperatingSystem.Proxy.NoProxy
 	assert.Equal(t, "localhost, 127.0.0.1, edge.suse.com", noProxy)
 
+	// Operating System -> Keymap
+	keymap := definition.OperatingSystem.Keymap
+	assert.Equal(t, "us", keymap)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -92,6 +92,19 @@ func TestParse(t *testing.T) {
 	unattended := definition.OperatingSystem.Unattended
 	assert.Equal(t, true, unattended)
 
+	// Operating System -> Time
+	time := definition.OperatingSystem.Time
+	assert.Equal(t, "Europe/London", time.Timezone)
+	expectedChronyPools := []string{
+		"2.suse.pool.ntp.org",
+	}
+	assert.Equal(t, expectedChronyPools, time.ChronyPools)
+	expectedChronyServers := []string{
+		"10.0.0.1",
+		"10.0.0.2",
+	}
+	assert.Equal(t, expectedChronyServers, time.ChronyServers)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -14,6 +14,10 @@ operatingSystem:
     chronyServers:
       - 10.0.0.1
       - 10.0.0.2
+  proxy:
+    httpProxy: http://10.0.0.1:3128
+    httpsProxy: http://10.0.0.1:3128
+    noProxy: localhost, 127.0.0.1, edge.suse.com
   kernelArgs:
     - alpha=foo
     - beta=bar

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -28,6 +28,7 @@ operatingSystem:
       - enable1
     disable:
       - disable0
+  keymap: us
   users:
     - username: alpha
       encryptedPassword: $6$bZfTI3Wj05fdxQcB$W1HJQTKw/MaGTCwK75ic9putEquJvYO7vMnDBVAfuAMFW58/79abky4mx9.8znK0UZwSKng9dVosnYQR1toH71

--- a/pkg/image/validation/image.go
+++ b/pkg/image/validation/image.go
@@ -1,0 +1,85 @@
+package validation
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+const (
+	imageComponent = "image"
+)
+
+var validImageTypes = []string{image.TypeISO, image.TypeRAW}
+var validArchTypes = []string{string(image.ArchTypeARM), string(image.ArchTypeX86)}
+
+func validateImage(ctx *image.Context) []FailedValidation {
+	def := ctx.ImageDefinition
+
+	var failures []FailedValidation
+
+	if def.Image.ImageType == "" {
+		failures = append(failures, FailedValidation{
+			userMessage: "The 'imageType' field is required in the 'image' section.",
+			component:   imageComponent,
+		})
+	} else if !slices.Contains(validImageTypes, def.Image.ImageType) {
+		msg := fmt.Sprintf("The 'imageType' field must be one of: %s", strings.Join(validImageTypes, ", "))
+		failures = append(failures, FailedValidation{
+			userMessage: msg,
+			component:   imageComponent,
+		})
+	}
+
+	if def.Image.Arch == "" {
+		failures = append(failures, FailedValidation{
+			userMessage: "The 'arch' field is required in the 'image' section.",
+			component:   imageComponent,
+		})
+	} else if !slices.Contains(validArchTypes, string(def.Image.Arch)) {
+		msg := fmt.Sprintf("The 'arch' field must be one of: %s", strings.Join(validArchTypes, ", "))
+		failures = append(failures, FailedValidation{
+			userMessage: msg,
+			component:   imageComponent,
+		})
+	}
+
+	if def.Image.OutputImageName == "" {
+		failures = append(failures, FailedValidation{
+			userMessage: "The 'outputImageName' field is required in the 'image' section.",
+			component:   imageComponent,
+		})
+	}
+
+	if def.Image.BaseImage == "" {
+		failures = append(failures, FailedValidation{
+			userMessage: "The 'baseImage' field is required in the 'image' section.",
+			component:   imageComponent,
+		})
+	} else {
+		baseImageFilename := filepath.Join(ctx.ImageConfigDir, "images", def.Image.BaseImage)
+		_, err := os.Stat(baseImageFilename)
+		if err != nil {
+			if os.IsNotExist(err) {
+				msg := fmt.Sprintf("The specified base image '%s' cannot be found.", def.Image.BaseImage)
+				failures = append(failures, FailedValidation{
+					userMessage: msg,
+					component:   imageComponent,
+				})
+			} else {
+				msg := fmt.Sprintf("The specified base image '%s' cannot be read. See the logs for more information.", def.Image.BaseImage)
+				failures = append(failures, FailedValidation{
+					userMessage: msg,
+					component:   imageComponent,
+					err:         err,
+				})
+			}
+		}
+	}
+
+	return failures
+}

--- a/pkg/image/validation/image.go
+++ b/pkg/image/validation/image.go
@@ -14,11 +14,11 @@ const (
 	imageComponent = "image"
 )
 
-var validImageTypes = []string{image.TypeISO, image.TypeRAW}
-var validArchTypes = []string{string(image.ArchTypeARM), string(image.ArchTypeX86)}
-
 func validateImage(ctx *image.Context) []FailedValidation {
 	def := ctx.ImageDefinition
+
+	validImageTypes := []string{image.TypeISO, image.TypeRAW}
+	validArchTypes := []string{string(image.ArchTypeARM), string(image.ArchTypeX86)}
 
 	var failures []FailedValidation
 

--- a/pkg/image/validation/image_test.go
+++ b/pkg/image/validation/image_test.go
@@ -1,0 +1,105 @@
+package validation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestValidateImage(t *testing.T) {
+	// Setup
+	imageConfigDir, err := os.MkdirTemp("", "eib-image-tests-")
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(imageConfigDir)
+	}()
+
+	testImagesDir := filepath.Join(imageConfigDir, "images")
+	err = os.Mkdir(testImagesDir, os.ModePerm)
+	require.NoError(t, err)
+
+	testBaseImageFilename := filepath.Join(testImagesDir, "base-image.iso")
+	_, err = os.Create(testBaseImageFilename)
+	require.NoError(t, err)
+
+	// Test Cases
+	tests := map[string]struct {
+		ImageDefinition        image.Definition
+		ExpectedFailedMessages []string
+	}{
+		`complete valid definition`: {
+			ImageDefinition: image.Definition{
+				Image: image.Image{
+					ImageType:       image.TypeISO,
+					Arch:            image.ArchTypeX86,
+					BaseImage:       "base-image.iso",
+					OutputImageName: "eib-created.iso",
+				},
+			},
+		},
+		`missing all fields`: {
+			ImageDefinition: image.Definition{
+				Image: image.Image{},
+			},
+			ExpectedFailedMessages: []string{
+				"The 'imageType' field is required in the 'image' section.",
+				"The 'arch' field is required in the 'image' section.",
+				"The 'outputImageName' field is required in the 'image' section.",
+				"The 'baseImage' field is required in the 'image' section.",
+			},
+		},
+		`invalid enum values`: {
+			ImageDefinition: image.Definition{
+				Image: image.Image{
+					ImageType:       "foo",
+					Arch:            "bar",
+					BaseImage:       "base-image.iso",
+					OutputImageName: "eib-created.iso",
+				},
+			},
+			ExpectedFailedMessages: []string{
+				"The 'imageType' field must be one of: iso, raw",
+				"The 'arch' field must be one of: aarch64, x86_64",
+			},
+		},
+		`base image not found`: {
+			ImageDefinition: image.Definition{
+				Image: image.Image{
+					ImageType:       image.TypeISO,
+					Arch:            image.ArchTypeX86,
+					BaseImage:       "not-there",
+					OutputImageName: "eib-created.iso",
+				},
+			},
+			ExpectedFailedMessages: []string{
+				"The specified base image 'not-there' cannot be found.",
+			},
+		},
+	}
+
+	// Run
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			imageDef := test.ImageDefinition
+			ctx := image.Context{
+				ImageConfigDir:  imageConfigDir,
+				ImageDefinition: &imageDef,
+			}
+			failedValidations := validateImage(&ctx)
+			assert.Len(t, failedValidations, len(test.ExpectedFailedMessages))
+
+			var foundMessages []string
+			for _, foundValidation := range failedValidations {
+				foundMessages = append(foundMessages, foundValidation.userMessage)
+			}
+
+			for _, expectedMessage := range test.ExpectedFailedMessages {
+				assert.Contains(t, foundMessages, expectedMessage)
+			}
+		})
+	}
+}

--- a/pkg/image/validation/image_test.go
+++ b/pkg/image/validation/image_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestValidateImage(t *testing.T) {
-	// Setup
 	imageConfigDir, err := os.MkdirTemp("", "eib-image-tests-")
 	require.NoError(t, err)
 	defer func() {
@@ -26,7 +25,6 @@ func TestValidateImage(t *testing.T) {
 	_, err = os.Create(testBaseImageFilename)
 	require.NoError(t, err)
 
-	// Test Cases
 	tests := map[string]struct {
 		ImageDefinition        image.Definition
 		ExpectedFailedMessages []string
@@ -81,7 +79,6 @@ func TestValidateImage(t *testing.T) {
 		},
 	}
 
-	// Run
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			imageDef := test.ImageDefinition

--- a/pkg/image/validation/validation.go
+++ b/pkg/image/validation/validation.go
@@ -1,0 +1,42 @@
+package validation
+
+import (
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+type FailedValidation struct {
+	component   string
+	userMessage string
+	err         error
+}
+
+type validateComponent func(ctx *image.Context) []FailedValidation
+
+func ValidateDefinition(ctx *image.Context) []FailedValidation {
+	var failures []FailedValidation
+
+	validations := []validateComponent{
+		validateImage,
+		validateOperatingSystem,
+	}
+	for _, v := range validations {
+		componentFailures := v(ctx)
+		failures = append(failures, componentFailures...)
+	}
+
+	return failures
+}
+
+func findDuplicates(items []string) []string {
+	var duplicates []string
+
+	seen := make(map[string]bool)
+	for _, item := range items {
+		if seen[item] {
+			duplicates = append(duplicates, item)
+		}
+		seen[item] = true
+	}
+
+	return duplicates
+}

--- a/pkg/image/validation/validation.go
+++ b/pkg/image/validation/validation.go
@@ -17,7 +17,6 @@ func ValidateDefinition(ctx *image.Context) []FailedValidation {
 
 	validations := []validateComponent{
 		validateImage,
-		validateOperatingSystem,
 	}
 	for _, v := range validations {
 		componentFailures := v(ctx)

--- a/pkg/image/validation/validation.go
+++ b/pkg/image/validation/validation.go
@@ -25,17 +25,3 @@ func ValidateDefinition(ctx *image.Context) []FailedValidation {
 
 	return failures
 }
-
-func findDuplicates(items []string) []string {
-	var duplicates []string
-
-	seen := make(map[string]bool)
-	for _, item := range items {
-		if seen[item] {
-			duplicates = append(duplicates, item)
-		}
-		seen[item] = true
-	}
-
-	return duplicates
-}

--- a/pkg/kubernetes/artefact_downloader.go
+++ b/pkg/kubernetes/artefact_downloader.go
@@ -10,7 +10,6 @@ import (
 	"github.com/suse-edge/edge-image-builder/pkg/http"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 	"github.com/suse-edge/edge-image-builder/pkg/log"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -126,22 +125,14 @@ func imageArtefacts(kubernetes image.Kubernetes, arch image.Arch) ([]string, err
 }
 
 func downloadArtefacts(artefacts []string, releaseURL, version, destinationPath string) error {
-	errGroup, ctx := errgroup.WithContext(context.Background())
-
 	for _, artefact := range artefacts {
-		func(artefact string) {
-			errGroup.Go(func() error {
-				url := fmt.Sprintf(releaseURL, version, artefact)
-				path := filepath.Join(destinationPath, artefact)
+		url := fmt.Sprintf(releaseURL, version, artefact)
+		path := filepath.Join(destinationPath, artefact)
 
-				if err := http.DownloadFile(ctx, url, path); err != nil {
-					return fmt.Errorf("downloading artefact '%s': %w", artefact, err)
-				}
-
-				return nil
-			})
-		}(artefact)
+		if err := http.DownloadFile(context.Background(), url, path); err != nil {
+			return fmt.Errorf("downloading artefact '%s': %w", artefact, err)
+		}
 	}
 
-	return errGroup.Wait()
+	return nil
 }

--- a/pkg/rpm/repo.go
+++ b/pkg/rpm/repo.go
@@ -1,0 +1,53 @@
+package rpm
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"go.uber.org/zap"
+)
+
+const (
+	createRepoExec = "/usr/bin/createrepo"
+	createRepoLog  = "createrepo.log"
+)
+
+type RepoCreator struct {
+	logOut string
+}
+
+func NewRepoCreator(logOut string) *RepoCreator {
+	return &RepoCreator{
+		logOut: logOut,
+	}
+}
+
+func (r *RepoCreator) Create(path string) error {
+	zap.S().Infof("Creating RPM repository from '%s'", path)
+
+	logFile, err := os.Create(filepath.Join(r.logOut, createRepoLog))
+	if err != nil {
+		return fmt.Errorf("generating createrepo log file: %w", err)
+	}
+	defer logFile.Close()
+
+	cmd := prepareRepoCommand(path, logFile)
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error running createrepo: %w", err)
+	}
+
+	zap.L().Info("RPM repository created successfully")
+	return nil
+}
+
+func prepareRepoCommand(path string, w io.Writer) *exec.Cmd {
+	cmd := exec.Command(createRepoExec, path)
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	return cmd
+}

--- a/pkg/rpm/resolver/base.go
+++ b/pkg/rpm/resolver/base.go
@@ -1,0 +1,122 @@
+package resolver
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+	"go.uber.org/zap"
+)
+
+const (
+	prepareBaseScriptName = "prepare-base.sh"
+	prepareBaseScriptLog  = "prepare-base.log"
+	baseImageArchiveName  = "sle-micro-base.tar.gz"
+	baseImageRef          = "slemicro"
+)
+
+//go:embed templates/prepare-base.sh.tpl
+var prepareBaseTemplate string
+
+func (r *Resolver) buildBase() error {
+	zap.L().Info("Building base resolver image...")
+
+	defer os.RemoveAll(r.getBaseImgDir())
+	if err := r.prepareBase(); err != nil {
+		return fmt.Errorf("preparing base image env: %w", err)
+	}
+
+	if err := r.writeBaseImageScript(); err != nil {
+		return fmt.Errorf("writing base resolver image script: %w", err)
+	}
+
+	if err := r.runBaseImageScript(); err != nil {
+		return fmt.Errorf("running base resolver image script: %w", err)
+	}
+
+	tarballPath := filepath.Join(r.getBaseImgDir(), baseImageArchiveName)
+	if err := r.podman.Import(tarballPath, baseImageRef); err != nil {
+		return fmt.Errorf("importing the base image: %w", err)
+	}
+
+	zap.L().Info("Base resolver image build successful")
+	return nil
+}
+
+func (r *Resolver) prepareBase() error {
+	baseImgDir := r.getBaseImgDir()
+	if err := os.MkdirAll(baseImgDir, os.ModePerm); err != nil {
+		return fmt.Errorf("creating %s dir: %w", baseImgDir, err)
+	}
+
+	// copy user provided image so that the resolver can
+	// safely work on the copy without worrying that it might
+	// break other EIB functionality
+	if err := fileio.CopyFile(r.imgPath, r.getBaseISOCopyPath(), fileio.NonExecutablePerms); err != nil {
+		return fmt.Errorf("creating work copy of image %s in repo work dir %s: %w", r.imgPath, baseImgDir, err)
+	}
+
+	return nil
+}
+
+func (r *Resolver) runBaseImageScript() error {
+	logFile, err := os.Create(filepath.Join(r.dir, prepareBaseScriptLog))
+	if err != nil {
+		return fmt.Errorf("generating prepare base image log file: %w", err)
+	}
+	defer logFile.Close()
+
+	cmd := r.prepareBaseImageCmd(logFile)
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("run script failure: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Resolver) prepareBaseImageCmd(log io.Writer) *exec.Cmd {
+	scriptPath := filepath.Join(r.dir, prepareBaseScriptName)
+	cmd := exec.Command(scriptPath)
+	cmd.Stdout = log
+	cmd.Stderr = log
+	return cmd
+}
+
+func (r *Resolver) writeBaseImageScript() error {
+	values := struct {
+		WorkDir     string
+		ImgPath     string
+		ArchiveName string
+		ImgType     string
+	}{
+		WorkDir:     r.getBaseImgDir(),
+		ImgPath:     r.getBaseISOCopyPath(),
+		ArchiveName: baseImageArchiveName,
+		ImgType:     r.imgType,
+	}
+
+	data, err := template.Parse(prepareBaseScriptName, prepareBaseTemplate, &values)
+	if err != nil {
+		return fmt.Errorf("parsing %s template: %w", prepareBaseScriptName, err)
+	}
+
+	filename := filepath.Join(r.dir, prepareBaseScriptName)
+	if err = os.WriteFile(filename, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing script %s: %w", filename, err)
+	}
+
+	return nil
+}
+
+func (r *Resolver) getBaseImgDir() string {
+	return filepath.Join(r.dir, "resolver-base-image")
+}
+
+func (r *Resolver) getBaseISOCopyPath() string {
+	return filepath.Join(r.getBaseImgDir(), filepath.Base(r.imgPath))
+}

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -1,0 +1,213 @@
+package resolver
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/rpm"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+	"go.uber.org/zap"
+)
+
+const (
+	resolverImageRef = "pkg-resolver"
+	dockerfileName   = "Dockerfile"
+	rpmRepoName      = "rpm-repo"
+)
+
+//go:embed templates/Dockerfile.tpl
+var dockerfileTemplate string
+
+type Podman interface {
+	Import(tarball, ref string) error
+	Build(context, name string) error
+	Create(img string) (string, error)
+	Copy(id, src, dest string) error
+}
+
+type Resolver struct {
+	// dir from where the resolver will work
+	dir string
+	// path to the image that the resolver will use as base
+	imgPath string
+	// type of the image that will be used as base (either ISO or RAW)
+	imgType string
+	// podman client which to use for container management tasks
+	podman Podman
+	// helper property, contains the names of the rpms that have been taken from the customRPMDir
+	rpms []string
+}
+
+func New(workDir, imgPath, imgType string, podman Podman) *Resolver {
+	return &Resolver{
+		dir:     workDir,
+		imgPath: imgPath,
+		imgType: imgType,
+		podman:  podman,
+	}
+}
+
+// Resolve resolves all dependencies for the provided pacakges and rpms. It then outputs the set of resolved rpms to a
+// directory (located in the provdied 'outputDir') from which an RPM repository can be created.
+//
+// Returns the full path to the created directory, the package/rpm names for which dependency resolution has been done, or an error if one has occurred.
+//
+// Parameters:
+// - packages - pacakge configuration
+//
+// - localPackagesPath - path to a directory containing local rpm packages. Will not be considered if left empty.
+//
+// - outputDir - directory in which the resolver will create a directory containing the resolved rpms.
+func (r *Resolver) Resolve(packages *image.Packages, localPackagesPath, outputDir string) (rpmDirPath string, pkgList []string, err error) {
+	zap.L().Info("Resolving package dependencies...")
+
+	if err = r.buildBase(); err != nil {
+		return "", nil, fmt.Errorf("building base resolver image: %w", err)
+	}
+
+	if err = r.prepare(localPackagesPath, packages); err != nil {
+		return "", nil, fmt.Errorf("generating context for the resolver image: %w", err)
+	}
+
+	if err = r.podman.Build(r.generateBuildContextPath(), resolverImageRef); err != nil {
+		return "", nil, fmt.Errorf("building resolver image: %w", err)
+	}
+
+	id, err := r.podman.Create(resolverImageRef)
+	if err != nil {
+		return "", nil, fmt.Errorf("run container from resolver image %s: %w", resolverImageRef, err)
+	}
+
+	err = r.podman.Copy(id, r.generateRPMRepoPath(), outputDir)
+	if err != nil {
+		return "", nil, fmt.Errorf("copying resolved package cache to %s: %w", outputDir, err)
+	}
+
+	// rpmRepoName is the name of the directory to which all packages/rpms have been resovled to.
+	// Since we are copying a directory inside of the 'outputDir', we concatenate the path in order
+	// to return the correct path.
+	return filepath.Join(outputDir, rpmRepoName), r.getPKGInstallList(packages), nil
+}
+
+func (r *Resolver) prepare(localPackagesPath string, packages *image.Packages) error {
+	zap.L().Info("Preparing resolver image context...")
+
+	buildContext := r.generateBuildContextPath()
+	if err := os.MkdirAll(buildContext, os.ModePerm); err != nil {
+		return fmt.Errorf("creating build context dir %s: %w", buildContext, err)
+	}
+
+	if localPackagesPath != "" {
+		dest := r.generateRPMPathInBuildContext()
+		if err := os.MkdirAll(dest, os.ModePerm); err != nil {
+			return fmt.Errorf("creating rpm directory in resolver dir: %w", err)
+		}
+
+		rpmNames, err := rpm.CopyRPMs(localPackagesPath, dest)
+		if err != nil {
+			return fmt.Errorf("copying local rpms to %s: %w", dest, err)
+		}
+		r.rpms = rpmNames
+	}
+
+	if err := r.writeDockerfile(localPackagesPath, packages); err != nil {
+		return fmt.Errorf("writing dockerfile: %w", err)
+	}
+
+	zap.L().Info("Resolver image context setup successful")
+	return nil
+}
+
+func (r *Resolver) writeDockerfile(localPackagesPath string, packages *image.Packages) error {
+	values := struct {
+		BaseImage   string
+		RegCode     string
+		AddRepo     string
+		CacheDir    string
+		PkgList     string
+		FromRPMPath string
+		ToRPMPath   string
+	}{
+		BaseImage: baseImageRef,
+		RegCode:   packages.RegCode,
+		AddRepo:   strings.Join(packages.AdditionalRepos, " "),
+		CacheDir:  r.generateRPMRepoPath(),
+		PkgList:   strings.Join(r.getPKGForResolve(packages), " "),
+	}
+
+	if localPackagesPath != "" {
+		values.FromRPMPath = filepath.Base(r.generateRPMPathInBuildContext())
+		values.ToRPMPath = r.generateLocalRPMDirPath()
+	}
+
+	data, err := template.Parse(dockerfileName, dockerfileTemplate, &values)
+	if err != nil {
+		return fmt.Errorf("parsing %s template: %w", dockerfileName, err)
+	}
+
+	filename := filepath.Join(r.generateBuildContextPath(), dockerfileName)
+	if err = os.WriteFile(filename, []byte(data), fileio.NonExecutablePerms); err != nil {
+		return fmt.Errorf("writing prepare base image script %s: %w", filename, err)
+	}
+
+	return nil
+}
+
+func (r *Resolver) getPKGForResolve(packages *image.Packages) []string {
+	list := []string{}
+
+	if len(packages.PKGList) > 0 {
+		list = append(list, packages.PKGList...)
+	}
+
+	if len(r.rpms) > 0 {
+		// generate RPM paths as seen in the resolver image,
+		// needed so that 'zypper install' can locate the rpms
+		for _, name := range r.rpms {
+			list = append(list, filepath.Join(r.generateLocalRPMDirPath(), name))
+		}
+	}
+	return list
+}
+
+func (r *Resolver) getPKGInstallList(packages *image.Packages) []string {
+	list := []string{}
+
+	if len(packages.PKGList) > 0 {
+		list = append(list, packages.PKGList...)
+	}
+
+	if len(r.rpms) > 0 {
+		// generate the RPMs as package names,
+		// so that zypper can locate them in the RPM repository
+		for _, name := range r.rpms {
+			list = append(list, strings.TrimSuffix(name, filepath.Ext(name)))
+		}
+	}
+	return list
+}
+
+// path to the build dir, as seen in the EIB image
+func (r *Resolver) generateBuildContextPath() string {
+	return filepath.Join(r.dir, "resolver-image-build")
+}
+
+// path to the rpms directory in the resolver build context, as seen in the EIB image
+func (r *Resolver) generateRPMPathInBuildContext() string {
+	return filepath.Join(r.generateBuildContextPath(), "rpms")
+}
+
+// path to rpm cache dir, as seen in the resolver image
+func (r *Resolver) generateRPMRepoPath() string {
+	return filepath.Join(os.TempDir(), rpmRepoName)
+}
+
+// path to the dir containing local rpms, as seen in the resolver image
+func (r *Resolver) generateLocalRPMDirPath() string {
+	return filepath.Join(r.generateRPMRepoPath(), "local")
+}

--- a/pkg/rpm/resolver/templates/Dockerfile.tpl
+++ b/pkg/rpm/resolver/templates/Dockerfile.tpl
@@ -1,0 +1,46 @@
+#  Template Fields
+#  BaseImage   - image to use as base for the build of this image
+#  FromRPMPath - path to the custom RPM directory relative to the resolver image build context in the EIB container
+#  ToRPMPath   - path to the custom RPM directory relative to the resolver image
+#  RegCode     - scc.suse.com registration code
+#  AddRepo     - additional third-party repositories that will be used in the resolution process
+#  CacheDir    - zypper cache directory where all rpm dependencies will be downloaded to
+#  PkgList     - list of packages for which to do the dependency resolution
+FROM {{.BaseImage}}
+
+{{ if and (ne .FromRPMPath "") (ne .ToRPMPath "") -}}
+COPY {{ .FromRPMPath }} {{ .ToRPMPath -}}
+{{ end }}
+
+{{ if ne .RegCode "" -}}
+RUN suseconnect -r {{.RegCode}}
+RUN SLE_SP=$(cat /etc/rpm/macros.sle | awk '/sle/ {print $2};' | cut -c4) && suseconnect -p PackageHub/15.$SLE_SP/x86_64
+RUN zypper ref
+{{ end }}
+
+{{ if ne .AddRepo "" -}}
+RUN counter=1 && \
+    for i in {{.AddRepo}}; \
+    do \
+      zypper ar --no-gpgcheck -f $i addrepo$counter; \
+      counter=$((counter+1)); \
+    done
+{{ end }}
+
+RUN zypper \
+    --pkg-cache-dir {{.CacheDir}} \ 
+    --no-gpg-checks \
+    install -y \
+    --download-only \
+    --force-resolution \
+    --auto-agree-with-licenses \
+    --allow-vendor-change \
+    -n {{.PkgList}}
+
+RUN touch {{.CacheDir}}/zypper-success
+
+{{ if ne .RegCode "" -}}
+RUN suseconnect -d
+{{ end }}
+
+CMD ["/bin/bash"]

--- a/pkg/rpm/resolver/templates/prepare-base.sh.tpl
+++ b/pkg/rpm/resolver/templates/prepare-base.sh.tpl
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+#  Template Fields
+#  WorkDir     - directory from where this script will be running
+#  ImgPath     - path to the image that will be prepared
+#  ImgType     - type of the image (either .iso, or .raw)
+#  ArchiveName - name of the virtual disk archive that will be created from this image
+
+WORK_DIR={{.WorkDir}}
+IMG_PATH={{.ImgPath}}
+
+{{ if eq .ImgType "iso" -}}
+xorriso -osirrox on -indev $IMG_PATH extract / $WORK_DIR/iso-root/
+
+ISO_ROOT=$WORK_DIR/iso-root
+cd $ISO_ROOT
+
+ISO_SQUASHFS=`find $ISO_ROOT -name "*.squashfs"`
+if [ `wc -w <<< $ISO_SQUASHFS` -ne 1 ]; then
+	echo "Unexpected number of '.squashfs' files: $ISO_SQUASHFS"
+	exit 1
+fi
+
+UNSQUASHFS_DIR=$ISO_ROOT/squashfs-root
+unsquashfs -d $UNSQUASHFS_DIR $ISO_SQUASHFS
+
+cd $UNSQUASHFS_DIR
+
+RAW_FILE=`find $UNSQUASHFS_DIR -name "*.raw"`
+if [ `wc -w <<< $RAW_FILE` -ne 1 ]; then
+	echo "Unexpected number of '.raw' files: $RAW_FILE"
+	exit 1
+fi
+
+virt-tar-out -a $RAW_FILE / - | gzip --best > $WORK_DIR/{{.ArchiveName}}
+{{ else }}
+virt-tar-out -a $IMG_PATH / - | gzip --best > $WORK_DIR/{{.ArchiveName}}
+{{ end }}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -1,0 +1,43 @@
+package rpm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"go.uber.org/zap"
+)
+
+// CopyRPMs copies all ".rpm" files from src to dest and returns
+// a list of the copied ".rpm" base filenames
+func CopyRPMs(src string, dest string) ([]string, error) {
+	if dest == "" {
+		return nil, fmt.Errorf("RPM destination directory cannot be empty")
+	}
+
+	list := []string{}
+
+	rpms, err := os.ReadDir(src)
+	if err != nil {
+		return nil, fmt.Errorf("reading RPM source dir: %w", err)
+	}
+
+	for _, rpm := range rpms {
+		if filepath.Ext(rpm.Name()) != ".rpm" {
+			zap.S().Warnf("Skipping %s as it is not a rpm file", rpm.Name())
+			continue
+		}
+
+		sourcePath := filepath.Join(src, rpm.Name())
+		destPath := filepath.Join(dest, rpm.Name())
+		err := fileio.CopyFile(sourcePath, destPath, fileio.NonExecutablePerms)
+		if err != nil {
+			return nil, fmt.Errorf("copying file %s: %w", sourcePath, err)
+		}
+		list = append(list, rpm.Name())
+
+	}
+
+	return list, nil
+}

--- a/pkg/rpm/rpm_test.go
+++ b/pkg/rpm/rpm_test.go
@@ -1,0 +1,79 @@
+package rpm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRPMSourceDir(t *testing.T) (dirPath string, teardown func()) {
+	dirPath = filepath.Join(os.TempDir(), "rpms")
+	require.NoError(t, os.Mkdir(dirPath, 0o755))
+
+	file1, err := os.Create(filepath.Join(dirPath, "rpm1.rpm"))
+	require.NoError(t, err)
+
+	file2, err := os.Create(filepath.Join(dirPath, "rpm2.rpm"))
+	require.NoError(t, err)
+
+	return dirPath, func() {
+		assert.NoError(t, file1.Close())
+		assert.NoError(t, file2.Close())
+		assert.NoError(t, os.RemoveAll(dirPath))
+	}
+}
+
+func TestCopyRPMs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "copy-location")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	rpmSourceDir, teardown := setupRPMSourceDir(t)
+	defer teardown()
+
+	rpmFileNames, err := CopyRPMs(rpmSourceDir, tmpDir)
+
+	require.NoError(t, err)
+
+	require.Len(t, rpmFileNames, 2)
+	assert.Contains(t, rpmFileNames, "rpm1.rpm")
+	assert.Contains(t, rpmFileNames, "rpm2.rpm")
+
+	_, err = os.Stat(filepath.Join(tmpDir, "rpm1.rpm"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(tmpDir, "rpm2.rpm"))
+	require.NoError(t, err)
+}
+
+func TestCopyRPMsNoRPMs(t *testing.T) {
+	fromTempDir, err := os.MkdirTemp("", "from-location")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(fromTempDir))
+	}()
+
+	toTempDir, err := os.MkdirTemp("", "to-location")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(toTempDir))
+	}()
+
+	// pass the same dir, to simulate a missing
+	rpmFileNames, err := CopyRPMs(fromTempDir, toTempDir)
+
+	require.NoError(t, err)
+	assert.Empty(t, rpmFileNames)
+}
+
+func TestCopyRPMsNoRPMSrcDir(t *testing.T) {
+	_, err := CopyRPMs("", "/foo/bar")
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "reading RPM source dir")
+}


### PR DESCRIPTION
This is currently not in use; the existing validation is still what is run.

This isn't complete. I'm not sure we'll keep error and/or component in `FailedValidation`. I'll make that call once I port the rest over and see what it looks like when I replace the existing call. But I wanted to submit the PRs in shorter pieces to make the actual review process less painful.