### PR TITLE
Introduce copy multiple files logic to fileio package

### DIFF
--- a/pkg/fileio/file_io_test.go
+++ b/pkg/fileio/file_io_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -135,4 +136,113 @@ func TestCopyFileN(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCopyFiles(t *testing.T) {
+	const (
+		expectedSubDirName = "sub1-copy-files"
+	)
+
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+	testDataPath := filepath.Join(pwd, "testdata", "copy-files")
+
+	tests := []struct {
+		name                     string
+		expectedRootDirFileNames []string
+		expectedSubDirFileNames  []string
+		extentsion               string
+		destDirPrefix            string
+		copySubDir               bool
+	}{
+		{
+			name:                     "Copy full directory filesystem",
+			expectedRootDirFileNames: []string{"gpg.gpg", "rpm.rpm", "sub1-copy-files"},
+			expectedSubDirFileNames:  []string{"dummy.txt", "gpg.gpg", "rpm.rpm"},
+			destDirPrefix:            "eib-copy-files-all-dirs-",
+			copySubDir:               true,
+		},
+		{
+			name:                     "Copy full directory structure and files with specific extension",
+			expectedRootDirFileNames: []string{"rpm.rpm", "sub1-copy-files"},
+			expectedSubDirFileNames:  []string{"rpm.rpm"},
+			destDirPrefix:            "eib-copy-files-ext-all-dirs-",
+			extentsion:               ".rpm",
+			copySubDir:               true,
+		},
+		{
+			name:                     "Copy all files only from the root directory",
+			expectedRootDirFileNames: []string{"gpg.gpg", "rpm.rpm"},
+			destDirPrefix:            "eib-copy-files-root-dir-only-",
+		},
+		{
+			name:                     "Copy files with specific extension only from the root directory",
+			expectedRootDirFileNames: []string{"rpm.rpm"},
+			destDirPrefix:            "eib-copy-files-root-dir-only-",
+			extentsion:               ".rpm",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rootDir, err := os.MkdirTemp("", test.destDirPrefix)
+			require.NoError(t, err)
+
+			err = CopyFiles(testDataPath, rootDir, test.extentsion, test.copySubDir)
+			require.NoError(t, err)
+
+			if test.copySubDir {
+				assertDir(t, rootDir, test.expectedRootDirFileNames, expectedSubDirName)
+				assertDir(t, filepath.Join(rootDir, expectedSubDirName), test.expectedSubDirFileNames, "")
+			} else {
+				assertDir(t, rootDir, test.expectedRootDirFileNames, "")
+			}
+
+			err = os.RemoveAll(rootDir)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCopyFilesMissingSource(t *testing.T) {
+	err := CopyFiles("", "", "", false)
+	assert.EqualError(t, err, "reading source dir: open : no such file or directory")
+}
+
+func TestCopyFilesMissingDestination(t *testing.T) {
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+	testDataPath := filepath.Join(pwd, "testdata", "copy-files")
+
+	err = CopyFiles(testDataPath, "", "", false)
+	assert.EqualError(t, err, "creating directory '': mkdir : no such file or directory")
+}
+
+func assertDir(t *testing.T, dirPath string, expectedFileNames []string, expectedSubDirName string) {
+	const (
+		expectedFileContent = "copy-files-test-data"
+	)
+
+	rootDirFiles, err := os.ReadDir(dirPath)
+	require.NoError(t, err)
+
+	fileNames := []string{}
+	for _, file := range rootDirFiles {
+		fileNames = append(fileNames, file.Name())
+
+		if expectedSubDirName == "" {
+			assert.False(t, file.IsDir())
+		}
+
+		if file.IsDir() {
+			assert.Equal(t, expectedSubDirName, file.Name())
+			continue
+		}
+
+		fileContent, err := os.ReadFile(filepath.Join(dirPath, file.Name()))
+		require.NoError(t, err)
+		assert.Equal(t, []byte(expectedFileContent), fileContent)
+	}
+
+	assert.Equal(t, expectedFileNames, fileNames)
 }

--- a/pkg/fileio/testdata/copy-files/gpg.gpg
+++ b/pkg/fileio/testdata/copy-files/gpg.gpg
@@ -1,0 +1,1 @@
+copy-files-test-data

--- a/pkg/fileio/testdata/copy-files/rpm.rpm
+++ b/pkg/fileio/testdata/copy-files/rpm.rpm
@@ -1,0 +1,1 @@
+copy-files-test-data

--- a/pkg/fileio/testdata/copy-files/sub1-copy-files/dummy.txt
+++ b/pkg/fileio/testdata/copy-files/sub1-copy-files/dummy.txt
@@ -1,0 +1,1 @@
+copy-files-test-data

--- a/pkg/fileio/testdata/copy-files/sub1-copy-files/gpg.gpg
+++ b/pkg/fileio/testdata/copy-files/sub1-copy-files/gpg.gpg
@@ -1,0 +1,1 @@
+copy-files-test-data

--- a/pkg/fileio/testdata/copy-files/sub1-copy-files/rpm.rpm
+++ b/pkg/fileio/testdata/copy-files/sub1-copy-files/rpm.rpm
@@ -1,0 +1,1 @@
+copy-files-test-data


### PR DESCRIPTION
This PR introduces logic that allows us to:

1. Copy multiple files from a single directory
2. Copy files with a specific file extension from a single directory
3. Copy full directory structure along with all files that the structure holds
4. Copy full directory structure along with files that have a specific file extension

Note: This PR is a prerequisite for the RPM resolver GPG validation logic PR that is currently being implemented.