### PR TITLE
Adding support for setting the system keymap

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -98,8 +98,8 @@ operatingSystem:
   be included; if neither are provided, this section is ignored.
   * `enable` - Optional; List of systemd services to enable.
   * `disable` - Optional; List of systemd services to disable.
-* `keymap` - Optional; sets the virtual console (VC) keymap, full list via `localectl list-keymaps`. It's not critical to set
-  a keymap as the default is `us`, but if this is left unset, you may see console warnings about a keymap not being set.
+* `keymap` - Optional; sets the virtual console (VC) keymap, full list via `localectl list-keymaps`. If unset, we default to
+  `us`.
 
 ## SUSE Manager (SUMA)
 

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -67,6 +67,7 @@ operatingSystem:
       - service1
     disable:
       - serviceX
+  keymap: us
 ```
 
 * `installDevice` - Optional; only for ISO images - specifies the disk that should be used as the install
@@ -97,6 +98,7 @@ operatingSystem:
   be included; if neither are provided, this section is ignored.
   * `enable` - Optional; List of systemd services to enable.
   * `disable` - Optional; List of systemd services to disable.
+* `keymap` - Optional; sets the virtual console (VC) keymap, full list via `localectl list-keymaps`
 
 ## SUSE Manager (SUMA)
 

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -98,7 +98,8 @@ operatingSystem:
   be included; if neither are provided, this section is ignored.
   * `enable` - Optional; List of systemd services to enable.
   * `disable` - Optional; List of systemd services to disable.
-* `keymap` - Optional; sets the virtual console (VC) keymap, full list via `localectl list-keymaps`
+* `keymap` - Optional; sets the virtual console (VC) keymap, full list via `localectl list-keymaps`. It's not critical to set
+  a keymap as the default is `us`, but if this is left unset, you may see console warnings about a keymap not being set.
 
 ## SUSE Manager (SUMA)
 

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -76,6 +76,10 @@ func Configure(ctx *image.Context) error {
 			name:     sumaComponentName,
 			runnable: configureSuma,
 		},
+		{
+			name:     keymapComponentName,
+			runnable: configureKeymap,
+		},
 	}
 
 	for _, component := range combustionComponents {

--- a/pkg/combustion/keymap.go
+++ b/pkg/combustion/keymap.go
@@ -21,12 +21,6 @@ const (
 var keymapScript string
 
 func configureKeymap(ctx *image.Context) ([]string, error) {
-	keymap := ctx.ImageDefinition.OperatingSystem.Keymap
-	if keymap == "" {
-		log.AuditComponentSkipped(keymapComponentName)
-		return nil, nil
-	}
-
 	if err := writeKeymapCombustionScript(ctx); err != nil {
 		log.AuditComponentFailed(keymapComponentName)
 		return nil, err

--- a/pkg/combustion/keymap.go
+++ b/pkg/combustion/keymap.go
@@ -1,0 +1,51 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"github.com/suse-edge/edge-image-builder/pkg/template"
+)
+
+const (
+	keymapComponentName = "keymap"
+	keymapScriptName    = "13-keymap-setup.sh"
+)
+
+//go:embed templates/13-keymap-setup.sh.tpl
+var keymapScript string
+
+func configureKeymap(ctx *image.Context) ([]string, error) {
+	keymap := ctx.ImageDefinition.OperatingSystem.Keymap
+	if keymap == "" {
+		log.AuditComponentSkipped(keymapComponentName)
+		return nil, nil
+	}
+
+	if err := writeKeymapCombustionScript(ctx); err != nil {
+		log.AuditComponentFailed(keymapComponentName)
+		return nil, err
+	}
+
+	log.AuditComponentSuccessful(keymapComponentName)
+	return []string{keymapScriptName}, nil
+}
+
+func writeKeymapCombustionScript(ctx *image.Context) error {
+	keymapScriptFilename := filepath.Join(ctx.CombustionDir, keymapScriptName)
+
+	data, err := template.Parse(keymapScriptName, keymapScript, ctx.ImageDefinition.OperatingSystem)
+	if err != nil {
+		return fmt.Errorf("applying template to %s: %w", keymapScriptName, err)
+	}
+
+	if err := os.WriteFile(keymapScriptFilename, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing file %s: %w", keymapScriptFilename, err)
+	}
+	return nil
+}

--- a/pkg/combustion/keymap_test.go
+++ b/pkg/combustion/keymap_test.go
@@ -51,8 +51,7 @@ func TestConfigureKeymap_NoConf(t *testing.T) {
 	defer teardown()
 
 	ctx.ImageDefinition = &image.Definition{
-		OperatingSystem: image.OperatingSystem{
-		},
+		OperatingSystem: image.OperatingSystem{},
 	}
 
 	// Test

--- a/pkg/combustion/keymap_test.go
+++ b/pkg/combustion/keymap_test.go
@@ -18,7 +18,40 @@ func TestConfigureKeymap(t *testing.T) {
 
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
-			Keymap: "us",
+			Keymap: "gb",
+		},
+	}
+
+	// Test
+	scripts, err := configureKeymap(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, keymapScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, keymapScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the keymap is set correctly
+	assert.Contains(t, foundContents, "echo \"KEYMAP=gb\" >> /etc/vconsole.conf", "keymap not correctly set")
+}
+
+func TestConfigureKeymap_NoConf(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
 		},
 	}
 

--- a/pkg/combustion/keymap_test.go
+++ b/pkg/combustion/keymap_test.go
@@ -1,0 +1,46 @@
+package combustion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestConfigureKeymap(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			Keymap: "us",
+		},
+	}
+
+	// Test
+	scripts, err := configureKeymap(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, keymapScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, keymapScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Make sure that the keymap is set correctly
+	assert.Contains(t, foundContents, "echo \"KEYMAP=us\" >> /etc/vconsole.conf", "keymap not correctly set")
+}

--- a/pkg/combustion/templates/13-keymap-setup.sh.tpl
+++ b/pkg/combustion/templates/13-keymap-setup.sh.tpl
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "KEYMAP={{ .Keymap }}" >> /etc/vconsole.conf

--- a/pkg/combustion/templates/13-keymap-setup.sh.tpl
+++ b/pkg/combustion/templates/13-keymap-setup.sh.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "KEYMAP={{ .Keymap }}" >> /etc/vconsole.conf
+echo "KEYMAP={{ or .Keymap "us" }}" >> /etc/vconsole.conf

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -65,6 +65,7 @@ type OperatingSystem struct {
 	Unattended    bool                  `yaml:"unattended"`
 	Time          Time                  `yaml:"time"`
 	Proxy         Proxy                 `yaml:"proxy"`
+	Keymap        string                `yaml:"keymap"`
 }
 
 type Packages struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -117,6 +117,10 @@ func TestParse(t *testing.T) {
 	noProxy := definition.OperatingSystem.Proxy.NoProxy
 	assert.Equal(t, "localhost, 127.0.0.1, edge.suse.com", noProxy)
 
+	// Operating System -> Keymap
+	keymap := definition.OperatingSystem.Keymap
+	assert.Equal(t, "us", keymap)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -28,6 +28,7 @@ operatingSystem:
       - enable1
     disable:
       - disable0
+  keymap: us
   users:
     - username: alpha
       encryptedPassword: $6$bZfTI3Wj05fdxQcB$W1HJQTKw/MaGTCwK75ic9putEquJvYO7vMnDBVAfuAMFW58/79abky4mx9.8znK0UZwSKng9dVosnYQR1toH71


### PR DESCRIPTION
This PR adds an additional feature that supports the configuration of the systems virtual console keymap. A list of available keymaps can be found via `localectl list-keymaps`. Without this feature, the system default appears to be `us`, but the system sometimes complains that one isn't set (although this seems to not be a significant issue).