### PR TITLE
Refactor "AdditionalRepos" field to a struct

### DIFF
--- a/pkg/combustion/rpm_test.go
+++ b/pkg/combustion/rpm_test.go
@@ -51,14 +51,22 @@ func TestSkipRPMComponentTrue(t *testing.T) {
 		{
 			name: "Additional repository without an RPM directory or package list",
 			packages: image.Packages{
-				AdditionalRepos: []string{"https://foo.bar"},
+				AdditionalRepos: []image.AddRepo{
+					{
+						URL: "https://foo.bar",
+					},
+				},
 			},
 		},
 		{
 			name: "Additional repository and registration code without RPM directory or package list",
 			packages: image.Packages{
-				AdditionalRepos: []string{"https://foo.bar"},
-				RegCode:         "foo.bar",
+				AdditionalRepos: []image.AddRepo{
+					{
+						URL: "https://foo.bar",
+					},
+				},
+				RegCode: "foo.bar",
 			},
 		},
 	}
@@ -107,9 +115,13 @@ func TestSkipRPMComponentFullConfig(t *testing.T) {
 	}()
 
 	ctx.ImageDefinition.OperatingSystem.Packages = image.Packages{
-		PKGList:         []string{"pkg1", "pkg2"},
-		AdditionalRepos: []string{"https://foo.bar"},
-		RegCode:         "foo.bar",
+		PKGList: []string{"pkg1", "pkg2"},
+		AdditionalRepos: []image.AddRepo{
+			{
+				URL: "https://foo.bar",
+			},
+		},
+		RegCode: "foo.bar",
 	}
 
 	assert.False(t, SkipRPMComponent(ctx))
