### PR TITLE
Adding definition tests for OperatingSystem.Time and fixing typo in docs

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -73,8 +73,8 @@ operatingSystem:
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
   If left omitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
-* `time` - Optional; section where the user can provide timezone information and Chronyd configuration
-  * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`
+* `time` - Optional; section where the user can provide timezone information and Chronyd configuration.
+  * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`.
   * `chronyPools` - Optional; a list of pools that Chrony can use as data sources.
   * `chronyServers` - Optional; a list of servers that Chrony can use as data sources.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -71,7 +71,7 @@ operatingSystem:
 * `unattended` - Optional; only for ISO images - forces GRUB override to automatically install the operating
   system rather than prompting user to begin the installation. In combination with `installDevice` can create
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
-  If left omiitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
+  If left omitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `time` - Optional; section where the user can provide timezone information and Chronyd configuration
   * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -92,6 +92,19 @@ func TestParse(t *testing.T) {
 	unattended := definition.OperatingSystem.Unattended
 	assert.Equal(t, true, unattended)
 
+	// Operating System -> Time
+	time := definition.OperatingSystem.Time
+	assert.Equal(t, "Europe/London", time.Timezone)
+	expectedChronyPools := []string{
+		"2.suse.pool.ntp.org",
+	}
+	assert.Equal(t, expectedChronyPools, time.ChronyPools)
+	expectedChronyServers := []string{
+		"10.0.0.1",
+		"10.0.0.2",
+	}
+	assert.Equal(t, expectedChronyServers, time.ChronyServers)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)


### PR DESCRIPTION
Realised that I had forgotten to add definition tests for `OperatingSystem.Time` in #102 and also spotted a typo that I introduced to the docs in #98 