### PR TITLE
Updates to the image definition for 1.0 release - Part 1

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -37,15 +37,17 @@ The operating system configuration section is entirely optional.
 The following describes the possible options for the operating system section:
 ```yaml
 operatingSystem:
-  installDevice: /path/to/disk
-  unattended: false
+  isoInstallation:
+    installDevice: /path/to/disk
+    unattended: false
   time:
     timezone: Europe/London
-    chronyPools:
-      - 1.pool.server.com
-    chronyServers:
-      - 10.0.0.1
-      - 10.0.0.2
+    ntp:
+      pools:
+        - 1.pool.server.com
+      servers:
+        - 10.0.0.1
+        - 10.0.0.2
   proxy:
     httpProxy: http://10.0.0.1:3128
     httpsProxy: http://10.0.0.1:3128
@@ -70,17 +72,19 @@ operatingSystem:
   keymap: us
 ```
 
-* `installDevice` - Optional; only for ISO images - specifies the disk that should be used as the install
+* `isoInstallation` - Optional; configuration in this section only applies to ISO images.
+  * `installDevice` - Optional; specifies the disk that should be used as the install
   device. This needs to be block special, and will default to automatically wipe any data found on the disk.
   If left omitted, the user will still have to select the disk to install to (if >1 found) and confirm wipe.
