### PR TITLE
Use pigz instead of gzip for base image archive

### DIFF
--- a/pkg/rpm/resolver/templates/prepare-base.sh.tpl
+++ b/pkg/rpm/resolver/templates/prepare-base.sh.tpl
@@ -33,7 +33,7 @@ if [ `wc -w <<< $RAW_FILE` -ne 1 ]; then
 	exit 1
 fi
 
-virt-tar-out -a $RAW_FILE / - | gzip --best > $WORK_DIR/{{.ArchiveName}}
+virt-tar-out -a $RAW_FILE / - | pigz --best > $WORK_DIR/{{.ArchiveName}}
 {{ else }}
-virt-tar-out -a $IMG_PATH / - | gzip --best > $WORK_DIR/{{.ArchiveName}}
+virt-tar-out -a $IMG_PATH / - | pigz --best > $WORK_DIR/{{.ArchiveName}}
 {{ end }}


### PR DESCRIPTION
Move away from using `gzip` when creating the SLE Micro archive when running RPM resolution. Currently we are using `gzip` to create an archive for the data passed by [virt-tar-out](https://github.com/suse-edge/edge-image-builder/blob/main/pkg/rpm/resolver/templates/prepare-base.sh.tpl#L36).

The problem here is that `gzip` is working on a single CPU thread which makes it very slow when archiving large data.
[pigz](https://zlib.net/pigz/) ([doc](https://zlib.net/pigz/pigz.pdf)) offers a `gzip` that can run in parallel. 

Using `pigz` dramatically decreases the time needed to create the SLE Micro archive which is used as a base image for the RPM resolver.