### PR TITLE
[WIP] Add support for nmc configuration via configdrive

### DIFF
--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -53,6 +53,10 @@ func Configure(ctx *image.Context) error {
 			runnable: configureNetwork,
 		},
 		{
+			name:     networkConfigdriveComponentName,
+			runnable: configureNetworkConfigdrive,
+		},
+		{
 			name:     usersComponentName,
 			runnable: configureUsers,
 		},
@@ -106,6 +110,8 @@ func Configure(ctx *image.Context) error {
 	var networkScript string
 	if isComponentConfigured(ctx, networkConfigDir) {
 		networkScript = networkConfigScriptName
+	} else if ctx.ImageDefinition.OperatingSystem.ConfigDrive {
+		networkScript = networkConfigdriveScriptName
 	}
 
 	script, err := assembleScript(combustionScripts, networkScript)

--- a/pkg/combustion/network_configdrive.go
+++ b/pkg/combustion/network_configdrive.go
@@ -1,0 +1,63 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"go.uber.org/zap"
+)
+
+const (
+	networkConfigdriveComponentName = "network-configdrive"
+	networkConfigdriveDir           = "network-configdrive"
+	networkConfigdriveScriptName    = "03-configure-network-configdrive.sh"
+)
+
+//go:embed templates/03-configure-network-configdrive.sh
+var configureNetworkConfigdriveScript string
+
+// Configures the network via configdrive if enabled.
+//
+//  1. Copies the NMC executable
+//  2. Writes the configuration script
+//
+// Example result file layout:
+//
+// combustion
+// ├── nmc
+// └── 03-configure-network-configdrive.sh
+func configureNetworkConfigdrive(ctx *image.Context) ([]string, error) {
+	if ! ctx.ImageDefinition.OperatingSystem.ConfigDrive {
+		log.AuditComponentSkipped(networkConfigdriveComponentName)
+		return nil, nil
+	}
+
+	if err := installNetworkConfigurator(ctx); err != nil {
+		log.AuditComponentFailed(networkConfigdriveComponentName)
+		return nil, fmt.Errorf("installing configurator: %w", err)
+	}
+
+	scriptName, err := writeNetworkConfigdriveScript(ctx)
+	if err != nil {
+		log.AuditComponentFailed(networkConfigdriveComponentName)
+		return nil, fmt.Errorf("writing network configuration script: %w", err)
+	}
+
+	log.AuditComponentSuccessful(networkConfigdriveComponentName)
+	zap.S().Info("Successfully configured network component")
+
+	return []string{scriptName}, nil
+}
+
+func writeNetworkConfigdriveScript(ctx *image.Context) (string, error) {
+	filename := filepath.Join(ctx.CombustionDir, networkConfigdriveScriptName)
+	if err := os.WriteFile(filename, []byte(configureNetworkConfigdriveScript), fileio.ExecutablePerms); err != nil {
+		return "", fmt.Errorf("writing network script: %w", err)
+	}
+	return networkConfigdriveScriptName, nil
+}

