### PR TITLE
Introduce file caching

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -81,7 +81,10 @@ func identifierHash(identifier string) (string, error) {
 		return "", err
 	}
 
-	return strconv.FormatUint(h.Sum64(), 10), nil
+	hash := strconv.FormatUint(h.Sum64(), 10)
+
+	zap.S().Debugf("Generated hash '%s' from identifier '%s'", hash, identifier)
+	return hash, nil
 }
 
 func exists(path string) bool {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,97 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"go.uber.org/zap"
+)
+
+type Cache struct {
+	cacheDir string
+}
+
+func New(rootDir string) (*Cache, error) {
+	cacheDir := filepath.Join(rootDir, "cache")
+	if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("creating a cache directory: %w", err)
+	}
+
+	return &Cache{cacheDir: cacheDir}, nil
+}
+
+func (cache *Cache) Get(fileIdentifier string) (path string, err error) {
+	path, err = cache.identifierPath(fileIdentifier)
+	if err != nil {
+		return "", fmt.Errorf("searching for identifier '%s' in cache: %w", fileIdentifier, err)
+	}
+
+	if !exists(path) {
+		return "", fs.ErrNotExist
+	}
+
+	return path, nil
+}
+
+func (cache *Cache) Put(fileIdentifier string, reader io.Reader) error {
+	path, err := cache.identifierPath(fileIdentifier)
+	if err != nil {
+		return fmt.Errorf("searching for identifier '%s' in cache: %w", fileIdentifier, err)
+	}
+
+	if exists(path) {
+		zap.S().Warnf("File with identifier '%s' already exists in cache", fileIdentifier)
+		return fs.ErrExist
+	}
+
+	zap.S().Infof("Storing file with identifier '%s' in cache", fileIdentifier)
+
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err = io.Copy(file, reader); err != nil {
+		return fmt.Errorf("storing file: %w", err)
+	}
+
+	return nil
+}
+
+func (cache *Cache) identifierPath(fileIdentifier string) (string, error) {
+	identifier, err := identifierHash(fileIdentifier)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(cache.cacheDir, identifier), nil
+}
+
+func identifierHash(identifier string) (string, error) {
+	h := fnv.New64()
+
+	if _, err := h.Write([]byte(identifier)); err != nil {
+		return "", err
+	}
+
+	return strconv.FormatUint(h.Sum64(), 10), nil
+}
+
+func exists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			zap.S().Warnf("Looking for file with identifier failed: %v", err)
+		}
+
+		return false
+	}
+
+	return true
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,62 @@
+package cache
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setup(t *testing.T) (cache *Cache, teardown func()) {
+	cache, err := New("test-cache")
+	require.NoError(t, err)
+
+	return cache, func() {
+		assert.NoError(t, os.RemoveAll("test-cache"))
+	}
+}
+
+func TestCache(t *testing.T) {
+	cache, teardown := setup(t)
+	defer teardown()
+
+	fileIdentifier := "some-cool-filename"
+	fileContents := "some-data"
+
+	require.NoError(t, cache.Put(fileIdentifier, strings.NewReader(fileContents)))
+
+	path, err := cache.Get(fileIdentifier)
+	require.NoError(t, err)
+	require.FileExists(t, path)
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fileContents, string(b))
+}
+
+func TestCache_MissingEntry(t *testing.T) {
+	cache, teardown := setup(t)
+	defer teardown()
+
+	fileIdentifier := "some-cool-filename"
+
+	path, err := cache.Get(fileIdentifier)
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	assert.NoFileExists(t, path)
+}
+
+func TestCache_DoubleInsert(t *testing.T) {
+	cache, teardown := setup(t)
+	defer teardown()
+
+	fileIdentifier := "https://raw.githubusercontent.com/suse-edge/edge-image-builder/main/README.md"
+	fileContents := "some-data"
+
+	require.NoError(t, cache.Put(fileIdentifier, strings.NewReader(fileContents)))
+	assert.ErrorIs(t, cache.Put(fileIdentifier, strings.NewReader(fileContents)), fs.ErrExist)
+}

