### PR TITLE
Adding support for setting the system-wide proxy servers

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -46,6 +46,10 @@ operatingSystem:
     chronyServers:
       - 10.0.0.1
       - 10.0.0.2
+  proxy:
+    httpProxy: http://10.0.0.1:3128
+    httpsProxy: http://10.0.0.1:3128
+    noProxy: localhost, 127.0.0.1, edge.suse.com
   kernelArgs:
   - arg1
   - arg2
@@ -72,11 +76,16 @@ operatingSystem:
   system rather than prompting user to begin the installation. In combination with `installDevice` can create
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
   If left omitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
-* `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `time` - Optional; section where the user can provide timezone information and Chronyd configuration.
   * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`.
   * `chronyPools` - Optional; a list of pools that Chrony can use as data sources.
   * `chronyServers` - Optional; a list of servers that Chrony can use as data sources.
+* `proxy` - Optional; section where the user can provide system-wide proxy information
+  * `httpProxy` - Optional; set the system-wide http proxy settings
+  * `httpsProxy` - Optional; set the system-wide https proxy settings
+  * `noProxy` - Optional; override the default `NO_PROXY` list. By default this is "localhost, 127.0.0.1" if parameter is omitted, but
+  if you set this flag, make sure you add these into your list if they're required.
+* `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:
   * `username` - Required; Username of the user to create. To set the password or SSH key for the root user,

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -57,6 +57,10 @@ func Configure(ctx *image.Context) error {
 			runnable: configureUsers,
 		},
 		{
+			name:     proxyComponentName,
+			runnable: configureProxy,
+		},
+		{
 			name:     rpmComponentName,
 			runnable: configureRPMs,
 		},

--- a/pkg/combustion/proxy.go
+++ b/pkg/combustion/proxy.go
@@ -22,7 +22,7 @@ var proxyScript string
 
 func configureProxy(ctx *image.Context) ([]string, error) {
 	proxy := ctx.ImageDefinition.OperatingSystem.Proxy
-	if proxy.HttpProxy == "" && proxy.HttpsProxy == "" {
+	if proxy.HTTPProxy == "" && proxy.HTTPSProxy == "" {
 		log.AuditComponentSkipped(proxyComponentName)
 		return nil, nil
 	}

--- a/pkg/combustion/proxy.go
+++ b/pkg/combustion/proxy.go
@@ -1,0 +1,51 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+)
+
+const (
+	proxyComponentName = "proxy"
+	proxyScriptName    = "08-proxy-setup.sh"
+)
+
+//go:embed templates/08-proxy-setup.sh.tpl
+var proxyScript string
+
+func configureProxy(ctx *image.Context) ([]string, error) {
+	proxy := ctx.ImageDefinition.OperatingSystem.Proxy
+	if proxy.HttpProxy == "" && proxy.HttpsProxy == "" {
+		log.AuditComponentSkipped(proxyComponentName)
+		return nil, nil
+	}
+
+	if err := writeProxyCombustionScript(ctx); err != nil {
+		log.AuditComponentFailed(proxyComponentName)
+		return nil, err
+	}
+
+	log.AuditComponentSuccessful(proxyComponentName)
+	return []string{proxyScriptName}, nil
+}
+
+func writeProxyCombustionScript(ctx *image.Context) error {
+	proxyScriptFilename := filepath.Join(ctx.CombustionDir, proxyScriptName)
+
+	data, err := template.Parse(proxyScriptName, proxyScript, ctx.ImageDefinition.OperatingSystem.Proxy)
+	if err != nil {
+		return fmt.Errorf("applying template to %s: %w", proxyScriptName, err)
+	}
+
+	if err := os.WriteFile(proxyScriptFilename, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing file %s: %w", proxyScriptFilename, err)
+	}
+	return nil
+}

--- a/pkg/combustion/proxy_test.go
+++ b/pkg/combustion/proxy_test.go
@@ -1,0 +1,77 @@
+package combustion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestConfigureProxy_NoConf(t *testing.T) {
+	// Setup
+	var ctx image.Context
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Proxy: image.Proxy{},
+		},
+	}
+
+	// Test
+	scripts, err := configureProxy(&ctx)
+
+	// Verify
+	require.NoError(t, err)
+	assert.Nil(t, scripts)
+}
+
+func TestConfigureProxy_FullConfiguration(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Proxy: image.Proxy{
+				HttpProxy:  "http://10.0.0.1:3128",
+				HttpsProxy: "http://10.0.0.1:3128",
+				NoProxy:    "localhost, 127.0.0.1, edge.suse.com",
+			},
+		},
+	}
+
+	// Test
+	scripts, err := configureProxy(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, proxyScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, proxyScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the global PROXY_ENABLED="yes" flag is set because either http/https proxy is set
+	assert.Contains(t, foundContents, "s/PROXY_ENABLED=.*/PROXY_ENABLED=\"yes\"/g", "global proxy has not been enabled")
+
+	// - Ensure that we have the HTTP_PROXY set correctly
+	assert.Contains(t, foundContents, "s/HTTP_PROXY=.*/HTTP_PROXY=\"http://10.0.0.1:3128\"/g", "HTTP_PROXY not set correctly")
+
+	// - Ensure that we have the HTTPS_PROXY set correctly
+	assert.Contains(t, foundContents, "s/HTTPS_PROXY=.*/HTTPS_PROXY=\"http://10.0.0.1:3128\"/g", "HTTPS_PROXY not set correctly")
+
+	// - Ensure that we have the NO_PROXY list overridden
+	assert.Contains(t, foundContents, "s/NO_PROXY=.*/NO_PROXY=\"localhost, 127.0.0.1, edge.suse.com\"/g", "NO_PROXY not set correctly")
+}

--- a/pkg/combustion/proxy_test.go
+++ b/pkg/combustion/proxy_test.go
@@ -37,8 +37,8 @@ func TestConfigureProxy_FullConfiguration(t *testing.T) {
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
 			Proxy: image.Proxy{
-				HttpProxy:  "http://10.0.0.1:3128",
-				HttpsProxy: "http://10.0.0.1:3128",
+				HTTPProxy:  "http://10.0.0.1:3128",
+				HTTPSProxy: "http://10.0.0.1:3128",
 				NoProxy:    "localhost, 127.0.0.1, edge.suse.com",
 			},
 		},

--- a/pkg/combustion/proxy_test.go
+++ b/pkg/combustion/proxy_test.go
@@ -64,14 +64,14 @@ func TestConfigureProxy_FullConfiguration(t *testing.T) {
 	foundContents := string(foundBytes)
 
 	// - Make sure that the global PROXY_ENABLED="yes" flag is set because either http/https proxy is set
-	assert.Contains(t, foundContents, "s/PROXY_ENABLED=.*/PROXY_ENABLED=\"yes\"/g", "global proxy has not been enabled")
+	assert.Contains(t, foundContents, "s|PROXY_ENABLED=.*|PROXY_ENABLED=\"yes\"|g", "global proxy has not been enabled")
 
 	// - Ensure that we have the HTTP_PROXY set correctly
-	assert.Contains(t, foundContents, "s/HTTP_PROXY=.*/HTTP_PROXY=\"http://10.0.0.1:3128\"/g", "HTTP_PROXY not set correctly")
+	assert.Contains(t, foundContents, "s|HTTP_PROXY=.*|HTTP_PROXY=\"http://10.0.0.1:3128\"|g", "HTTP_PROXY not set correctly")
 
 	// - Ensure that we have the HTTPS_PROXY set correctly
-	assert.Contains(t, foundContents, "s/HTTPS_PROXY=.*/HTTPS_PROXY=\"http://10.0.0.1:3128\"/g", "HTTPS_PROXY not set correctly")
+	assert.Contains(t, foundContents, "s|HTTPS_PROXY=.*|HTTPS_PROXY=\"http://10.0.0.1:3128\"|g", "HTTPS_PROXY not set correctly")
 
 	// - Ensure that we have the NO_PROXY list overridden
-	assert.Contains(t, foundContents, "s/NO_PROXY=.*/NO_PROXY=\"localhost, 127.0.0.1, edge.suse.com\"/g", "NO_PROXY not set correctly")
+	assert.Contains(t, foundContents, "s|NO_PROXY=.*|NO_PROXY=\"localhost, 127.0.0.1, edge.suse.com\"|g", "NO_PROXY not set correctly")
 }

--- a/pkg/combustion/templates/08-proxy-setup.sh.tpl
+++ b/pkg/combustion/templates/08-proxy-setup.sh.tpl
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+{{ if or ( .HttpProxy ) ( .HttpsProxy ) }}
+sed -i 's|PROXY_ENABLED=.*|PROXY_ENABLED="yes"|g' /etc/sysconfig/proxy
+{{ end -}}
+
+{{ if .HttpProxy -}}
+sed -i 's|HTTP_PROXY=.*|HTTP_PROXY="{{ .HttpProxy }}"|g' /etc/sysconfig/proxy
+{{ end -}}
+
+{{ if .HttpsProxy -}}
+sed -i 's|HTTPS_PROXY=.*|HTTPS_PROXY="{{ .HttpsProxy }}"|g' /etc/sysconfig/proxy
+{{ end -}}
+
+{{ if .NoProxy -}}
+sed -i 's|NO_PROXY=.*|NO_PROXY="{{ .NoProxy }}"|g' /etc/sysconfig/proxy
+{{ end -}}
+

--- a/pkg/combustion/templates/08-proxy-setup.sh.tpl
+++ b/pkg/combustion/templates/08-proxy-setup.sh.tpl
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-{{ if or ( .HttpProxy ) ( .HttpsProxy ) }}
+{{ if or ( .HTTPProxy ) ( .HTTPSProxy ) }}
 sed -i 's|PROXY_ENABLED=.*|PROXY_ENABLED="yes"|g' /etc/sysconfig/proxy
 {{ end -}}
 
-{{ if .HttpProxy -}}
-sed -i 's|HTTP_PROXY=.*|HTTP_PROXY="{{ .HttpProxy }}"|g' /etc/sysconfig/proxy
+{{ if .HTTPProxy -}}
+sed -i 's|HTTP_PROXY=.*|HTTP_PROXY="{{ .HTTPProxy }}"|g' /etc/sysconfig/proxy
 {{ end -}}
 
-{{ if .HttpsProxy -}}
-sed -i 's|HTTPS_PROXY=.*|HTTPS_PROXY="{{ .HttpsProxy }}"|g' /etc/sysconfig/proxy
+{{ if .HTTPSProxy -}}
+sed -i 's|HTTPS_PROXY=.*|HTTPS_PROXY="{{ .HTTPSProxy }}"|g' /etc/sysconfig/proxy
 {{ end -}}
 
 {{ if .NoProxy -}}

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -97,8 +97,8 @@ type Time struct {
 }
 
 type Proxy struct {
-	HttpProxy  string `yaml:"httpProxy"`
-	HttpsProxy string `yaml:"httpsProxy"`
+	HTTPProxy  string `yaml:"httpProxy"`
+	HTTPSProxy string `yaml:"httpsProxy"`
 	NoProxy    string `yaml:"noProxy"`
 }
 

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -64,6 +64,7 @@ type OperatingSystem struct {
 	InstallDevice string                `yaml:"installDevice"`
 	Unattended    bool                  `yaml:"unattended"`
 	Time          Time                  `yaml:"time"`
+	Proxy         Proxy                 `yaml:"proxy"`
 }
 
 type Packages struct {
@@ -93,6 +94,12 @@ type Time struct {
 	Timezone      string   `yaml:"timezone"`
 	ChronyPools   []string `yaml:"chronyPools"`
 	ChronyServers []string `yaml:"chronyServers"`
+}
+
+type Proxy struct {
+	HttpProxy  string `yaml:"httpProxy"`
+	HttpsProxy string `yaml:"httpsProxy"`
+	NoProxy    string `yaml:"noProxy"`
 }
 
 type EmbeddedArtifactRegistry struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -105,12 +105,12 @@ func TestParse(t *testing.T) {
 	}
 	assert.Equal(t, expectedChronyServers, time.ChronyServers)
 
-	// Operating System -> Proxy -> HttpProxy
-	httpProxy := definition.OperatingSystem.Proxy.HttpProxy
+	// Operating System -> Proxy -> HTTPProxy
+	httpProxy := definition.OperatingSystem.Proxy.HTTPProxy
 	assert.Equal(t, "http://10.0.0.1:3128", httpProxy)
 
-	// Operating System -> Proxy -> HttpsProxy
-	httpsProxy := definition.OperatingSystem.Proxy.HttpsProxy
+	// Operating System -> Proxy -> HTTPSProxy
+	httpsProxy := definition.OperatingSystem.Proxy.HTTPSProxy
 	assert.Equal(t, "http://10.0.0.1:3128", httpsProxy)
 
 	// Operating System -> Proxy -> NoProxy

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -105,6 +105,18 @@ func TestParse(t *testing.T) {
 	}
 	assert.Equal(t, expectedChronyServers, time.ChronyServers)
 
+	// Operating System -> Proxy -> HttpProxy
+	httpProxy := definition.OperatingSystem.Proxy.HttpProxy
+	assert.Equal(t, "http://10.0.0.1:3128", httpProxy)
+
+	// Operating System -> Proxy -> HttpsProxy
+	httpsProxy := definition.OperatingSystem.Proxy.HttpsProxy
+	assert.Equal(t, "http://10.0.0.1:3128", httpsProxy)
+
+	// Operating System -> Proxy -> NoProxy
+	noProxy := definition.OperatingSystem.Proxy.NoProxy
+	assert.Equal(t, "localhost, 127.0.0.1, edge.suse.com", noProxy)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -14,6 +14,10 @@ operatingSystem:
     chronyServers:
       - 10.0.0.1
       - 10.0.0.2
+  proxy:
+    httpProxy: http://10.0.0.1:3128
+    httpsProxy: http://10.0.0.1:3128
+    noProxy: localhost, 127.0.0.1, edge.suse.com
   kernelArgs:
     - alpha=foo
     - beta=bar


### PR DESCRIPTION
This PR adds support for setting the system-wide proxy servers. It takes care of the following in `/etc/sysconfig/proxy`:

1. If either `httpProxy` or `httpsProxy` are set, it forces `PROXY_ENABLED="yes"`
2. If `httpProxy` is set, it will setup `HTTP_PROXY="<httpProxy>"`
3. If `httpsProxy` is set, it will setup `HTTPS_PROXY="<httpsProxy>"`
4. If `noProxy` is set, it will setup `NO_PROXY="<noProxy>"` (if left omitted it will leave default, `localhost, 127.0.0.1`).

This was tested via Squid and works exactly as required. This likely needs to be setup very early in the boot-up procedure as many items may require proxy.
