### PR TITLE
renamed API-facing initializer attribute for consistency

### DIFF
--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -146,7 +146,7 @@ type Network struct {
 type Node struct {
 	Hostname    string `yaml:"hostname"`
 	Type        string `yaml:"type"`
-	Initialiser bool   `yaml:"initialiser"`
+	Initialiser bool   `yaml:"initializer"`
 }
 
 type Manifests struct {

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -73,7 +73,7 @@ kubernetes:
       type: server
     - hostname: node2.suse.com
       type: server
-      initialiser: true
+      initializer: true
     - hostname: node3.suse.com
       type: agent
     - hostname: node4.suse.com


### PR DESCRIPTION
I only changed the definition spelling; internally it's anything goes on spelling.