### PR TITLE
Registry logic restructuring

### DIFF
--- a/pkg/combustion/templates/13-embedded-registry.sh.tpl
+++ b/pkg/combustion/templates/13-embedded-registry.sh.tpl
@@ -4,7 +4,7 @@ set -euo pipefail
 mkdir /opt/hauler
 
 mount /usr/local
-mv {{ .EmbeddedRegistryTar }} /opt/hauler/{{ .EmbeddedRegistryTar }}
+mv ./registry/* /opt/hauler/
 mv hauler /usr/local/bin/hauler
 umount /usr/local
 
@@ -17,12 +17,13 @@ cat <<- EOF > /etc/systemd/system/eib-embedded-registry.service
   Type=simple
   User=root
   WorkingDirectory=/opt/hauler
-  ExecStartPre=/usr/local/bin/hauler store load {{ .EmbeddedRegistryTar }}
-  ExecStart=/usr/local/bin/hauler store serve
+  ExecStartPre=/bin/bash -c 'for file in /opt/hauler/*.tar.zst; do /usr/local/bin/hauler store load \$file; done'
+  ExecStart=/usr/local/bin/hauler store serve -p {{ .Port }}
   Restart=on-failure
 
   [Install]
   WantedBy=multi-user.target
 EOF
+
 
 systemctl enable eib-embedded-registry.service

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -120,10 +120,11 @@ type HelmChart struct {
 }
 
 type Kubernetes struct {
-	Version   string    `yaml:"version"`
-	Network   Network   `yaml:"network"`
-	Nodes     []Node    `yaml:"nodes"`
-	Manifests Manifests `yaml:"manifests"`
+	Version    string      `yaml:"version"`
+	Network    Network     `yaml:"network"`
+	Nodes      []Node      `yaml:"nodes"`
+	Manifests  Manifests   `yaml:"manifests"`
+	HelmCharts []HelmChart `yaml:"charts"`
 }
 
 type Network struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -126,9 +126,6 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)
 	assert.Equal(t, "rgcrprod.azurecr.us/longhornio/longhorn-ui:v1.5.1", embeddedArtifactRegistry.ContainerImages[1].Name)
 	assert.Equal(t, "carbide-key.pub", embeddedArtifactRegistry.ContainerImages[1].SupplyChainKey)
-	assert.Equal(t, "rancher", embeddedArtifactRegistry.HelmCharts[0].Name)
-	assert.Equal(t, "https://releases.rancher.com/server-charts/stable", embeddedArtifactRegistry.HelmCharts[0].RepoURL)
-	assert.Equal(t, "2.8.0", embeddedArtifactRegistry.HelmCharts[0].Version)
 
 	// Kubernetes
 	kubernetes := definition.Kubernetes
@@ -152,6 +149,9 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "agent", kubernetes.Nodes[4].Type)
 	assert.Equal(t, false, kubernetes.Nodes[4].First)
 	assert.Equal(t, "https://k8s.io/examples/application/nginx-app.yaml", kubernetes.Manifests.URLs[0])
+	assert.Equal(t, "rancher", kubernetes.HelmCharts[0].Name)
+	assert.Equal(t, "https://releases.rancher.com/server-charts/stable", kubernetes.HelmCharts[0].RepoURL)
+	assert.Equal(t, "2.8.0", kubernetes.HelmCharts[0].Version)
 }
 
 func TestParseBadConfig(t *testing.T) {

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -58,10 +58,6 @@ embeddedArtifactRegistry:
     - name: hello-world:latest
     - name: rgcrprod.azurecr.us/longhornio/longhorn-ui:v1.5.1
       supplyChainKey: carbide-key.pub
-  charts:
-    - name: rancher
-      repoURL: https://releases.rancher.com/server-charts/stable
-      version: 2.8.0
 kubernetes:
   version: v1.29.0+rke2r1
   network:
@@ -82,3 +78,7 @@ kubernetes:
   manifests:
     urls:
       - https://k8s.io/examples/application/nginx-app.yaml
+  charts:
+    - name: rancher
+      repoURL: https://releases.rancher.com/server-charts/stable
+      version: 2.8.0

--- a/pkg/image/validation/kubernetes_test.go
+++ b/pkg/image/validation/kubernetes_test.go
@@ -375,3 +375,92 @@ func TestValidateManifestURLs(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateHelmCharts(t *testing.T) {
+	tests := map[string]struct {
+		Kubernetes             image.Kubernetes
+		ExpectedFailedMessages []string
+	}{
+		`no helm charts`: {
+			Kubernetes: image.Kubernetes{},
+		},
+		`valid charts`: {
+			Kubernetes: image.Kubernetes{
+				HelmCharts: []image.HelmChart{
+					{
+						Name:    "foo",
+						RepoURL: "http://valid.com", // shows http:// is allowed
+						Version: "1.0",
+					},
+					{
+						Name:    "bar",
+						RepoURL: "https://valid.com", // shows https:// is allowed
+						Version: "2.0",
+					},
+				},
+			},
+		},
+		`missing fields`: {
+			Kubernetes: image.Kubernetes{
+				HelmCharts: []image.HelmChart{
+					{},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				"The 'name' field is required for each entry in 'charts'.",
+				"The 'repoURL' field is required for each entry in 'charts'.",
+				"The 'version' field is required for each entry in 'charts'.",
+			},
+		},
+		`duplicate chart`: {
+			Kubernetes: image.Kubernetes{
+				HelmCharts: []image.HelmChart{
+					{
+						Name:    "foo",
+						RepoURL: "http://foo.com",
+						Version: "1.0",
+					},
+					{
+						Name:    "foo",
+						RepoURL: "https://bar.com",
+						Version: "2.0",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				"Duplicate chart name 'foo' found in the 'charts' section.",
+			},
+		},
+		`invalid repo`: {
+			Kubernetes: image.Kubernetes{
+				HelmCharts: []image.HelmChart{
+					{
+						Name:    "foo",
+						RepoURL: "example.com",
+						Version: "1.0",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				"The 'repoURL' field must begin with either 'http://' or 'https://'.",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ear := test.Kubernetes
+			failures := validateHelmCharts(&ear.HelmCharts)
+			assert.Len(t, failures, len(test.ExpectedFailedMessages))
+
+			var foundMessages []string
+			for _, foundValidation := range failures {
+				foundMessages = append(foundMessages, foundValidation.UserMessage)
+			}
+
+			for _, expectedMessage := range test.ExpectedFailedMessages {
+				assert.Contains(t, foundMessages, expectedMessage)
+			}
+		})
+	}
+}

--- a/pkg/image/validation/registry.go
+++ b/pkg/image/validation/registry.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
@@ -15,7 +14,6 @@ func validateEmbeddedArtifactRegistry(ctx *image.Context) []FailedValidation {
 	var failures []FailedValidation
 
 	failures = append(failures, validateContainerImages(&ctx.ImageDefinition.EmbeddedArtifactRegistry)...)
-	failures = append(failures, validateHelmCharts(&ctx.ImageDefinition.EmbeddedArtifactRegistry)...)
 
 	return failures
 }
@@ -38,46 +36,6 @@ func validateContainerImages(ear *image.EmbeddedArtifactRegistry) []FailedValida
 			})
 		}
 		seenContainerImages[cImage.Name] = true
-	}
-
-	return failures
-}
-
-func validateHelmCharts(ear *image.EmbeddedArtifactRegistry) []FailedValidation {
-	var failures []FailedValidation
-
-	charts := ear.HelmCharts
-	seenCharts := make(map[string]bool)
-	for _, chart := range charts {
-		if chart.Name == "" {
-			failures = append(failures, FailedValidation{
-				UserMessage: "The 'name' field is required for each entry in 'charts'.",
-			})
-		}
-
-		if chart.RepoURL == "" {
-			failures = append(failures, FailedValidation{
-				UserMessage: "The 'repoURL' field is required for each entry in 'charts'.",
-			})
-		} else if !strings.HasPrefix(chart.RepoURL, "http") {
-			failures = append(failures, FailedValidation{
-				UserMessage: "The 'repoURL' field must begin with either 'http://' or 'https://'.",
-			})
-		}
-
-		if chart.Version == "" {
-			failures = append(failures, FailedValidation{
-				UserMessage: "The 'version' field is required for each entry in 'charts'.",
-			})
-		}
-
-		if seenCharts[chart.Name] {
-			msg := fmt.Sprintf("Duplicate chart name '%s' found in the 'charts' section.", chart.Name)
-			failures = append(failures, FailedValidation{
-				UserMessage: msg,
-			})
-		}
-		seenCharts[chart.Name] = true
 	}
 
 	return failures

--- a/pkg/image/validation/registry_test.go
+++ b/pkg/image/validation/registry_test.go
@@ -49,7 +49,6 @@ func TestValidateEmbeddedArtifactRegistry(t *testing.T) {
 			},
 			ExpectedFailedMessages: []string{
 				"The 'name' field is required for each entry in 'images'.",
-				"The 'name' field is required for each entry in 'charts'.",
 			},
 		},
 	}
@@ -131,95 +130,6 @@ func TestValidateContainerImages(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ear := test.Registry
 			failures := validateContainerImages(&ear)
-			assert.Len(t, failures, len(test.ExpectedFailedMessages))
-
-			var foundMessages []string
-			for _, foundValidation := range failures {
-				foundMessages = append(foundMessages, foundValidation.UserMessage)
-			}
-
-			for _, expectedMessage := range test.ExpectedFailedMessages {
-				assert.Contains(t, foundMessages, expectedMessage)
-			}
-		})
-	}
-}
-
-func TestValidateHelmCharts(t *testing.T) {
-	tests := map[string]struct {
-		Registry               image.EmbeddedArtifactRegistry
-		ExpectedFailedMessages []string
-	}{
-		`no helm charts`: {
-			Registry: image.EmbeddedArtifactRegistry{},
-		},
-		`valid charts`: {
-			Registry: image.EmbeddedArtifactRegistry{
-				HelmCharts: []image.HelmChart{
-					{
-						Name:    "foo",
-						RepoURL: "http://valid.com", // shows http:// is allowed
-						Version: "1.0",
-					},
-					{
-						Name:    "bar",
-						RepoURL: "https://valid.com", // shows https:// is allowed
-						Version: "2.0",
-					},
-				},
-			},
-		},
-		`missing fields`: {
-			Registry: image.EmbeddedArtifactRegistry{
-				HelmCharts: []image.HelmChart{
-					{},
-				},
-			},
-			ExpectedFailedMessages: []string{
-				"The 'name' field is required for each entry in 'charts'.",
-				"The 'repoURL' field is required for each entry in 'charts'.",
-				"The 'version' field is required for each entry in 'charts'.",
-			},
-		},
-		`duplicate chart`: {
-			Registry: image.EmbeddedArtifactRegistry{
-				HelmCharts: []image.HelmChart{
-					{
-						Name:    "foo",
-						RepoURL: "http://foo.com",
-						Version: "1.0",
-					},
-					{
-						Name:    "foo",
-						RepoURL: "https://bar.com",
-						Version: "2.0",
-					},
-				},
-			},
-			ExpectedFailedMessages: []string{
-				"Duplicate chart name 'foo' found in the 'charts' section.",
-			},
-		},
-		`invalid repo`: {
-			Registry: image.EmbeddedArtifactRegistry{
-				HelmCharts: []image.HelmChart{
-					{
-						Name:    "foo",
-						RepoURL: "example.com",
-						Version: "1.0",
-					},
-				},
-			},
-			ExpectedFailedMessages: []string{
-				"The 'repoURL' field must begin with either 'http://' or 'https://'.",
-			},
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			ear := test.Registry
-			failures := validateHelmCharts(&ear)
 			assert.Len(t, failures, len(test.ExpectedFailedMessages))
 
 			var foundMessages []string


### PR DESCRIPTION
This PR contains a lot of restructuring based on the conversations we had. A lot of the tests need to be updated and this implementation is not complete but I’m putting it up as a draft to get a second set of eyes on it. There also may be some lingering parts that don’t necessarily make sense at the moment.

To this though, I’ve tested the current implementation and this is deploying exactly what was being deployed before the restructure without any change to the image definition file.