@@ -131,8 +143,12 @@ func TestConfigureRPMSError(t *testing.T) {
 
 	// do not skip RPM component
 	ctx.ImageDefinition.OperatingSystem.Packages = image.Packages{
-		PKGList:         []string{"foo", "bar"},
-		AdditionalRepos: []string{"https://foo.bar"},
+		PKGList: []string{"foo", "bar"},
+		AdditionalRepos: []image.AddRepo{
+			{
+				URL: "https://foo.bar",
+			},
+		},
 	}
 
 	tests := []struct {
@@ -215,8 +231,12 @@ func TestConfigureRPMSSuccessfulConfig(t *testing.T) {
 	defer teardown()
 
 	ctx.ImageDefinition.OperatingSystem.Packages = image.Packages{
-		PKGList:         []string{"foo", "bar"},
-		AdditionalRepos: []string{"https://foo.bar"},
+		PKGList: []string{"foo", "bar"},
+		AdditionalRepos: []image.AddRepo{
+			{
+				URL: "https://foo.bar",
+			},
+		},
 	}
 
 	rpmDir := filepath.Join(ctx.ImageConfigDir, userRPMsDir)

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -69,9 +69,13 @@ type OperatingSystem struct {
 }
 
 type Packages struct {
-	PKGList         []string `yaml:"packageList"`
-	AdditionalRepos []string `yaml:"additionalRepos"`
-	RegCode         string   `yaml:"registrationCode"`
+	PKGList         []string  `yaml:"packageList"`
+	AdditionalRepos []AddRepo `yaml:"additionalRepos"`
+	RegCode         string    `yaml:"registrationCode"`
+}
+
+type AddRepo struct {
+	URL string `yaml:"url"`
 }
 
 type OperatingSystemUser struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -77,9 +77,13 @@ func TestParse(t *testing.T) {
 		"libbpf0",
 	}
 	assert.Equal(t, expectedPKGList, pkgConfig.PKGList)
-	expectedAddRepos := []string{
-		"https://download.nvidia.com/suse/sle15sp5/",
-		"https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/",
+	expectedAddRepos := []AddRepo{
+		{
+			URL: "https://download.nvidia.com/suse/sle15sp5/",
+		},
+		{
+			URL: "https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/",
+		},
 	}
 	assert.Equal(t, expectedAddRepos, pkgConfig.AdditionalRepos)
 	assert.Equal(t, "INTERNAL-USE-ONLY-foo-bar", pkgConfig.RegCode)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -50,8 +50,8 @@ operatingSystem:
       - libatomic1
       - libbpf0
     additionalRepos:
-      - https://download.nvidia.com/suse/sle15sp5/
-      - https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
+      - url: https://download.nvidia.com/suse/sle15sp5/
+      - url: https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
     registrationCode: INTERNAL-USE-ONLY-foo-bar
 embeddedArtifactRegistry:
   images:

--- a/pkg/image/validation.go
+++ b/pkg/image/validation.go
@@ -361,8 +361,20 @@ func validatePackages(os *OperatingSystem) error {
 		return fmt.Errorf("package list contains duplicate: %s", duplicate)
 	}
 
-	if duplicate := checkForDuplicates(os.Packages.AdditionalRepos); duplicate != "" {
-		return fmt.Errorf("additional repository list contains duplicate: %s", duplicate)
+	if len(os.Packages.AdditionalRepos) > 0 {
+		urlSlice := []string{}
+
+		for _, repo := range os.Packages.AdditionalRepos {
+			if repo.URL == "" {
+				return fmt.Errorf("additional repository list contains an entry with empty 'url' field")
+			}
+
+			urlSlice = append(urlSlice, repo.URL)
+		}
+
+		if duplicate := checkForDuplicates(urlSlice); duplicate != "" {
+			return fmt.Errorf("additional repository list contains duplicate: %s", duplicate)
+		}
 	}
 
 	if len(os.Packages.PKGList) > 0 && len(os.Packages.AdditionalRepos) == 0 && os.Packages.RegCode == "" {

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -166,12 +166,27 @@ func validatePackages(os *image.OperatingSystem) []FailedValidation {
 		})
 	}
 
-	if duplicates := findDuplicates(os.Packages.AdditionalRepos); len(duplicates) > 0 {
-		duplicateValues := strings.Join(duplicates, ", ")
-		msg := fmt.Sprintf("The 'additionalRepos' field contains duplicate repos: %s", duplicateValues)
-		failures = append(failures, FailedValidation{
-			UserMessage: msg,
-		})
+	if len(os.Packages.AdditionalRepos) > 0 {
+		urlSlice := []string{}
+
+		for _, repo := range os.Packages.AdditionalRepos {
+			if repo.URL == "" {
+				msg := "Additional repository list contains an entry with empty 'url' field."
+				failures = append(failures, FailedValidation{
+					UserMessage: msg,
+				})
+			}
+
+			urlSlice = append(urlSlice, repo.URL)
+		}
+
+		if duplicates := findDuplicates(urlSlice); len(duplicates) > 0 {
+			duplicateValues := strings.Join(duplicates, ", ")
+			msg := fmt.Sprintf("The 'additionalRepos' field contains duplicate repos: %s", duplicateValues)
+			failures = append(failures, FailedValidation{
+				UserMessage: msg,
+			})
+		}
 	}
 
 	if len(os.Packages.PKGList) > 0 && len(os.Packages.AdditionalRepos) == 0 && os.Packages.RegCode == "" {

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -467,7 +467,7 @@ func TestPackages(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				"additional repository list contains an entry with empty 'url' field",
+				"Additional repository list contains an entry with empty 'url' field.",
 			},
 		},
 	}

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -39,9 +39,13 @@ func TestValidateOperatingSystem(t *testing.T) {
 						ActivationKey: "please?",
 					},
 					Packages: image.Packages{
-						PKGList:         []string{"zsh", "git"},
-						AdditionalRepos: []string{"myrepo.com"},
-						RegCode:         "letMeIn",
+						PKGList: []string{"zsh", "git"},
+						AdditionalRepos: []image.AddRepo{
+							{
+								URL: "myrepo.com",
+							},
+						},
+						RegCode: "letMeIn",
 					},
 					Unattended:    true,
 					InstallDevice: "/dev/sda",
@@ -410,9 +414,13 @@ func TestPackages(t *testing.T) {
 		},
 		`valid`: {
 			Packages: image.Packages{
-				PKGList:         []string{"foo"},
-				AdditionalRepos: []string{"myrepo"},
-				RegCode:         "regcode",
+				PKGList: []string{"foo"},
+				AdditionalRepos: []image.AddRepo{
+					{
+						URL: "myrepo",
+					},
+				},
+				RegCode: "regcode",
 			},
 		},
 		`package list only`: {
@@ -434,10 +442,32 @@ func TestPackages(t *testing.T) {
 		},
 		`duplicate repos`: {
 			Packages: image.Packages{
-				AdditionalRepos: []string{"foo", "bar", "foo"},
+				AdditionalRepos: []image.AddRepo{
+					{
+						URL: "foo",
+					},
+					{
+						URL: "bar",
+					},
+					{
+						URL: "foo",
+					},
+				},
 			},
 			ExpectedFailedMessages: []string{
 				"The 'additionalRepos' field contains duplicate repos: foo",
+			},
+		},
+		`missing repo url`: {
+			Packages: image.Packages{
+				AdditionalRepos: []image.AddRepo{
+					{
+						URL: "",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				"additional repository list contains an entry with empty 'url' field",
 			},
 		},
 	}

--- a/pkg/image/validation_test.go
+++ b/pkg/image/validation_test.go
@@ -1079,10 +1079,33 @@ func TestValidatePackages(t *testing.T) {
 			name: "Additional repository with duplicate",
 			os: &OperatingSystem{
 				Packages: Packages{
-					AdditionalRepos: []string{"https://foo.bar", "https://bar.foo", "https://foo.bar"},
+					AdditionalRepos: []AddRepo{
+						{
+							URL: "https://foo.bar",
+						},
+						{
+							URL: "https://bar.foo",
+						},
+						{
+							URL: "https://foo.bar",
+						},
+					},
 				},
 			},
 			expectedErr: "additional repository list contains duplicate: https://foo.bar",
+		},
+		{
+			name: "Additional repository with empty URL",
+			os: &OperatingSystem{
+				Packages: Packages{
+					AdditionalRepos: []AddRepo{
+						{
+							URL: "",
+						},
+					},
+				},
+			},
+			expectedErr: "additional repository list contains an entry with empty 'url' field",
 		},
 		{
 			name: "Package list defined without registration code or third party repo",
@@ -1106,8 +1129,12 @@ func TestValidatePackages(t *testing.T) {
 			name: "Configuring package from third party repo",
 			os: &OperatingSystem{
 				Packages: Packages{
-					PKGList:         []string{"foo", "bar"},
-					AdditionalRepos: []string{"https://foo.bar"},
+					PKGList: []string{"foo", "bar"},
+					AdditionalRepos: []AddRepo{
+						{
+							URL: "https://foo.bar",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -135,7 +135,7 @@ func (r *Resolver) writeDockerfile(localPackagesPath string, packages *image.Pac
 	}{
 		BaseImage: baseImageRef,
 		RegCode:   packages.RegCode,
-		AddRepo:   strings.Join(packages.AdditionalRepos, " "),
+		AddRepo:   strings.Join(r.generateAddRepoList(packages.AdditionalRepos), " "),
 		CacheDir:  r.generateRPMRepoPath(),
 		PkgList:   strings.Join(r.getPKGForResolve(packages), " "),
 	}
@@ -156,6 +156,14 @@ func (r *Resolver) writeDockerfile(localPackagesPath string, packages *image.Pac
 	}
 
 	return nil
+}
+
+func (r *Resolver) generateAddRepoList(repos []image.AddRepo) (repoList []string) {
+	for _, repo := range repos {
+		repoList = append(repoList, repo.URL)
+	}
+
+	return repoList
 }
 
 func (r *Resolver) getPKGForResolve(packages *image.Packages) []string {

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -135,7 +135,7 @@ func (r *Resolver) writeDockerfile(localPackagesPath string, packages *image.Pac
 	}{
 		BaseImage: baseImageRef,
 		RegCode:   packages.RegCode,
-		AddRepo:   strings.Join(r.generateAddRepoList(packages.AdditionalRepos), " "),
+		AddRepo:   r.generateAddRepoStr(packages.AdditionalRepos),
 		CacheDir:  r.generateRPMRepoPath(),
 		PkgList:   strings.Join(r.getPKGForResolve(packages), " "),
 	}
@@ -158,12 +158,13 @@ func (r *Resolver) writeDockerfile(localPackagesPath string, packages *image.Pac
 	return nil
 }
 
-func (r *Resolver) generateAddRepoList(repos []image.AddRepo) (repoList []string) {
+func (r *Resolver) generateAddRepoStr(repos []image.AddRepo) string {
+	list := []string{}
 	for _, repo := range repos {
-		repoList = append(repoList, repo.URL)
+		list = append(list, repo.URL)
 	}
 
-	return repoList
+	return strings.Join(list, " ")
 }
 
 func (r *Resolver) getPKGForResolve(packages *image.Packages) []string {


### PR DESCRIPTION
Refactoring `AdditionalRepos` from a `[]string` to a struct was discussed in #64. 
By adopting this structure we get the flexibility to easily add additional repo configurations whenever the need for such configuration arises.

Note: This PR is a prerequisite for the RPM resolver GPG validation logic PR that is currently being implemented.