--- a/pkg/http/download_integration_test.go
+++ b/pkg/http/download_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package http
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadFile_Successful_NoCache(t *testing.T) {
+	url := "https://raw.githubusercontent.com/suse-edge/edge-image-builder/main/README.md"
+	path := "README.md"
+
+	require.NoError(t, DownloadFile(context.Background(), url, path, nil))
+	defer func() {
+		assert.NoError(t, os.Remove(path))
+	}()
+
+	assert.FileExists(t, path)
+}
+
+func TestDownloadFile_Successful_Cache(t *testing.T) {
+	url := "https://raw.githubusercontent.com/suse-edge/edge-image-builder/main/README.md"
+	path := "README.md"
+
+	var sb strings.Builder
+
+	require.NoError(t, DownloadFile(context.Background(), url, path, &sb))
+	defer func() {
+		assert.NoError(t, os.Remove(path))
+	}()
+
+	require.FileExists(t, path)
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, sb.String(), string(b))
+}

--- a/pkg/http/download_test.go
+++ b/pkg/http/download_test.go
@@ -1,10 +1,7 @@
-//go:build integration
-
 package http
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,27 +39,13 @@ func TestDownloadFile(t *testing.T) {
 			path:        "downloads/abc",
 			expectedErr: "creating file: open downloads/abc: no such file or directory",
 		},
-		{
-			name: "Successful download",
-			ctx:  context.Background(),
-			url:  "https://raw.githubusercontent.com/suse-edge/edge-image-builder/main/README.md",
-			path: "README.md",
-		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := DownloadFile(test.ctx, test.url, test.path)
-			if test.expectedErr != "" {
-				require.Error(t, err)
-				assert.EqualError(t, err, test.expectedErr)
-			} else {
-				require.NoError(t, err)
-
-				_, err := os.Stat(test.path)
-				assert.NoError(t, err)
-				assert.NoError(t, os.Remove(test.path))
-			}
+			err := DownloadFile(test.ctx, test.url, test.path, nil)
+			require.Error(t, err)
+			assert.EqualError(t, err, test.expectedErr)
 		})
 	}
 }

--- a/pkg/kubernetes/artefact_downloader.go
+++ b/pkg/kubernetes/artefact_downloader.go
@@ -2,14 +2,20 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 	"github.com/suse-edge/edge-image-builder/pkg/http"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -29,7 +35,14 @@ const (
 	rke2MultusImages = "rke2-images-multus.linux-%s.tar.zst"
 )
 
