### PR TITLE
Reverting back to /opt/bin for k3s to align with k3s install script

### DIFF
--- a/pkg/combustion/kubernetes_test.go
+++ b/pkg/combustion/kubernetes_test.go
@@ -209,7 +209,7 @@ func TestConfigureKubernetes_SuccessfulSingleNodeK3sCluster(t *testing.T) {
 	assert.Contains(t, contents, "echo \"192.168.122.100 api.cluster01.hosted.on.edge.suse.com\" >> /etc/hosts")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
-	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/k3s/bin")
+	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/bin")
 	assert.Contains(t, contents, "chmod +x kubernetes/install/cool-k3s-binary")
 	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
 
@@ -306,7 +306,7 @@ func TestConfigureKubernetes_SuccessfulMultiNodeK3sCluster(t *testing.T) {
 	assert.Contains(t, contents, "export INSTALL_K3S_EXEC=$NODETYPE")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
-	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/k3s/bin")
+	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/bin")
 	assert.Contains(t, contents, "chmod +x kubernetes/install/cool-k3s-binary")
 	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
 

--- a/pkg/combustion/templates/15-k3s-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-k3s-multi-node-installer.sh.tpl
@@ -53,7 +53,7 @@ cp {{ .registryMirrors }} /etc/rancher/k3s/registries.yaml
 export INSTALL_K3S_EXEC=$NODETYPE
 export INSTALL_K3S_SKIP_DOWNLOAD=true
 export INSTALL_K3S_SKIP_START=true
-export INSTALL_K3S_BIN_DIR=/opt/k3s/bin
+export INSTALL_K3S_BIN_DIR=/opt/bin
 
 mkdir -p $INSTALL_K3S_BIN_DIR
 chmod +x {{ .binaryPath }}

--- a/pkg/combustion/templates/15-k3s-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/15-k3s-single-node-installer.sh.tpl
@@ -31,7 +31,7 @@ cp {{ .registryMirrors }} /etc/rancher/k3s/registries.yaml
 
 export INSTALL_K3S_SKIP_DOWNLOAD=true
 export INSTALL_K3S_SKIP_START=true
-export INSTALL_K3S_BIN_DIR=/opt/k3s/bin
+export INSTALL_K3S_BIN_DIR=/opt/bin
 
 mkdir -p $INSTALL_K3S_BIN_DIR
 chmod +x {{ .binaryPath }}


### PR DESCRIPTION
In https://github.com/k3s-io/k3s-selinux/pull/58 it was correctly pointed out that in the k3s installer they explicitly use `/opt/bin/` for the k3s bin directory (https://github.com/k3s-io/k3s/blob/master/install.sh#L227-L234). This unfortunately doesn't have consistency with rke2, but we can't break existing installer functionality, nor impact potential upgrade concerns. This change modifies to suit.