--- a/pkg/combustion/network_configdrive_test.go
+++ b/pkg/combustion/network_configdrive_test.go
@@ -1,0 +1,94 @@
+package combustion
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func assertNetworkConfigdriveScript(t *testing.T, scriptPath string) {
+	data, err := os.ReadFile(scriptPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "nmc generate --config-dir /tmp/nmc/desired")
+
+	info, err := os.Stat(scriptPath)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, info.Mode())
+}
+
+func TestConfigureNetworkConfigdrive_NotConfigured(t *testing.T) {
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	scripts, err := configureNetworkConfigdrive(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, scripts)
+}
+
+func TestConfigureNetworkConfigdrive(t *testing.T) {
+	tests := []struct {
+		name                  string
+		configuratorInstaller mockNetworkConfiguratorInstaller
+		expectedErr           string
+	}{
+		{
+			name: "Installing configurator fails",
+			configuratorInstaller: mockNetworkConfiguratorInstaller{
+				installConfiguratorFunc: func(arch image.Arch, sourcePath, installPath string) error {
+					return fmt.Errorf("no installer for you")
+				},
+			},
+			expectedErr: "installing configurator: no installer for you",
+		},
+		{
+			name: "Successful configuration",
+			configuratorInstaller: mockNetworkConfiguratorInstaller{
+				installConfiguratorFunc: func(arch image.Arch, sourcePath, installPath string) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx.NetworkConfiguratorInstaller = test.configuratorInstaller
+			ctx.ImageDefinition.OperatingSystem.ConfigDrive = true
+
+			scripts, err := configureNetworkConfigdrive(ctx)
+
+			if test.expectedErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedErr)
+				return
+			}
+
+			assert.Equal(t, []string{networkConfigdriveScriptName}, scripts)
+
+			scriptPath := filepath.Join(ctx.CombustionDir, networkConfigdriveScriptName)
+			assertNetworkConfigdriveScript(t, scriptPath)
+		})
+	}
+}
+
+func TestWriteNetworkConfigdriveScript(t *testing.T) {
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	script, err := writeNetworkConfigdriveScript(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, networkConfigdriveScriptName, script)
+
+	scriptPath := filepath.Join(ctx.CombustionDir, script)
+	assertNetworkConfigdriveScript(t, scriptPath)
+}

--- a/pkg/combustion/templates/03-configure-network-configdrive.sh
+++ b/pkg/combustion/templates/03-configure-network-configdrive.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# Attempt to statically configure a nic in the case where we find a network_data.json
+# In a configuration drive
+
+CONFIG_DRIVE=$(blkid --label config-2)
+if [ -z "${CONFIG_DRIVE}" ]; then
+  echo "No config-2 device found, skipping network configuration"
+  exit 0
+fi
+
+mount -o ro $CONFIG_DRIVE /mnt
+
+NETWORK_DATA_FILE="/mnt/openstack/latest/network_data.json"
+
+if [ ! -f "${NETWORK_DATA_FILE}" ]; then
+  echo "No ${NETWORK_DATA_FILE} found, skipping network configuration"
+  umount /mnt
+  exit 0
+fi
+
+mkdir -p /tmp/nmc/{desired,generated}
+cp ${NETWORK_DATA_FILE} /tmp/nmc/desired/hostname.yaml
+umount /mnt
+
+nmc generate --config-dir /tmp/nmc/desired --output-dir /tmp/nmc/generated
+nmc apply --config-dir /tmp/nmc/generated
+
+systemctl restart NetworkManager

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -65,6 +65,7 @@ type OperatingSystem struct {
 	Time            Time                  `yaml:"time"`
 	Proxy           Proxy                 `yaml:"proxy"`
 	Keymap          string                `yaml:"keymap"`
+	ConfigDrive     bool                  `yaml:"configdrive"`
 }
 
 type IsoInstallation struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -124,6 +124,10 @@ func TestParse(t *testing.T) {
 	keymap := definition.OperatingSystem.Keymap
 	assert.Equal(t, "us", keymap)
 
+	// Operating System -> ConfigDrive
+	configdrive := definition.OperatingSystem.ConfigDrive
+	assert.True(t, configdrive)
+
 	// EmbeddedArtifactRegistry
 	embeddedArtifactRegistry := definition.EmbeddedArtifactRegistry
 	assert.Equal(t, "hello-world:latest", embeddedArtifactRegistry.ContainerImages[0].Name)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -34,6 +34,7 @@ operatingSystem:
     disable:
       - disable0
   keymap: us
+  configdrive: true
   users:
     - username: alpha
       encryptedPassword: $6$bZfTI3Wj05fdxQcB$W1HJQTKw/MaGTCwK75ic9putEquJvYO7vMnDBVAfuAMFW58/79abky4mx9.8znK0UZwSKng9dVosnYQR1toH71


### PR DESCRIPTION
To enable network configuration in the Metal3 DHCP-less flow, we need to inject nmc and a script which reads the config-drive data, then runs nmc to generate/apply the config.

This draft adds a new os.configdrive definition option, which enables this behavior - open to suggestions on alternative interfaces though.