### PR TITLE
renamed package registration code to include 'scc'

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -51,7 +51,10 @@ operatingSystem:
   proxy:
     httpProxy: http://10.0.0.1:3128
     httpsProxy: http://10.0.0.1:3128
-    noProxy: localhost, 127.0.0.1, edge.suse.com
+    noProxy:
+    - localhost
+    - 127.0.0.1
+    - edge.suse.com
   kernelArgs:
   - arg1
   - arg2
@@ -88,8 +91,8 @@ operatingSystem:
 * `proxy` - Optional; section where the user can provide system-wide proxy information
   * `httpProxy` - Optional; set the system-wide http proxy settings
   * `httpsProxy` - Optional; set the system-wide https proxy settings
-  * `noProxy` - Optional; override the default `NO_PROXY` list. By default this is "localhost, 127.0.0.1" if parameter is omitted, but
-  if you set this flag, make sure you add these into your list if they're required.
+  * `noProxy` - Optional; override the default `NO_PROXY` list. By default, this is "localhost, 127.0.0.1" if this
+  parameter is omitted. If this option is set, these may need to be manually added if they are still in use.
 * `kernelArgs` - Optional; Provides a list of flags that should be passed to the kernel on boot.
 * `users` - Optional; Defines a list of operating system users to be created. Each entry is made up of
   the following fields:

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -76,7 +76,7 @@ type Packages struct {
 	NoGPGCheck      bool      `yaml:"noGPGCheck"`
 	PKGList         []string  `yaml:"packageList"`
 	AdditionalRepos []AddRepo `yaml:"additionalRepos"`
-	RegCode         string    `yaml:"registrationCode"`
+	RegCode         string    `yaml:"sccRegistrationCode"`
 }
 
 type AddRepo struct {

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -57,7 +57,7 @@ operatingSystem:
     additionalRepos:
       - url: https://download.nvidia.com/suse/sle15sp5/
       - url: https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
-    registrationCode: INTERNAL-USE-ONLY-foo-bar
+    sccRegistrationCode: INTERNAL-USE-ONLY-foo-bar
 embeddedArtifactRegistry:
   images:
     - name: hello-world:latest


### PR DESCRIPTION
I only changed the YAML key; given the struct embedding it was redundant in the code.

I also snuck in the doc fixes for the previous noProxy change.