### PR TITLE
fixed super unlikely timing bug

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -85,7 +85,7 @@ func SetupBuildDirectory(rootDir string) (buildDir string, combustionDir string,
 	}
 
 	combustionDir = filepath.Join(buildDir, "combustion")
-	if err = os.Mkdir(combustionDir, os.ModePerm); err != nil {
+	if err = os.MkdirAll(combustionDir, os.ModePerm); err != nil {
 		return "", "", fmt.Errorf("creating a combustion directory: %w", err)
 	}
 


### PR DESCRIPTION
I accidentally bumped into the bug by running two builds too close to each other (only possible if the validation fails). 