-type ArtefactDownloader struct{}
+type cache interface {
+	Get(artefact string) (filepath string, err error)
+	Put(artefact string, reader io.Reader) error
+}
+
+type ArtefactDownloader struct {
+	Cache cache
+}
 
 func (d ArtefactDownloader) DownloadArtefacts(arch image.Arch, version, cni string, multusEnabled bool, destinationPath string) (installPath, imagesPath string, err error) {
 	if !strings.Contains(version, image.KubernetesDistroRKE2) {
@@ -57,12 +70,12 @@ func (d ArtefactDownloader) DownloadArtefacts(arch image.Arch, version, cni stri
 		return "", "", fmt.Errorf("gathering RKE2 image artefacts: %w", err)
 	}
 
-	if err = downloadArtefacts(artefacts, rke2ReleaseURL, version, imagesDestination); err != nil {
+	if err = d.downloadArtefacts(artefacts, rke2ReleaseURL, version, imagesDestination); err != nil {
 		return "", "", fmt.Errorf("downloading RKE2 image artefacts: %w", err)
 	}
 
 	artefacts = installerArtefacts(arch)
-	if err = downloadArtefacts(artefacts, rke2ReleaseURL, version, installDestination); err != nil {
+	if err = d.downloadArtefacts(artefacts, rke2ReleaseURL, version, installDestination); err != nil {
 		return "", "", fmt.Errorf("downloading RKE2 install artefacts: %w", err)
 	}
 
@@ -115,15 +128,70 @@ func imageArtefacts(cni string, multusEnabled bool, arch image.Arch) ([]string, 
 	return artefacts, nil
 }
 
-func downloadArtefacts(artefacts []string, releaseURL, version, destinationPath string) error {
+func (d ArtefactDownloader) downloadArtefacts(artefacts []string, releaseURL, version, destinationPath string) error {
 	for _, artefact := range artefacts {
 		url := fmt.Sprintf(releaseURL, version, artefact)
 		path := filepath.Join(destinationPath, artefact)
 
-		if err := http.DownloadFile(context.Background(), url, path, nil); err != nil {
-			return fmt.Errorf("downloading artefact '%s': %w", artefact, err)
+		copied, err := d.copyArtefactFromCache(artefact, path)
+		if err != nil {
+			return fmt.Errorf("retrieving artefact '%s' from cache: %w", artefact, err)
+		}
+
+		if !copied {
+			if err = d.downloadArtefact(url, path, artefact); err != nil {
+				return fmt.Errorf("downloading artefact '%s': %w", artefact, err)
+			}
 		}
 	}
 
 	return nil
+}
+
+func (d ArtefactDownloader) copyArtefactFromCache(artefact, destPath string) (bool, error) {
+	sourcePath, err := d.Cache.Get(artefact)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("querying cache: %w", err)
+	}
+
+	zap.S().Infof("Copying artefact '%s' from cache", artefact)
+
+	if err = fileio.CopyFile(sourcePath, destPath, fileio.NonExecutablePerms); err != nil {
+		return false, fmt.Errorf("copying from cache: %w", err)
+	}
+
+	return true, nil
+}
+
+func (d ArtefactDownloader) downloadArtefact(url, path, artefact string) error {
+	reader, writer := io.Pipe()
+
+	errGroup, ctx := errgroup.WithContext(context.Background())
+
+	errGroup.Go(func() error {
+		defer func() {
+			if err := writer.Close(); err != nil {
+				zap.S().Warnf("Closing pipe writer failed unexpectedly: %v", err)
+			}
+		}()
+
+		if err := http.DownloadFile(ctx, url, path, writer); err != nil {
+			return fmt.Errorf("downloading artefact: %w", err)
+		}
+		return nil
+	})
+
+	errGroup.Go(func() error {
+		if err := d.Cache.Put(artefact, reader); err != nil {
+			return fmt.Errorf("caching artefact: %w", err)
+		}
+
+		return nil
+	})
+
+	return errGroup.Wait()
 }

--- a/pkg/kubernetes/artefact_downloader.go
+++ b/pkg/kubernetes/artefact_downloader.go
@@ -120,7 +120,7 @@ func downloadArtefacts(artefacts []string, releaseURL, version, destinationPath 
 		url := fmt.Sprintf(releaseURL, version, artefact)
 		path := filepath.Join(destinationPath, artefact)
 
-		if err := http.DownloadFile(context.Background(), url, path); err != nil {
+		if err := http.DownloadFile(context.Background(), url, path, nil); err != nil {
 			return fmt.Errorf("downloading artefact '%s': %w", artefact, err)
 		}
 	}

--- a/pkg/registry/manifests.go
+++ b/pkg/registry/manifests.go
@@ -140,7 +140,7 @@ func downloadManifests(manifestURLs []string, destPath string) ([]string, error)
 		filePath := filepath.Join(destPath, fmt.Sprintf("manifest-%d.yaml", index+1))
 		manifestPaths = append(manifestPaths, filePath)
 
-		if err := http.DownloadFile(context.Background(), manifestURL, filePath); err != nil {
+		if err := http.DownloadFile(context.Background(), manifestURL, filePath, nil); err != nil {
 			return nil, fmt.Errorf("downloading manifest '%s': %w", manifestURL, err)
 		}
 	}


### PR DESCRIPTION
- Introduces basic file caching mechanism
- Uses a `cache` directory in the root build dir

Examples:
```
suse-edge380@edge380:~/atanas/eib> ll _build/
total 0
drwxr-xr-x 1 suse-edge380 users 298 Jan 26 07:12 build-Jan26_12-11-25
drwxr-xr-x 1 suse-edge380 users 298 Jan 26 07:12 build-Jan26_12-12-23
drwxr-xr-x 1 suse-edge380 users 298 Jan 26 07:14 build-Jan26_12-13-48
drwxr-xr-x 1 suse-edge380 users 312 Jan 26 07:14 cache
```

```
suse-edge380@edge380:~/atanas/eib> ll _build/cache/
total 2349668
-rw-r--r-- 1 suse-edge380 users  28110568 Jan 26 07:11 11240812976698639811
-rw-r--r-- 1 suse-edge380 users      3626 Jan 26 07:14 12598788008564349138
-rw-r--r-- 1 suse-edge380 users 398552443 Jan 26 07:14 12731077518120169689
-rw-r--r-- 1 suse-edge380 users  28127289 Jan 26 07:14 14781665220435981056
-rw-r--r-- 1 suse-edge380 users 777780488 Jan 26 07:11 1929961855871891474
-rw-r--r-- 1 suse-edge380 users      3626 Jan 26 07:11 2370503944097354381
-rw-r--r-- 1 suse-edge380 users 774918501 Jan 26 07:13 6182514610487109539
-rw-r--r-- 1 suse-edge380 users 398552483 Jan 26 07:11 8116377040248119712
```

First build:
```
2024-01-26T12:11:25.032Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.5+rke2r1/rke2-images-core.linux-amd64.tar.zst' in cache
2024-01-26T12:11:25.032Z	INFO	http/download.go:22	Downloading file 'rke2-images-core.linux-amd64.tar.zst' from 'https://github.com/rancher/rke2/releases/download/v1.28.5+rke2r1/rke2-images-core.linux-amd64.tar.zst' to '/eib/_build/build-Jan26_12-11-25/combustion/kubernetes/images'...
2024-01-26T12:11:33.562Z	INFO	http/download.go:58	Downloading file 'rke2-images-core.linux-amd64.tar.zst' completed
2024-01-26T12:11:33.562Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.5+rke2r1/rke2-images-cilium.linux-amd64.tar.zst' in cache
2024-01-26T12:11:33.562Z	INFO	http/download.go:22	Downloading file 'rke2-images-cilium.linux-amd64.tar.zst' from 'https://github.com/rancher/rke2/releases/download/v1.28.5+rke2r1/rke2-images-cilium.linux-amd64.tar.zst' to '/eib/_build/build-Jan26_12-11-25/combustion/kubernetes/images'...
2024-01-26T12:11:37.494Z	INFO	http/download.go:58	Downloading file 'rke2-images-cilium.linux-amd64.tar.zst' completed
2024-01-26T12:11:37.495Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.5+rke2r1/rke2.linux-amd64.tar.gz' in cache
2024-01-26T12:11:37.495Z	INFO	http/download.go:22	Downloading file 'rke2.linux-amd64.tar.gz' from 'https://github.com/rancher/rke2/releases/download/v1.28.5+rke2r1/rke2.linux-amd64.tar.gz' to '/eib/_build/build-Jan26_12-11-25/combustion/kubernetes/install'...
2024-01-26T12:11:38.150Z	INFO	http/download.go:58	Downloading file 'rke2.linux-amd64.tar.gz' completed
2024-01-26T12:11:38.150Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.5+rke2r1/sha256sum-amd64.txt' in cache
2024-01-26T12:11:38.150Z	INFO	http/download.go:22	Downloading file 'sha256sum-amd64.txt' from 'https://github.com/rancher/rke2/releases/download/v1.28.5+rke2r1/sha256sum-amd64.txt' to '/eib/_build/build-Jan26_12-11-25/combustion/kubernetes/install'...
2024-01-26T12:11:38.502Z	INFO	http/download.go:58	Downloading file 'sha256sum-amd64.txt' completed
```

Second build:
```
2024-01-26T12:12:23.194Z	INFO	kubernetes/artefact_downloader.go:162	Copying artefact with identifier 'v1.28.5+rke2r1/rke2-images-core.linux-amd64.tar.zst' from cache
2024-01-26T12:12:23.194Z	INFO	kubernetes/artefact_downloader.go:162	Copying artefact with identifier 'v1.28.5+rke2r1/rke2-images-cilium.linux-amd64.tar.zst' from cache
2024-01-26T12:12:23.194Z	INFO	kubernetes/artefact_downloader.go:162	Copying artefact with identifier 'v1.28.5+rke2r1/rke2.linux-amd64.tar.gz' from cache
2024-01-26T12:12:23.194Z	INFO	kubernetes/artefact_downloader.go:162	Copying artefact with identifier 'v1.28.5+rke2r1/sha256sum-amd64.txt' from cache
```

Third build (different RKE2 version):
```
2024-01-26T12:13:48.213Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.4+rke2r1/rke2-images-core.linux-amd64.tar.zst' in cache
2024-01-26T12:13:48.213Z	INFO	http/download.go:22	Downloading file 'rke2-images-core.linux-amd64.tar.zst' from 'https://github.com/rancher/rke2/releases/download/v1.28.4+rke2r1/rke2-images-core.linux-amd64.tar.zst' to '/eib/_build/build-Jan26_12-13-48/combustion/kubernetes/images'...
2024-01-26T12:13:56.285Z	INFO	http/download.go:58	Downloading file 'rke2-images-core.linux-amd64.tar.zst' completed
2024-01-26T12:13:56.285Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.4+rke2r1/rke2-images-cilium.linux-amd64.tar.zst' in cache
2024-01-26T12:13:56.285Z	INFO	http/download.go:22	Downloading file 'rke2-images-cilium.linux-amd64.tar.zst' from 'https://github.com/rancher/rke2/releases/download/v1.28.4+rke2r1/rke2-images-cilium.linux-amd64.tar.zst' to '/eib/_build/build-Jan26_12-13-48/combustion/kubernetes/images'...
2024-01-26T12:14:00.691Z	INFO	http/download.go:58	Downloading file 'rke2-images-cilium.linux-amd64.tar.zst' completed
2024-01-26T12:14:00.691Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.4+rke2r1/rke2.linux-amd64.tar.gz' in cache
2024-01-26T12:14:00.691Z	INFO	http/download.go:22	Downloading file 'rke2.linux-amd64.tar.gz' from 'https://github.com/rancher/rke2/releases/download/v1.28.4+rke2r1/rke2.linux-amd64.tar.gz' to '/eib/_build/build-Jan26_12-13-48/combustion/kubernetes/install'...
2024-01-26T12:14:01.422Z	INFO	http/download.go:58	Downloading file 'rke2.linux-amd64.tar.gz' completed
2024-01-26T12:14:01.422Z	INFO	cache/cache.go:53	Storing file with identifier 'v1.28.4+rke2r1/sha256sum-amd64.txt' in cache
2024-01-26T12:14:01.422Z	INFO	http/download.go:22	Downloading file 'sha256sum-amd64.txt' from 'https://github.com/rancher/rke2/releases/download/v1.28.4+rke2r1/sha256sum-amd64.txt' to '/eib/_build/build-Jan26_12-13-48/combustion/kubernetes/install'...
2024-01-26T12:14:01.833Z	INFO	http/download.go:58	Downloading file 'sha256sum-amd64.txt' completed
```