### PR TITLE
Use UUID for RKE2 cluster token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	// podman mod file https://github.com/containers/podman/blob/v4.8.3/go.mod#L14
 	github.com/containers/buildah v1.33.2
 	github.com/containers/podman/v4 v4.8.3
+	github.com/google/uuid v1.6.0
 	github.com/schollz/progressbar/v3 v3.14.1
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
+	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -65,7 +67,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-containerregistry v0.16.1 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
-	github.com/google/uuid v1.4.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/schema v1.2.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -127,7 +128,6 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
-	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,8 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
-github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
@@ -1138,8 +1138,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
-golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/kubernetes/cluster.go
+++ b/pkg/kubernetes/cluster.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 	"github.com/suse-edge/edge-image-builder/pkg/log"
 	"go.uber.org/zap"
@@ -150,7 +151,7 @@ func setClusterToken(config map[string]any) {
 		return
 	}
 
-	token := "foobar" // TODO: generate
+	token := uuid.NewString()
 
 	zap.S().Infof("Generated cluster token: %s", token)
 	config[tokenKey] = token

--- a/pkg/kubernetes/cluster_test.go
+++ b/pkg/kubernetes/cluster_test.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
@@ -78,23 +79,26 @@ func TestNewCluster_MultiNode_MissingConfig(t *testing.T) {
 	assert.Equal(t, "node1.suse.com", cluster.InitialiserName)
 
 	require.NotNil(t, cluster.InitialiserConfig)
+	clusterToken := cluster.InitialiserConfig["token"]
+	require.NotPanics(t, func() {
+		uuid.MustParse(clusterToken.(string))
+	})
 	assert.Equal(t, "cilium", cluster.InitialiserConfig["cni"])
 	assert.Equal(t, []string{"192.168.122.50", "api.suse.edge.com"}, cluster.InitialiserConfig["tls-san"])
-	assert.Equal(t, "foobar", cluster.InitialiserConfig["token"])
 	assert.Nil(t, cluster.InitialiserConfig["server"])
 	assert.Nil(t, cluster.InitialiserConfig["selinux"])
 
 	require.NotNil(t, cluster.ServerConfig)
 	assert.Equal(t, "cilium", cluster.ServerConfig["cni"])
 	assert.Equal(t, []string{"192.168.122.50", "api.suse.edge.com"}, cluster.ServerConfig["tls-san"])
-	assert.Equal(t, "foobar", cluster.ServerConfig["token"])
+	assert.Equal(t, clusterToken, cluster.ServerConfig["token"])
 	assert.Equal(t, "https://192.168.122.50:9345", cluster.ServerConfig["server"])
 	assert.Nil(t, cluster.ServerConfig["selinux"])
 
 	require.NotNil(t, cluster.AgentConfig)
 	assert.Equal(t, "cilium", cluster.AgentConfig["cni"])
 	assert.Equal(t, []string{"192.168.122.50", "api.suse.edge.com"}, cluster.AgentConfig["tls-san"])
-	assert.Equal(t, "foobar", cluster.AgentConfig["token"])
+	assert.Equal(t, clusterToken, cluster.AgentConfig["token"])
 	assert.Equal(t, "https://192.168.122.50:9345", cluster.AgentConfig["server"])
 	assert.Nil(t, cluster.ServerConfig["debug"])
 }


### PR DESCRIPTION
- Generate a UUID as a [short](https://docs.k3s.io/cli/token#short) cluster token for RKE2 clusters