-* `unattended` - Optional; only for ISO images - forces GRUB override to automatically install the operating
+  * `unattended` - Optional; forces GRUB override to automatically install the operating
   system rather than prompting user to begin the installation. In combination with `installDevice` can create
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
   If left omitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
 * `time` - Optional; section where the user can provide timezone information and Chronyd configuration.
   * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`.
-  * `chronyPools` - Optional; a list of pools that Chrony can use as data sources.
-  * `chronyServers` - Optional; a list of servers that Chrony can use as data sources.
+  * `ntp` - Optional; contains attributes related to configuring NTP
+    * `pools` - Optional; a list of pools that Chrony can use as data sources.
+    * `servers` - Optional; a list of servers that Chrony can use as data sources.
 * `proxy` - Optional; section where the user can provide system-wide proxy information
   * `httpProxy` - Optional; set the system-wide http proxy settings
   * `httpsProxy` - Optional; set the system-wide https proxy settings

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -123,8 +123,8 @@ func (b *Builder) writeIsoScript(templateContents, outputFilename string) error 
 		IsoSource:           b.generateBaseImageFilename(),
 		OutputImageFilename: b.generateOutputImageFilename(),
 		CombustionDir:       b.context.CombustionDir,
-		InstallDevice:       b.context.ImageDefinition.OperatingSystem.InstallDevice,
-		Unattended:          b.context.ImageDefinition.OperatingSystem.Unattended,
+		InstallDevice:       b.context.ImageDefinition.OperatingSystem.IsoInstallation.InstallDevice,
+		Unattended:          b.context.ImageDefinition.OperatingSystem.IsoInstallation.Unattended,
 	}
 
 	contents, err := template.Parse("iso-script", templateContents, arguments)

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -131,8 +131,10 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
-			InstallDevice: "/dev/vda",
-			Unattended:    true,
+			IsoInstallation: image.IsoInstallation{
+				InstallDevice: "/dev/vda",
+				Unattended:    true,
+			},
 		},
 	}
 

--- a/pkg/combustion/templates/09-time-setup.sh.tpl
+++ b/pkg/combustion/templates/09-time-setup.sh.tpl
@@ -5,14 +5,14 @@ set -euo pipefail
 ln -sf /usr/share/zoneinfo/{{ .Timezone }} /etc/localtime
 {{ end -}}
 
-{{ if or (gt (len .ChronyPools) 0) (gt (len .ChronyServers) 0) }}
+{{ if or (gt (len .Pools) 0) (gt (len .Servers) 0) }}
 rm -f /etc/chrony.d/pool.conf
 {{ end -}}
 
-{{ range .ChronyPools -}}
+{{ range .Pools -}}
 echo "pool {{ . }} iburst" >> /etc/chrony.d/eib-sources.conf
 {{ end -}}
 
-{{ range .ChronyServers -}}
+{{ range .Servers -}}
 echo "server {{ . }} iburst" >> /etc/chrony.d/eib-sources.conf
 {{ end -}}

--- a/pkg/combustion/time.go
+++ b/pkg/combustion/time.go
@@ -39,7 +39,17 @@ func configureTime(ctx *image.Context) ([]string, error) {
 func writeTimeCombustionScript(ctx *image.Context) error {
 	timeScriptFilename := filepath.Join(ctx.CombustionDir, timeScriptName)
 
-	data, err := template.Parse(timeScriptName, timeScript, ctx.ImageDefinition.OperatingSystem.Time)
+	values := struct {
+		Timezone string
+		Pools    []string
+		Servers  []string
+	}{
+		Timezone: ctx.ImageDefinition.OperatingSystem.Time.Timezone,
+		Pools:    ctx.ImageDefinition.OperatingSystem.Time.NtpConfiguration.Pools,
+		Servers:  ctx.ImageDefinition.OperatingSystem.Time.NtpConfiguration.Servers,
+	}
+
+	data, err := template.Parse(timeScriptName, timeScript, values)
 	if err != nil {
 		return fmt.Errorf("applying template to %s: %w", timeScriptName, err)
 	}

--- a/pkg/combustion/time_test.go
+++ b/pkg/combustion/time_test.go
@@ -37,9 +37,11 @@ func TestConfigureTime_FullConfiguration(t *testing.T) {
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
 			Time: image.Time{
-				Timezone:      "Europe/London",
-				ChronyPools:   []string{"2.suse.pool.ntp.org"},
-				ChronyServers: []string{"10.0.0.1", "10.0.0.2"},
+				Timezone: "Europe/London",
+				NtpConfiguration: image.NtpConfiguration{
+					Pools:   []string{"2.suse.pool.ntp.org"},
+					Servers: []string{"10.0.0.1", "10.0.0.2"},
+				},
 			},
 		},
 	}

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -101,9 +101,13 @@ type Suma struct {
 }
 
 type Time struct {
-	Timezone      string   `yaml:"timezone"`
-	ChronyPools   []string `yaml:"chronyPools"`
-	ChronyServers []string `yaml:"chronyServers"`
+	Timezone         string           `yaml:"timezone"`
+	NtpConfiguration NtpConfiguration `yaml:"ntp"`
+}
+
+type NtpConfiguration struct {
+	Pools   []string `yaml:"pools"`
+	Servers []string `yaml:"servers"`
 }
 
 type Proxy struct {

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -56,16 +56,20 @@ type Image struct {
 }
 
 type OperatingSystem struct {
-	KernelArgs    []string              `yaml:"kernelArgs"`
-	Users         []OperatingSystemUser `yaml:"users"`
-	Systemd       Systemd               `yaml:"systemd"`
-	Suma          Suma                  `yaml:"suma"`
-	Packages      Packages              `yaml:"packages"`
-	InstallDevice string                `yaml:"installDevice"`
-	Unattended    bool                  `yaml:"unattended"`
-	Time          Time                  `yaml:"time"`
-	Proxy         Proxy                 `yaml:"proxy"`
-	Keymap        string                `yaml:"keymap"`
+	KernelArgs      []string              `yaml:"kernelArgs"`
+	Users           []OperatingSystemUser `yaml:"users"`
+	Systemd         Systemd               `yaml:"systemd"`
+	Suma            Suma                  `yaml:"suma"`
+	Packages        Packages              `yaml:"packages"`
+	IsoInstallation IsoInstallation       `yaml:"isoInstallation"`
+	Time            Time                  `yaml:"time"`
+	Proxy           Proxy                 `yaml:"proxy"`
+	Keymap          string                `yaml:"keymap"`
+}
+
+type IsoInstallation struct {
+	InstallDevice string `yaml:"installDevice"`
+	Unattended    bool   `yaml:"unattended"`
 }
 
 type Packages struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -102,12 +102,12 @@ func TestParse(t *testing.T) {
 	expectedChronyPools := []string{
 		"2.suse.pool.ntp.org",
 	}
-	assert.Equal(t, expectedChronyPools, time.ChronyPools)
+	assert.Equal(t, expectedChronyPools, time.NtpConfiguration.Pools)
 	expectedChronyServers := []string{
 		"10.0.0.1",
 		"10.0.0.2",
 	}
-	assert.Equal(t, expectedChronyServers, time.ChronyServers)
+	assert.Equal(t, expectedChronyServers, time.NtpConfiguration.Servers)
 
 	// Operating System -> Proxy -> HTTPProxy
 	httpProxy := definition.OperatingSystem.Proxy.HTTPProxy

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -89,12 +89,11 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, expectedAddRepos, pkgConfig.AdditionalRepos)
 	assert.Equal(t, "INTERNAL-USE-ONLY-foo-bar", pkgConfig.RegCode)
 
-	// Operating System -> InstallDevice
-	installDevice := definition.OperatingSystem.InstallDevice
+	// Operating System -> IsoInstallation
+	installDevice := definition.OperatingSystem.IsoInstallation.InstallDevice
 	assert.Equal(t, "/dev/sda", installDevice)
 
-	// Operating System -> Unattended
-	unattended := definition.OperatingSystem.Unattended
+	unattended := definition.OperatingSystem.IsoInstallation.Unattended
 	assert.Equal(t, true, unattended)
 
 	// Operating System -> Time

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -5,8 +5,9 @@ image:
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
 operatingSystem:
-  installDevice: /dev/sda
-  unattended: true
+  isoInstallation:
+    installDevice: /dev/sda
+    unattended: true
   time:
     timezone: Europe/London
     chronyPools:

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -10,11 +10,12 @@ operatingSystem:
     unattended: true
   time:
     timezone: Europe/London
-    chronyPools:
-      - 2.suse.pool.ntp.org
-    chronyServers:
-      - 10.0.0.1
-      - 10.0.0.2
+    ntp:
+      pools:
+        - 2.suse.pool.ntp.org
+      servers:
+        - 10.0.0.1
+        - 10.0.0.2
   proxy:
     httpProxy: http://10.0.0.1:3128
     httpsProxy: http://10.0.0.1:3128

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -201,15 +201,15 @@ func validatePackages(os *image.OperatingSystem) []FailedValidation {
 func validateUnattended(def *image.Definition) []FailedValidation {
 	var failures []FailedValidation
 
-	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.Unattended {
-		msg := fmt.Sprintf("The 'unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO)
+	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoInstallation.Unattended {
+		msg := fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})
 	}
 
-	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.InstallDevice != "" {
-		msg := fmt.Sprintf("The 'installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO)
+	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoInstallation.InstallDevice != "" {
+		msg := fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -47,8 +47,10 @@ func TestValidateOperatingSystem(t *testing.T) {
 						},
 						RegCode: "letMeIn",
 					},
-					Unattended:    true,
-					InstallDevice: "/dev/sda",
+					IsoInstallation: image.IsoInstallation{
+						Unattended:    true,
+						InstallDevice: "/dev/sda",
+					},
 				},
 			},
 		},
@@ -74,8 +76,10 @@ func TestValidateOperatingSystem(t *testing.T) {
 					Packages: image.Packages{
 						PKGList: []string{"zsh", "git"},
 					},
-					Unattended:    true,
-					InstallDevice: "/dev/sda",
+					IsoInstallation: image.IsoInstallation{
+						Unattended:    true,
+						InstallDevice: "/dev/sda",
+					},
 				},
 			},
 			ExpectedFailedMessages: []string{
@@ -84,8 +88,8 @@ func TestValidateOperatingSystem(t *testing.T) {
 				"User 'danny' must have either a password or SSH key.",
 				"The 'host' field is required for the 'suma' section.",
 				"When including the 'packageList' field, either additional repositories or a registration code must be included.",
-				fmt.Sprintf("The 'unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
-				fmt.Sprintf("The 'installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 			},
 		},
 	}
@@ -506,8 +510,10 @@ func TestValidateUnattended(t *testing.T) {
 					ImageType: image.TypeISO,
 				},
 				OperatingSystem: image.OperatingSystem{
-					Unattended:    true,
-					InstallDevice: "/dev/sda",
+					IsoInstallation: image.IsoInstallation{
+						Unattended:    true,
+						InstallDevice: "/dev/sda",
+					},
 				},
 			},
 		},
@@ -517,11 +523,13 @@ func TestValidateUnattended(t *testing.T) {
 					ImageType: image.TypeRAW,
 				},
 				OperatingSystem: image.OperatingSystem{
-					Unattended: true,
+					IsoInstallation: image.IsoInstallation{
+						Unattended: true,
+					},
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 			},
 		},
 		`not iso install device`: {
@@ -530,11 +538,13 @@ func TestValidateUnattended(t *testing.T) {
 					ImageType: image.TypeRAW,
 				},
 				OperatingSystem: image.OperatingSystem{
-					InstallDevice: "/dev/sda",
+					IsoInstallation: image.IsoInstallation{
+						InstallDevice: "/dev/sda",
+					},
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 			},
 		},
 	}


### PR DESCRIPTION
Includes:
* Moving the two installation-related fields (`installDevice` and `unattended`) under their own section called `isoInstallation`
* Moved the two NTP-related fields (`chronyServers` and `chronyPools`) under their own section called `ntp`, removing the `chrony` prefix in the process