### PR TITLE
Cli UX Improvements

### DIFF
--- a/cmd/eib/main.go
+++ b/cmd/eib/main.go
@@ -172,7 +172,7 @@ func parseImageDefinition(cliArguments CLIArguments) *image.Definition {
 
 	configData, err := os.ReadFile(definitionFilePath)
 	if err != nil {
-		audit.AuditInfof("The specified definition file '%s' could be read. %s", definitionFilePath, checkLogMessage)
+		audit.AuditInfof("The specified definition file '%s' could not be read. %s", definitionFilePath, checkLogMessage)
 		zap.S().Error(err)
 		return nil
 	}

--- a/pkg/log/audit.go
+++ b/pkg/log/audit.go
@@ -28,21 +28,13 @@ func Auditf(message string, args ...any) {
 	doAudit(auditMe, nil)
 }
 
-func AuditError(err error) {
-	doAudit(err.Error(), nil)
-}
-
-func AuditAndLog(message string) {
+func AuditInfo(message string) {
 	doAudit(message, zap.S().Info)
 }
 
-func AuditfAndLog(message string, args ...any) {
+func AuditInfof(message string, args ...any) {
 	auditMe := fmt.Sprintf(message, args...)
 	doAudit(auditMe, zap.S().Info)
-}
-
-func AuditErrorAndLog(err error) {
-	doAudit(err.Error(), zap.S().Error)
 }
 
 func AuditComponentSuccessful(component string) {

--- a/pkg/log/audit.go
+++ b/pkg/log/audit.go
@@ -22,6 +22,15 @@ func Audit(message string) {
 	fmt.Println(message)
 }
 
+func Auditf(message string, args ...string) {
+	auditMe := fmt.Sprintf(message, args)
+	Audit(auditMe)
+}
+
+func AuditError(err error) {
+	Audit(err.Error())
+}
+
 func AuditComponentSuccessful(component string) {
 	message := formatComponentStatus(component, messageSuccess)
 	Audit(message)

--- a/pkg/log/audit.go
+++ b/pkg/log/audit.go
@@ -23,8 +23,8 @@ func Audit(message string) {
 	doAudit(message, nil)
 }
 
-func Auditf(message string, args ...string) {
-	auditMe := fmt.Sprintf(message, args)
+func Auditf(message string, args ...any) {
+	auditMe := fmt.Sprintf(message, args...)
 	doAudit(auditMe, nil)
 }
 
@@ -36,8 +36,8 @@ func AuditAndLog(message string) {
 	doAudit(message, zap.S().Info)
 }
 
-func AuditfAndLog(message string, args ...string) {
-	auditMe := fmt.Sprintf(message, args)
+func AuditfAndLog(message string, args ...any) {
+	auditMe := fmt.Sprintf(message, args...)
 	doAudit(auditMe, zap.S().Info)
 }
 

--- a/pkg/log/audit.go
+++ b/pkg/log/audit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/zap"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -19,16 +20,29 @@ const (
 // Audit displays a message to the user. This shouldn't be used for debug logging purposes; all
 // messages passed in here should be user-readable.
 func Audit(message string) {
-	fmt.Println(message)
+	doAudit(message, nil)
 }
 
 func Auditf(message string, args ...string) {
 	auditMe := fmt.Sprintf(message, args)
-	Audit(auditMe)
+	doAudit(auditMe, nil)
 }
 
 func AuditError(err error) {
-	Audit(err.Error())
+	doAudit(err.Error(), nil)
+}
+
+func AuditAndLog(message string) {
+	doAudit(message, zap.S().Info)
+}
+
+func AuditfAndLog(message string, args ...string) {
+	auditMe := fmt.Sprintf(message, args)
+	doAudit(auditMe, zap.S().Info)
+}
+
+func AuditErrorAndLog(err error) {
+	doAudit(err.Error(), zap.S().Error)
 }
 
 func AuditComponentSuccessful(component string) {
@@ -44,6 +58,13 @@ func AuditComponentSkipped(component string) {
 func AuditComponentFailed(component string) {
 	message := formatComponentStatus(component, messageFailed)
 	Audit(message)
+}
+
+func doAudit(message string, logFunc func(args ...any)) {
+	fmt.Println(message)
+	if logFunc != nil {
+		logFunc(message)
+	}
 }
 
 func formatComponentStatus(component, status string) string {


### PR DESCRIPTION
Prior to this patch, the output when running EIB with a definition file that doesn't exist is:
```
2024/01/23 15:42:18 CLI arguments could not be parsed: parsing image definition file raw-image.yaml: image definition file "raw-image.yaml" cannot be read: open /eib/raw-image.yaml: no such file or directory
```

This patch uses a similar approach as with image validation errors to display more user-friendly messages in the case of most user errors. The following are examples of various ways that EIB can fail to even start building an image:

### Missing Image Configuration Directory
_Note: This is the only step that occurs prior to initializing logging_
```
$ podman run --rm -it -v ~/Code/eib/:/not-there eib:dev /bin/eib -config-file ./raw-simple.yaml -config-dir /eib -build-dir /eib/_build
The specified image configuration directory '/eib' could not be found.
```

### Image Definition File does not exist
```
$ eib-run not-there
The specified definition file '/eib/not-there' could not be found.
```

### Unparsable (not-YAML) Image Definition File
```
$ eib-run not-yaml.yaml
The image definition file '/eib/not-yaml.yaml' could not be parsed. Please check the eib-build.log file under the build directory for more information.

$ cat _build/build-Jan23_20-22-06/eib-build.log
2024-01-24T19:32:17.968Z	INFO	log/audit.go:58	The image definition file '/eib/not-yaml.yaml' could not be parsed.
2024-01-24T19:32:17.968Z	ERROR	eib/main.go:176	could not parse the image definition: yaml: did not find expected whitespace or line break
main.parseImageDefinition
	/src/cmd/eib/main.go:176
main.main
	/src/cmd/eib/main.go:59
runtime.main
	/usr/lib64/go/1.21/src/runtime/proc.go:267
```

### Invalid Definition File (fails our semantic checks)
_Note: This has changed from the previous patch to point users towards the log file._
```
$ eib-run raw-invalid.yaml
Image definition validation found the following errors:
  Image
    The 'arch' field is required in the 'image' section.
Please check the eib-build.log file under the build directory for more information.

$ cat _build/build-Jan23_20-23-03/eib-build.log
2024-01-24T19:33:03.935Z	ERROR	eib/main.go:226	image definition validation failures:
The 'arch' field is required in the 'image' section.

main.isImageDefinitionValid
	/src/cmd/eib/main.go:226
main.main
	/src/cmd/eib/main.go:66
runtime.main
	/usr/lib64/go/1.21/src/runtime/proc.go:267
```

### Validate Flag is Specified
```
$ eib-run raw-simple.yaml -validate
The specified image definition is valid.

$ cat _build/build-Jan23_20-23-41/eib-build.log
2024-01-23T20:23:41.008Z	INFO	log/audit.go:66	The specified image definition is valid.
```

### With RPM Dependency Resolution
_Note: This is currently failing for me on HEAD, unrelated to these changes._
```
$ eib-run raw-rpms.yaml
The services for RPM dependency resolution failed to start. Please check the eib-build.log file under the build directory for more information.

$ cat _build/build-Jan23_20-28-30/eib-build.log
2024-01-24T19:34:46.417Z	INFO	log/audit.go:58	The services for RPM dependency resolution failed to start.
2024-01-24T19:34:46.417Z	ERROR	eib/main.go:243	creating new podman connection: unable to connect to Podman socket: Get "http://d/v4.8.3/libpod/_ping": dial unix /run/podman/podman.sock: connect: no such file or directory
main.bootstrapRpmDependencyServices
	/src/cmd/eib/main.go:243
main.main
	/src/cmd/eib/main.go:77
runtime.main
	/usr/lib64/go/1.21/src/runtime/proc.go:267```
