### PR TITLE
Complete air-gapped manifest deployment

### DIFF
--- a/pkg/combustion/kubernetes.go
+++ b/pkg/combustion/kubernetes.go
@@ -124,11 +124,12 @@ func configureRKE2(ctx *image.Context) (string, error) {
 	}
 
 	templateValues := map[string]any{
-		"apiVIP":        ctx.ImageDefinition.Kubernetes.Network.APIVIP,
-		"apiHost":       ctx.ImageDefinition.Kubernetes.Network.APIHost,
-		"installPath":   installPath,
-		"imagesPath":    imagesPath,
-		"manifestsPath": manifestsPath,
+		"apiVIP":             ctx.ImageDefinition.Kubernetes.Network.APIVIP,
+		"apiHost":            ctx.ImageDefinition.Kubernetes.Network.APIHost,
+		"installPath":        installPath,
+		"imagesPath":         imagesPath,
+		"manifestsPath":      manifestsPath,
+		"registriesManifest": registriesManifestFileName,
 	}
 
 	singleNode := len(ctx.ImageDefinition.Kubernetes.Nodes) < 2

--- a/pkg/combustion/kubernetes.go
+++ b/pkg/combustion/kubernetes.go
@@ -124,12 +124,12 @@ func configureRKE2(ctx *image.Context) (string, error) {
 	}
 
 	templateValues := map[string]any{
-		"apiVIP":             ctx.ImageDefinition.Kubernetes.Network.APIVIP,
-		"apiHost":            ctx.ImageDefinition.Kubernetes.Network.APIHost,
-		"installPath":        installPath,
-		"imagesPath":         imagesPath,
-		"manifestsPath":      manifestsPath,
-		"registriesManifest": registriesManifestFileName,
+		"apiVIP":          ctx.ImageDefinition.Kubernetes.Network.APIVIP,
+		"apiHost":         ctx.ImageDefinition.Kubernetes.Network.APIHost,
+		"installPath":     installPath,
+		"imagesPath":      imagesPath,
+		"manifestsPath":   manifestsPath,
+		"registryMirrors": registryMirrorsFileName,
 	}
 
 	singleNode := len(ctx.ImageDefinition.Kubernetes.Nodes) < 2

--- a/pkg/combustion/kubernetes_integration_test.go
+++ b/pkg/combustion/kubernetes_integration_test.go
@@ -108,7 +108,7 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 	assert.Contains(t, contents, "systemctl enable rke2-server.service")
 	assert.Contains(t, contents, "mkdir -p /var/lib/rancher/rke2/server/manifests/")
 	assert.Contains(t, contents, "cp kubernetes/manifests/* /var/lib/rancher/rke2/server/manifests/")
-	assert.Contains(t, contents, "cp "+registriesManifestFileName+" /etc/rancher/rke2/registries.yaml")
+	assert.Contains(t, contents, "cp "+registryMirrorsFileName+" /etc/rancher/rke2/registries.yaml")
 
 	// Config file assertions
 	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")

--- a/pkg/combustion/kubernetes_integration_test.go
+++ b/pkg/combustion/kubernetes_integration_test.go
@@ -108,6 +108,7 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 	assert.Contains(t, contents, "systemctl enable rke2-server.service")
 	assert.Contains(t, contents, "mkdir -p /var/lib/rancher/rke2/server/manifests/")
 	assert.Contains(t, contents, "cp kubernetes/manifests/* /var/lib/rancher/rke2/server/manifests/")
+	assert.Contains(t, contents, "cp "+registriesManifestFileName+" /etc/rancher/rke2/registries.yaml")
 
 	// Config file assertions
 	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -35,7 +35,7 @@ var haulerManifest string
 var registryScript string
 
 //go:embed templates/registries.yaml.tpl
