### PR TITLE
Creating /opt/cni directory for SELinux issues

### DIFF
--- a/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
@@ -53,6 +53,8 @@ cp {{ .registryMirrors }} /etc/rancher/rke2/registries.yaml
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2
 export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 
+# Create the CNI directory, usually created and labelled by the
+# rke2-selinux package, but isn't executed during combustion.
 mkdir -p /opt/cni
 
 ./rke2_installer.sh

--- a/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-multi-node-installer.sh.tpl
@@ -53,6 +53,8 @@ cp {{ .registryMirrors }} /etc/rancher/rke2/registries.yaml
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2
 export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 
+mkdir -p /opt/cni
+
 ./rke2_installer.sh
 
 systemctl enable rke2-$NODETYPE.service

--- a/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
@@ -32,6 +32,8 @@ cp {{ .registryMirrors }} /etc/rancher/rke2/registries.yaml
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2
 export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 
+# Create the CNI directory, usually created and labelled by the
+# rke2-selinux package, but isn't executed during combustion.
 mkdir -p /opt/cni
 
 ./rke2_installer.sh

--- a/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-rke2-single-node-installer.sh.tpl
@@ -32,6 +32,8 @@ cp {{ .registryMirrors }} /etc/rancher/rke2/registries.yaml
 export INSTALL_RKE2_TAR_PREFIX=/opt/rke2
 export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 
+mkdir -p /opt/cni
+
 ./rke2_installer.sh
 
 systemctl enable rke2-server.service


### PR DESCRIPTION
There seems to be an issue where Cilium cannot be installed on SLE Micro with the out of the box rke2+rke2-selinux configuration. An issue was raised back in 2022 for a similar issue (https://github.com/rancher/rke2/issues/3561) and it was fixed by manually creating the directory during the rke2-selinux post-install RPM script. (https://github.com/rancher/rke2-selinux/pull/29/files).

However, this line: https://github.com/rancher/rke2-selinux/blob/master/policy/slemicro/rke2-selinux.spec#L66 isn't triggered during Combustion, so the directory isn't created and hence we run into the originally reported issue. This change forces the creation of the directory at combustion time, and hence allows the policy enhancement from the original fix to take effect as expected (https://github.com/rancher/rke2-selinux/blob/master/policy/slemicro/rke2.fc#L15)