### PR TITLE
Allow SELinux configuration for k3s clusters

### DIFF
--- a/pkg/combustion/kubernetes_test.go
+++ b/pkg/combustion/kubernetes_test.go
@@ -209,9 +209,8 @@ func TestConfigureKubernetes_SuccessfulSingleNodeK3sCluster(t *testing.T) {
 	assert.Contains(t, contents, "echo \"192.168.122.100 api.cluster01.hosted.on.edge.suse.com\" >> /etc/hosts")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
-	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/k3s")
 	assert.Contains(t, contents, "chmod +x kubernetes/install/cool-k3s-binary")
-	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
+	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary /usr/local/bin/k3s")
 
 	// Config file assertions
 	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")
@@ -306,9 +305,8 @@ func TestConfigureKubernetes_SuccessfulMultiNodeK3sCluster(t *testing.T) {
 	assert.Contains(t, contents, "export INSTALL_K3S_EXEC=$NODETYPE")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
-	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/k3s")
 	assert.Contains(t, contents, "chmod +x kubernetes/install/cool-k3s-binary")
-	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
+	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary /usr/local/bin/k3s")
 
 	// Server config file assertions
 	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")

--- a/pkg/combustion/templates/15-k3s-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-k3s-multi-node-installer.sh.tpl
@@ -53,10 +53,12 @@ cp {{ .registryMirrors }} /etc/rancher/k3s/registries.yaml
 export INSTALL_K3S_EXEC=$NODETYPE
 export INSTALL_K3S_SKIP_DOWNLOAD=true
 export INSTALL_K3S_SKIP_START=true
-export INSTALL_K3S_BIN_DIR=/opt/k3s
 
-mkdir -p $INSTALL_K3S_BIN_DIR
+mount /usr/local
+
 chmod +x {{ .binaryPath }}
-cp {{ .binaryPath }} $INSTALL_K3S_BIN_DIR/k3s
+cp {{ .binaryPath }} /usr/local/bin/k3s
 
 ./k3s_installer.sh
+
+umount /usr/local

--- a/pkg/combustion/templates/15-k3s-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-k3s-single-node-installer.sh.tpl
@@ -31,10 +31,12 @@ cp {{ .registryMirrors }} /etc/rancher/k3s/registries.yaml
 
 export INSTALL_K3S_SKIP_DOWNLOAD=true
 export INSTALL_K3S_SKIP_START=true
-export INSTALL_K3S_BIN_DIR=/opt/k3s
 
-mkdir -p $INSTALL_K3S_BIN_DIR
+mount /usr/local
+
 chmod +x {{ .binaryPath }}
-cp {{ .binaryPath }} $INSTALL_K3S_BIN_DIR/k3s
+cp {{ .binaryPath }} /usr/local/bin/k3s
 
 ./k3s_installer.sh
+
+umount /usr/local


### PR DESCRIPTION
- The existing [k3s-selinux](https://github.com/k3s-io/k3s-selinux/blob/master/policy/slemicro/k3s.fc) policy does not cover `/opt` installation as a supported context
```
localhost:~ # cat /etc/rancher/k3s/config.yaml
selinux: true
localhost:~ # semodule -l | grep k3s
k3s
localhost:~ # journalctl -u k3s | grep selinux
Feb 02 13:48:27 localhost.localdomain k3s[2408]: time="2024-02-02T13:48:27Z" level=warning msg="SELinux is enabled for k3s but process is not running in context 'container_runtime_t', k3s-selinux policy may need to be applied"
```