### PR TITLE
Drop Kubernetes options from the EIB definition in favour of RKE2 config file

### DIFF
--- a/pkg/combustion/kubernetes_test.go
+++ b/pkg/combustion/kubernetes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"gopkg.in/yaml.v3"
 )
 
 type mockKubernetesScriptInstaller struct {
@@ -25,12 +26,18 @@ func (m mockKubernetesScriptInstaller) InstallScript(distribution, sourcePath, d
 }
 
 type mockKubernetesArtefactDownloader struct {
-	downloadArtefacts func(kubernetes image.Kubernetes, arch image.Arch, destPath string) (string, string, error)
+	downloadArtefacts func(arch image.Arch, version, cni string, multusEnabled bool, destPath string) (string, string, error)
 }
 
-func (m mockKubernetesArtefactDownloader) DownloadArtefacts(kubernetes image.Kubernetes, arch image.Arch, destPath string) (installPath, imagesPath string, err error) {
+func (m mockKubernetesArtefactDownloader) DownloadArtefacts(
+	arch image.Arch,
+	version string,
+	cni string,
+	multusEnabled bool,
+	destPath string,
+) (installPath string, imagesPath string, err error) {
 	if m.downloadArtefacts != nil {
-		return m.downloadArtefacts(kubernetes, arch, destPath)
+		return m.downloadArtefacts(arch, version, cni, multusEnabled, destPath)
 	}
 
 	panic("not implemented")
@@ -97,21 +104,20 @@ func TestConfigureKubernetes_ScriptInstallerErrorRKE2(t *testing.T) {
 }
 
 func TestConfigureKubernetes_ArtefactDownloaderErrorRKE2(t *testing.T) {
-	ctx := &image.Context{
-		ImageDefinition: &image.Definition{
-			Kubernetes: image.Kubernetes{
-				Version: "v1.29.0+rke2r1",
-			},
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition.Kubernetes = image.Kubernetes{
+		Version: "v1.29.0+rke2r1",
+	}
+	ctx.KubernetesScriptInstaller = mockKubernetesScriptInstaller{
+		installScript: func(distribution, sourcePath, destPath string) error {
+			return nil
 		},
-		KubernetesScriptInstaller: mockKubernetesScriptInstaller{
-			installScript: func(distribution, sourcePath, destPath string) error {
-				return nil
-			},
-		},
-		KubernetesArtefactDownloader: mockKubernetesArtefactDownloader{
-			downloadArtefacts: func(kubernetes image.Kubernetes, arch image.Arch, destPath string) (string, string, error) {
-				return "", "", fmt.Errorf("some error")
-			},
+	}
+	ctx.KubernetesArtefactDownloader = mockKubernetesArtefactDownloader{
+		downloadArtefacts: func(arch image.Arch, version, cni string, multusEnabled bool, destPath string) (string, string, error) {
+			return "", "", fmt.Errorf("some error")
 		},
 	}
 
@@ -134,7 +140,7 @@ func TestConfigureKubernetes_ConfigFileMissingErrorRKE2(t *testing.T) {
 		},
 	}
 	ctx.KubernetesArtefactDownloader = mockKubernetesArtefactDownloader{
-		downloadArtefacts: func(kubernetes image.Kubernetes, arch image.Arch, destPath string) (string, string, error) {
+		downloadArtefacts: func(arch image.Arch, version, cni string, multusEnabled bool, destPath string) (string, string, error) {
 			return "", "", nil
 		},
 	}
@@ -143,7 +149,7 @@ func TestConfigureKubernetes_ConfigFileMissingErrorRKE2(t *testing.T) {
 
 	scripts, err := configureKubernetes(ctx)
 	require.Error(t, err)
-	assert.EqualError(t, err, "configuring kubernetes components: copying RKE2 config: "+
+	assert.EqualError(t, err, "configuring kubernetes components: parsing RKE2 config: "+
 		"kubernetes component directory exists but does not contain config.yaml")
 	assert.Nil(t, scripts)
 }
@@ -161,15 +167,17 @@ func TestConfigureKubernetes_SuccessfulRKE2Server(t *testing.T) {
 		},
 	}
 	ctx.KubernetesArtefactDownloader = mockKubernetesArtefactDownloader{
-		downloadArtefacts: func(kubernetes image.Kubernetes, arch image.Arch, destPath string) (string, string, error) {
+		downloadArtefacts: func(arch image.Arch, version, cni string, multusEnabled bool, destPath string) (string, string, error) {
 			return "server-installer", "server-images", nil
 		},
 	}
 
 	configDir := filepath.Join(ctx.ImageConfigDir, k8sConfigDir)
 	require.NoError(t, os.Mkdir(configDir, os.ModePerm))
+
 	configFile := filepath.Join(configDir, k8sConfigFile)
-	require.NoError(t, os.WriteFile(configFile, []byte("some-config-data"), os.ModePerm))
+	data := []byte("") // default CNI will be used since the file will not contain one
+	require.NoError(t, os.WriteFile(configFile, data, os.ModePerm))
 
 	scripts, err := configureKubernetes(ctx)
 	require.NoError(t, err)
@@ -205,8 +213,11 @@ func TestConfigureKubernetes_SuccessfulRKE2Server(t *testing.T) {
 	b, err = os.ReadFile(configPath)
 	require.NoError(t, err)
 
-	contents = string(b)
-	assert.Equal(t, "some-config-data", contents)
+	var configContents map[string]any
+	require.NoError(t, yaml.Unmarshal(b, &configContents))
+
+	require.Contains(t, configContents, "cni")
+	assert.Equal(t, "cilium", configContents["cni"], "default CNI is not set")
 }
 
 func TestConfigureKubernetes_SuccessfulRKE2Agent(t *testing.T) {
@@ -223,15 +234,29 @@ func TestConfigureKubernetes_SuccessfulRKE2Agent(t *testing.T) {
 		},
 	}
 	ctx.KubernetesArtefactDownloader = mockKubernetesArtefactDownloader{
-		downloadArtefacts: func(kubernetes image.Kubernetes, arch image.Arch, destPath string) (string, string, error) {
+		downloadArtefacts: func(arch image.Arch, version, cni string, multusEnabled bool, destPath string) (string, string, error) {
 			return "agent-installer", "agent-images", nil
 		},
 	}
+
+	configDir := filepath.Join(ctx.ImageConfigDir, k8sConfigDir)
+	require.NoError(t, os.Mkdir(configDir, os.ModePerm))
+
+	data := map[string]any{
+		"cni":   []string{"calico"},
+		"debug": true,
+	}
+	b, err := yaml.Marshal(data)
+	require.NoError(t, err)
+
+	configFile := filepath.Join(configDir, k8sConfigFile)
+	require.NoError(t, os.WriteFile(configFile, b, os.ModePerm))
 
 	scripts, err := configureKubernetes(ctx)
 	require.NoError(t, err)
 	require.Len(t, scripts, 1)
 
+	// Script file assertions
 	scriptPath := filepath.Join(ctx.CombustionDir, scripts[0])
 
 	info, err := os.Stat(scriptPath)
@@ -239,13 +264,148 @@ func TestConfigureKubernetes_SuccessfulRKE2Agent(t *testing.T) {
 
 	assert.Equal(t, fileio.ExecutablePerms, info.Mode())
 
-	b, err := os.ReadFile(scriptPath)
+	b, err = os.ReadFile(scriptPath)
 	require.NoError(t, err)
 
 	contents := string(b)
 	assert.Contains(t, contents, "cp agent-images/* /var/lib/rancher/rke2/agent/images/")
 	assert.Contains(t, contents, "export INSTALL_RKE2_TYPE=agent")
-	assert.NotContains(t, contents, "cp rke2_config.yaml /etc/rancher/rke2/config.yaml")
+	assert.Contains(t, contents, "cp rke2_config.yaml /etc/rancher/rke2/config.yaml")
 	assert.Contains(t, contents, "export INSTALL_RKE2_ARTIFACT_PATH=agent-installer")
 	assert.Contains(t, contents, "systemctl enable rke2-agent.service")
+
+	// Config file assertions
+	configPath := filepath.Join(ctx.CombustionDir, "rke2_config.yaml")
+
+	info, err = os.Stat(configPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, fileio.NonExecutablePerms, info.Mode())
+
+	b, err = os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var configContents map[string]any
+	require.NoError(t, yaml.Unmarshal(b, &configContents))
+
+	require.Contains(t, configContents, "cni")
+	assert.Equal(t, []any{"calico"}, configContents["cni"])
+	assert.Equal(t, true, configContents["debug"])
+}
+
+func TestExtractCNI(t *testing.T) {
+	tests := map[string]struct {
+		input                 map[string]any
+		expectedCNI           string
+		expectedMultusEnabled bool
+		expectedErr           string
+	}{
+		"CNI not configured": {
+			input:       map[string]any{},
+			expectedErr: "invalid cni: <nil>",
+		},
+		"Empty CNI string": {
+			input: map[string]any{
+				"cni": "",
+			},
+			expectedErr: "cni not configured",
+		},
+		"Empty CNI list": {
+			input: map[string]any{
+				"cni": []string{},
+			},
+			expectedErr: "invalid cni value: []",
+		},
+		"Multiple CNI list": {
+			input: map[string]any{
+				"cni": []string{"canal", "calico", "cilium"},
+			},
+			expectedErr: "invalid cni value: [canal calico cilium]",
+		},
+		"Valid CNI string": {
+			input: map[string]any{
+				"cni": "calico",
+			},
+			expectedCNI: "calico",
+		},
+		"Valid CNI list": {
+			input: map[string]any{
+				"cni": []string{"calico"},
+			},
+			expectedCNI: "calico",
+		},
+		"Valid CNI string with multus": {
+			input: map[string]any{
+				"cni": "multus, calico",
+			},
+			expectedCNI:           "calico",
+			expectedMultusEnabled: true,
+		},
+		"Valid CNI list with multus": {
+			input: map[string]any{
+				"cni": []string{"multus", "calico"},
+			},
+			expectedCNI:           "calico",
+			expectedMultusEnabled: true,
+		},
+		"Invalid standalone multus": {
+			input: map[string]any{
+				"cni": "multus",
+			},
+			expectedErr: "multus must be used alongside another primary cni selection",
+		},
+		"Invalid standalone multus list": {
+			input: map[string]any{
+				"cni": []string{"multus"},
+			},
+			expectedErr: "multus must be used alongside another primary cni selection",
+		},
+		"Valid CNI with invalid multus placement": {
+			input: map[string]any{
+				"cni": "cilium, multus",
+			},
+			expectedErr: "multiple cni values are only allowed if multus is the first one",
+		},
+		"Valid CNI list with invalid multus placement": {
+			input: map[string]any{
+				"cni": []string{"cilium", "multus"},
+			},
+			expectedErr: "multiple cni values are only allowed if multus is the first one",
+		},
+		"Invalid CNI list": {
+			input: map[string]any{
+				"cni": []any{"cilium", 6},
+			},
+			expectedErr: "invalid cni value: 6",
+		},
+		"Invalid CNI format": {
+			input: map[string]any{
+				"cni": 6,
+			},
+			expectedErr: "invalid cni: 6",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			b, err := yaml.Marshal(test.input)
+			require.NoError(t, err)
+
+			var config map[string]any
+			require.NoError(t, yaml.Unmarshal(b, &config))
+
+			cni, multusEnabled, err := extractCNI(config)
+
+			if test.expectedErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedErr)
+				assert.False(t, multusEnabled)
+				assert.Empty(t, cni)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedCNI, cni)
+				assert.Equal(t, test.expectedMultusEnabled, multusEnabled)
+			}
+		})
+	}
 }

--- a/pkg/combustion/templates/15-rke2-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-installer.sh.tpl
@@ -6,10 +6,8 @@ mkdir -p /var/lib/rancher/rke2/agent/images/
 cp {{ .ImagesPath }}/* /var/lib/rancher/rke2/agent/images/
 umount /var
 
-{{- if .ConfigFile }}
 mkdir -p /etc/rancher/rke2/
 cp {{ .ConfigFile }} /etc/rancher/rke2/config.yaml
-{{- end }}
 
 {{- if .NodeType }}
 export INSTALL_RKE2_TYPE={{ .NodeType }}

--- a/pkg/image/context.go
+++ b/pkg/image/context.go
@@ -17,7 +17,7 @@ type kubernetesScriptInstaller interface {
 }
 
 type kubernetesArtefactDownloader interface {
-	DownloadArtefacts(kubernetes Kubernetes, arch Arch, destinationPath string) (installPath, imagesPath string, err error)
+	DownloadArtefacts(arch Arch, version, cni string, multusEnabled bool, destinationPath string) (installPath, imagesPath string, err error)
 }
 
 type rpmResolver interface {

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -120,11 +120,8 @@ type HelmChart struct {
 }
 
 type Kubernetes struct {
-	Version        string `yaml:"version"`
-	NodeType       string `yaml:"nodeType"`
-	CNI            string `yaml:"cni"`
-	MultusEnabled  bool   `yaml:"multus"`
-	VSphereEnabled bool   `yaml:"vSphere"`
+	Version  string `yaml:"version"`
+	NodeType string `yaml:"nodeType"`
 }
 
 func ParseDefinition(data []byte) (*Definition, error) {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -134,9 +134,6 @@ func TestParse(t *testing.T) {
 	kubernetes := definition.Kubernetes
 	assert.Equal(t, "v1.29.0+rke2r1", kubernetes.Version)
 	assert.Equal(t, "server", kubernetes.NodeType)
-	assert.Equal(t, "cilium", kubernetes.CNI)
-	assert.Equal(t, true, kubernetes.MultusEnabled)
-	assert.Equal(t, false, kubernetes.VSphereEnabled)
 }
 
 func TestParseBadConfig(t *testing.T) {

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -65,6 +65,3 @@ embeddedArtifactRegistry:
 kubernetes:
   version: v1.29.0+rke2r1
   nodeType: server
-  cni: cilium
-  multus: true
-  vSphere: false

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-
-	"github.com/suse-edge/edge-image-builder/pkg/log"
 )
 
 func ValidateDefinition(definition *Definition) error {
@@ -90,14 +88,7 @@ func validateKubernetes(definition *Definition) error {
 		return nil
 	}
 
-	supportedCNIs := []string{CNITypeNone, CNITypeCanal, CNITypeCalico, CNITypeCilium}
-
-	if definition.Kubernetes.CNI == "" {
-		log.Audit("Kubernetes CNI was not specified. Please set \"cni: none\" if you intend to use your own")
-		return fmt.Errorf("CNI not specified")
-	} else if !slices.Contains(supportedCNIs, definition.Kubernetes.CNI) {
-		return fmt.Errorf("CNI '%s' is not supported", definition.Kubernetes.CNI)
-	}
+	// TODO: Validate config file
 
 	// Empty string corresponds to a "server" node type
 	supportedNodeTypes := []string{"", KubernetesNodeTypeServer, KubernetesNodeTypeAgent}

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -79,68 +79,11 @@ func TestValidateKubernetes(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name: "Empty CNI",
-			definition: &Definition{
-				Kubernetes: Kubernetes{
-					Version: "v1.29.0+rke2r1",
-					CNI:     "",
-				},
-			},
-			expectedErr: "CNI not specified",
-		},
-		{
-			name: "Unsupported CNI",
-			definition: &Definition{
-				Kubernetes: Kubernetes{
-					Version: "v1.29.0+rke2r1",
-					CNI:     "flannel",
-				},
-			},
-			expectedErr: "CNI 'flannel' is not supported",
-		},
-		{
-			name: "No CNI",
-			definition: &Definition{
-				Kubernetes: Kubernetes{
-					Version: "v1.29.0+rke2r1",
-					CNI:     "none",
-				},
-			},
-		},
-		{
-			name: "Canal CNI",
-			definition: &Definition{
-				Kubernetes: Kubernetes{
-					Version: "v1.29.0+rke2r1",
-					CNI:     "canal",
-				},
-			},
-		},
-		{
-			name: "Calico CNI",
-			definition: &Definition{
-				Kubernetes: Kubernetes{
-					Version: "v1.29.0+rke2r1",
-					CNI:     "calico",
-				},
-			},
-		},
-		{
-			name: "Cilium CNI",
-			definition: &Definition{
-				Kubernetes: Kubernetes{
-					Version: "v1.29.0+rke2r1",
-					CNI:     "cilium",
-				},
-			},
-		},
-		{
 			name: "Server node type",
 			definition: &Definition{
 				Kubernetes: Kubernetes{
 					Version:  "v1.29.0+rke2r1",
 					NodeType: "server",
-					CNI:      "cilium",
 				},
 			},
 		},
@@ -150,7 +93,6 @@ func TestValidateKubernetes(t *testing.T) {
 				Kubernetes: Kubernetes{
 					Version:  "v1.29.0+rke2r1",
 					NodeType: "agent",
-					CNI:      "cilium",
 				},
 			},
 		},
@@ -160,7 +102,6 @@ func TestValidateKubernetes(t *testing.T) {
 				Kubernetes: Kubernetes{
 					Version:  "v1.29.0+rke2r1",
 					NodeType: "worker",
-					CNI:      "cilium",
 				},
 			},
 			expectedErr: "unknown node type: worker",

--- a/pkg/kubernetes/artefact_downloader_test.go
+++ b/pkg/kubernetes/artefact_downloader_test.go
@@ -19,30 +19,26 @@ func TestInstallerArtefacts(t *testing.T) {
 func TestImageArtefacts(t *testing.T) {
 	tests := []struct {
 		name              string
-		kubernetes        image.Kubernetes
+		cni               string
+		multusEnabled     bool
 		arch              image.Arch
 		expectedArtefacts []string
 		expectedError     string
 	}{
 		{
 			name:          "CNI not specified",
-			kubernetes:    image.Kubernetes{},
 			arch:          image.ArchTypeX86,
 			expectedError: "CNI not specified",
 		},
 		{
-			name: "CNI not supported",
-			kubernetes: image.Kubernetes{
-				CNI: "flannel",
-			},
+			name:          "CNI not supported",
+			cni:           "flannel",
 			arch:          image.ArchTypeX86,
 			expectedError: "unsupported CNI: flannel",
 		},
 		{
 			name: "x86_64 artefacts without CNI",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeNone,
-			},
+			cni:  image.CNITypeNone,
 			arch: image.ArchTypeX86,
 			expectedArtefacts: []string{
 				"rke2-images-core.linux-amd64.tar.zst",
@@ -50,9 +46,7 @@ func TestImageArtefacts(t *testing.T) {
 		},
 		{
 			name: "x86_64 artefacts with canal CNI",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeCanal,
-			},
+			cni:  image.CNITypeCanal,
 			arch: image.ArchTypeX86,
 			expectedArtefacts: []string{
 				"rke2-images-core.linux-amd64.tar.zst",
@@ -61,9 +55,7 @@ func TestImageArtefacts(t *testing.T) {
 		},
 		{
 			name: "x86_64 artefacts with calico CNI",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeCalico,
-			},
+			cni:  image.CNITypeCalico,
 			arch: image.ArchTypeX86,
 			expectedArtefacts: []string{
 				"rke2-images-core.linux-amd64.tar.zst",
@@ -72,9 +64,7 @@ func TestImageArtefacts(t *testing.T) {
 		},
 		{
 			name: "x86_64 artefacts with cilium CNI",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeCilium,
-			},
+			cni:  image.CNITypeCilium,
 			arch: image.ArchTypeX86,
 			expectedArtefacts: []string{
 				"rke2-images-core.linux-amd64.tar.zst",
@@ -82,25 +72,19 @@ func TestImageArtefacts(t *testing.T) {
 			},
 		},
 		{
-			name: "x86_64 artefacts with cilium CNI + multus + vSphere",
-			kubernetes: image.Kubernetes{
-				CNI:            image.CNITypeCilium,
-				MultusEnabled:  true,
-				VSphereEnabled: true,
-			},
-			arch: image.ArchTypeX86,
+			name:          "x86_64 artefacts with cilium CNI + multus",
+			cni:           image.CNITypeCilium,
+			multusEnabled: true,
+			arch:          image.ArchTypeX86,
 			expectedArtefacts: []string{
 				"rke2-images-core.linux-amd64.tar.zst",
 				"rke2-images-cilium.linux-amd64.tar.zst",
 				"rke2-images-multus.linux-amd64.tar.zst",
-				"rke2-images-vsphere.linux-amd64.tar.zst",
 			},
 		},
 		{
 			name: "aarch64 artefacts for CNI none",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeNone,
-			},
+			cni:  image.CNITypeNone,
 			arch: image.ArchTypeARM,
 			expectedArtefacts: []string{
 				"rke2-images-core.linux-arm64.tar.zst",
@@ -108,9 +92,7 @@ func TestImageArtefacts(t *testing.T) {
 		},
 		{
 			name: "aarch64 artefacts with canal CNI",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeCanal,
-			},
+			cni:  image.CNITypeCanal,
 			arch: image.ArchTypeARM,
 			expectedArtefacts: []string{
 				"rke2-images-core.linux-arm64.tar.zst",
@@ -118,44 +100,29 @@ func TestImageArtefacts(t *testing.T) {
 			},
 		},
 		{
-			name: "aarch64 artefacts with calico CNI",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeCalico,
-			},
+			name:          "aarch64 artefacts with calico CNI",
+			cni:           image.CNITypeCalico,
 			arch:          image.ArchTypeARM,
 			expectedError: "calico is not supported on aarch64 platforms",
 		},
 		{
-			name: "aarch64 artefacts with cilium CNI",
-			kubernetes: image.Kubernetes{
-				CNI: image.CNITypeCilium,
-			},
+			name:          "aarch64 artefacts with cilium CNI",
+			cni:           image.CNITypeCilium,
 			arch:          image.ArchTypeARM,
 			expectedError: "cilium is not supported on aarch64 platforms",
 		},
 		{
-			name: "aarch64 artefacts with canal CNI + multus",
-			kubernetes: image.Kubernetes{
-				CNI:           image.CNITypeCanal,
-				MultusEnabled: true,
-			},
+			name:          "aarch64 artefacts with canal CNI + multus",
+			cni:           image.CNITypeCanal,
+			multusEnabled: true,
 			arch:          image.ArchTypeARM,
 			expectedError: "multus is not supported on aarch64 platforms",
-		},
-		{
-			name: "aarch64 artefacts with canal CNI + vSphere",
-			kubernetes: image.Kubernetes{
-				CNI:            image.CNITypeCanal,
-				VSphereEnabled: true,
-			},
-			arch:          image.ArchTypeARM,
-			expectedError: "vSphere is not supported on aarch64 platforms",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			artefacts, err := imageArtefacts(test.kubernetes, test.arch)
+			artefacts, err := imageArtefacts(test.cni, test.multusEnabled, test.arch)
 
 			if test.expectedError != "" {
 				require.EqualError(t, err, test.expectedError)


### PR DESCRIPTION
- Removes CNI and multus configurations from EIB definition
- Uses a Kubernetes (RKE2) configuration file instead
- Uses Cilium as a default CNI if one is not provided
- Drops vSphere support