-var k8sRegistriesManifest string
+var k8sRegistryMirrors string
 
 func configureRegistry(ctx *image.Context) ([]string, error) {
 	if !IsEmbeddedArtifactRegistryConfigured(ctx) {
@@ -260,7 +260,7 @@ func writeRegistryMirrors(ctx *image.Context, hostnames []string) error {
 		Port:      registryPort,
 	}
 
-	data, err := template.Parse(registryMirrorsFileName, k8sRegistriesManifest, registriesDef)
+	data, err := template.Parse(registryMirrorsFileName, k8sRegistryMirrors, registriesDef)
 	if err != nil {
 		return fmt.Errorf("applying template to %s: %w", registryMirrorsFileName, err)
 	}

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -254,12 +254,12 @@ func TestWriteRegistriesManifestValid(t *testing.T) {
 	hostnames := []string{"hello-world:latest", "rgcrprod.azurecr.us/longhornio/longhorn-ui:v1.5.1", "quay.io"}
 
 	// Test
-	err := writeRegistriesManifest(ctx, hostnames)
+	err := writeRegistryMirrors(ctx, hostnames)
 
 	// Verify
 	require.NoError(t, err)
 
-	manifestFileName := filepath.Join(ctx.CombustionDir, registriesManifestFileName)
+	manifestFileName := filepath.Join(ctx.CombustionDir, registryMirrorsFileName)
 	_, err = os.Stat(manifestFileName)
 	require.NoError(t, err)
 

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -245,3 +245,52 @@ func TestIsEmbeddedArtifactRegistryConfigured(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteRegistriesManifestValid(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	hostnames := []string{"hello-world:latest", "rgcrprod.azurecr.us/longhornio/longhorn-ui:v1.5.1", "quay.io"}
+
+	// Test
+	err := writeRegistriesManifest(ctx, hostnames)
+
+	// Verify
+	require.NoError(t, err)
+
+	manifestFileName := filepath.Join(ctx.CombustionDir, registriesManifestFileName)
+	_, err = os.Stat(manifestFileName)
+	require.NoError(t, err)
+
+	foundBytes, err := os.ReadFile(manifestFileName)
+	require.NoError(t, err)
+	found := string(foundBytes)
+	assert.Contains(t, found, "- \"http://localhost:6545\"")
+	assert.Contains(t, found, "docker.io")
+	assert.Contains(t, found, "rgcrprod.azurecr.us")
+	assert.Contains(t, found, "quay.io")
+}
+
+func TestGetImageHostnames(t *testing.T) {
+	// Setup
+	containerImages := []image.ContainerImage{
+		{
+			Name: "hello-world:latest",
+		},
+		{
+			Name: "quay.io/podman/hello",
+		},
+		{
+			Name:           "rgcrprod.azurecr.us/longhornio/longhorn-ui:v1.5.1",
+			SupplyChainKey: "carbide-key.pub",
+		},
+	}
+	expectedHostnames := []string{"quay.io", "rgcrprod.azurecr.us"}
+
+	// Test
+	hostnames := getImageHostnames(containerImages)
+
+	// Verify
+	assert.Equal(t, expectedHostnames, hostnames)
+}

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -246,7 +246,7 @@ func TestIsEmbeddedArtifactRegistryConfigured(t *testing.T) {
 	}
 }
 
-func TestWriteRegistriesManifestValid(t *testing.T) {
+func TestWriteRegistryMirrorsValid(t *testing.T) {
 	// Setup
 	ctx, teardown := setupContext(t)
 	defer teardown()

--- a/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
@@ -47,6 +47,10 @@ echo "{{ .apiVIP }} {{ .apiHost }}" >> /etc/hosts
 mkdir -p /etc/rancher/rke2/
 cp $CONFIGFILE /etc/rancher/rke2/config.yaml
 
+{{- if .manifestsPath }}
+cp {{ .registriesManifest }} /etc/rancher/rke2/registries.yaml
+{{- end }}
+
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2
 export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 

--- a/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
@@ -48,7 +48,7 @@ mkdir -p /etc/rancher/rke2/
 cp $CONFIGFILE /etc/rancher/rke2/config.yaml
 
 {{- if .manifestsPath }}
-cp {{ .registriesManifest }} /etc/rancher/rke2/registries.yaml
+cp {{ .registryMirrors }} /etc/rancher/rke2/registries.yaml
 {{- end }}
 
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2

--- a/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
@@ -25,6 +25,10 @@ echo "{{ .apiVIP }} {{ .apiHost }}" >> /etc/hosts
 mkdir -p /etc/rancher/rke2/
 cp {{ .configFile }} /etc/rancher/rke2/config.yaml
 
+{{- if .manifestsPath }}
+cp {{ .registriesManifest }} /etc/rancher/rke2/registries.yaml
+{{- end }}
+
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2
 export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 

--- a/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
@@ -26,7 +26,7 @@ mkdir -p /etc/rancher/rke2/
 cp {{ .configFile }} /etc/rancher/rke2/config.yaml
 
 {{- if .manifestsPath }}
-cp {{ .registriesManifest }} /etc/rancher/rke2/registries.yaml
+cp {{ .registryMirrors }} /etc/rancher/rke2/registries.yaml
 {{- end }}
 
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2

--- a/pkg/combustion/templates/registries.yaml.tpl
+++ b/pkg/combustion/templates/registries.yaml.tpl
@@ -1,0 +1,9 @@
+mirrors:
+  docker.io:
+    endpoint:
+      - "http://localhost:{{ .Port }}"
+{{- range .Hostnames }}
+  {{ . }}:
+    endpoint:
+      - "http://localhost:{{ $.Port }}"
+{{- end }}


### PR DESCRIPTION
This is the finale in the manifest deployment saga, excluding helm charts. This includes the final piece of the puzzle for actually using all of the previous merged implementations for completely air-gapped manifest deployment.