### PR TITLE
Adding support for specifying the desired raw disk size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,10 @@ RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:Edge
 # 5. Network configurator
 RUN zypper install -y \
     xorriso squashfs  \
-    libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs \
+    libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs guestfs-tools lvm2 \
     podman \
     createrepo_c \
-    nm-configurator \
-    guestfs-tools lvm2
+    nm-configurator
 
 RUN curl -o hauler-amd64.tar -L https://github.com/rancherfederal/hauler/releases/download/v0.4.2/hauler_0.4.2_linux_amd64.tar.gz && \
     tar -xf hauler-amd64.tar && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN zypper install -y \
     libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs \
     podman \
     createrepo_c \
-    nm-configurator
+    nm-configurator \
+    guestfs-tools lvm2
 
 RUN curl -o hauler-amd64.tar -L https://github.com/rancherfederal/hauler/releases/download/v0.4.2/hauler_0.4.2_linux_amd64.tar.gz && \
     tar -xf hauler-amd64.tar && \

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -83,6 +83,12 @@ operatingSystem:
   system rather than prompting user to begin the installation. In combination with `installDevice` can create
   a fully unattended and automated install. Beware of creating boot loops and data loss with these options.
   If left omitted (or set to `false`) the user will still have to choose to install via the GRUB menu.
+* `rawConfiguration` - Optional; configuration in this section only applies to RAW images only.
+  * `diskSize` - Optional; sets the desired raw disk image size. This is important to ensure that your disk
+  image is large enough to accommodate any artifacts that you're embedding. It's advised to set this to slightly
+  smaller than your SDcard size (or block device if writing directly to a disk) and the system will automatically
+  expand at boot time to fill the size of the block device. This is optional, but highly recommended. Specify in
+  integer format with either "M" (Megabyte) or "G" (Gigabyte) as a suffix, e.g. "32G".
 * `time` - Optional; section where the user can provide timezone information and Chronyd configuration.
   * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`.
   * `ntp` - Optional; contains attributes related to configuring NTP

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -88,7 +88,7 @@ operatingSystem:
   image is large enough to accommodate any artifacts that you're embedding. It's advised to set this to slightly
   smaller than your SDcard size (or block device if writing directly to a disk) and the system will automatically
   expand at boot time to fill the size of the block device. This is optional, but highly recommended. Specify in
-  integer format with either "M" (Megabyte) or "G" (Gigabyte) as a suffix, e.g. "32G".
+  integer format with either "M" (Megabyte), "G" (Gigabyte), or "T" (Terabyte) as a suffix, e.g. "32G".
 * `time` - Optional; section where the user can provide timezone information and Chronyd configuration.
   * `timezone` - Optional; the timezone in the format of "Region/Locality", e.g. "Europe/London". Full list via `timedatectl list-timezones`.
   * `ntp` - Optional; contains attributes related to configuring NTP

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -86,12 +86,14 @@ func (b *Builder) writeModifyScript(imageFilename string, includeCombustion, ren
 		ConfigureGRUB       string
 		ConfigureCombustion bool
 		RenameFilesystem    bool
+		DiskSize            string
 	}{
 		ImagePath:           imageFilename,
 		CombustionDir:       b.context.CombustionDir,
 		ConfigureGRUB:       grubConfiguration,
 		ConfigureCombustion: includeCombustion,
 		RenameFilesystem:    renameFilesystem,
+		DiskSize:            b.context.ImageDefinition.OperatingSystem.RawConfiguration.DiskSize,
 	}
 
 	data, err := template.Parse(modifyScriptName, modifyRawImageTemplate, &values)

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -52,6 +52,9 @@ func TestWriteModifyScript(t *testing.T) {
 		},
 		OperatingSystem: image.OperatingSystem{
 			KernelArgs: []string{"alpha", "beta"},
+			RawConfiguration: image.RawConfiguration{
+				DiskSize: "64G",
+			},
 		},
 	}
 	builder := Builder{context: ctx}
@@ -74,6 +77,7 @@ func TestWriteModifyScript(t *testing.T) {
 				"download /boot/grub2/grub.cfg /tmp/grub.cfg",
 				"btrfs filesystem label / INSTALL",
 				"sed -i '/ignition.platform/ s/$/ alpha beta /' /tmp/grub.cfg",
+				"truncate -s 64G",
 			},
 			expectedMissing: []string{},
 		},

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -78,6 +78,7 @@ func TestWriteModifyScript(t *testing.T) {
 				"btrfs filesystem label / INSTALL",
 				"sed -i '/ignition.platform/ s/$/ alpha beta /' /tmp/grub.cfg",
 				"truncate -s 64G",
+				"virt-resize --expand /dev/sda3",
 			},
 			expectedMissing: []string{},
 		},

--- a/pkg/build/templates/modify-raw-image.sh.tpl
+++ b/pkg/build/templates/modify-raw-image.sh.tpl
@@ -12,6 +12,17 @@ set -euo pipefail
 #
 # Guestfish Command Documentation: https://libguestfs.org/guestfish.1.html
 
+# Resize the raw disk image to accommodate the users desired raw disk image size
+# This is also required if embedding content into /combustion, especially for airgap.
+# Should *only* execute if the user is building a raw disk image.
+{{ if ne .DiskSize "" -}}
+truncate -r {{.ImagePath}} {{.ImagePath}}.expanded
+truncate -s {{.DiskSize}} {{.ImagePath}}.expanded
+virt-resize --expand /dev/sda3 {{.ImagePath}} {{.ImagePath}}.expanded
+cp {{.ImagePath}}.expanded {{.ImagePath}}
+rm -f {{.ImagePath}}.expanded
+{{ end }}
+
 guestfish --format=raw --rw -a {{.ImagePath}} -i <<'EOF'
   # Enables write access to the read only filesystem
   sh "btrfs property set / ro false"

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -56,20 +56,25 @@ type Image struct {
 }
 
 type OperatingSystem struct {
-	KernelArgs      []string              `yaml:"kernelArgs"`
-	Users           []OperatingSystemUser `yaml:"users"`
-	Systemd         Systemd               `yaml:"systemd"`
-	Suma            Suma                  `yaml:"suma"`
-	Packages        Packages              `yaml:"packages"`
-	IsoInstallation IsoInstallation       `yaml:"isoInstallation"`
-	Time            Time                  `yaml:"time"`
-	Proxy           Proxy                 `yaml:"proxy"`
-	Keymap          string                `yaml:"keymap"`
+	KernelArgs       []string              `yaml:"kernelArgs"`
+	Users            []OperatingSystemUser `yaml:"users"`
+	Systemd          Systemd               `yaml:"systemd"`
+	Suma             Suma                  `yaml:"suma"`
+	Packages         Packages              `yaml:"packages"`
+	IsoInstallation  IsoInstallation       `yaml:"isoInstallation"`
+	RawConfiguration RawConfiguration      `yaml:"rawConfiguration"`
+	Time             Time                  `yaml:"time"`
+	Proxy            Proxy                 `yaml:"proxy"`
+	Keymap           string                `yaml:"keymap"`
 }
 
 type IsoInstallation struct {
 	InstallDevice string `yaml:"installDevice"`
 	Unattended    bool   `yaml:"unattended"`
+}
+
+type RawConfiguration struct {
+	DiskSize string `yaml:"diskSize"`
 }
 
 type Packages struct {

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -1,6 +1,6 @@
 apiVersion: 1.0
 image:
-  imageType: ISO
+  imageType: iso
   arch: x86_64
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
@@ -8,6 +8,8 @@ operatingSystem:
   isoInstallation:
     installDevice: /dev/sda
     unattended: true
+  rawConfiguration:
+    diskSize: 32G
   time:
     timezone: Europe/London
     ntp:

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -228,21 +228,21 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 		return nil
 	}
 
-	if def.Image.ImageType != image.TypeRAW && def.OperatingSystem.RawConfiguration.DiskSize != "" {
+	if def.Image.ImageType != image.TypeRAW {
 		msg := fmt.Sprintf("The 'rawConfiguration/diskSize' field can only be used when 'image type' is '%s'.", image.TypeRAW)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})
 	}
 
-	if def.OperatingSystem.RawConfiguration.DiskSize != "" && def.OperatingSystem.IsoInstallation.InstallDevice != "" {
+	if def.OperatingSystem.IsoInstallation.InstallDevice != "" {
 		msg := "You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type."
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})
 	}
 
-	if def.OperatingSystem.RawConfiguration.DiskSize != "" && !isValidSize(def.OperatingSystem.RawConfiguration.DiskSize) {
+	if !isValidSize(def.OperatingSystem.RawConfiguration.DiskSize) {
 		msg := fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -222,7 +222,7 @@ func validateUnattended(def *image.Definition) []FailedValidation {
 
 func validateRawConfig(def *image.Definition) []FailedValidation {
 	var failures []FailedValidation
-	isValidSize := regexp.MustCompile(`[0-9]+[MGT]`).MatchString
+	isValidSize := regexp.MustCompile(`^([1-9]\d+|[1-9])+[MGT]`).MatchString
 
 	if def.Image.ImageType != image.TypeRAW && def.OperatingSystem.RawConfiguration.DiskSize != "" {
 		msg := fmt.Sprintf("The 'rawConfiguration/diskSize' field can only be used when 'image type' is '%s'.", image.TypeRAW)
@@ -232,7 +232,7 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 	}
 
 	if def.OperatingSystem.RawConfiguration.DiskSize != "" && def.OperatingSystem.IsoInstallation.InstallDevice != "" {
-		msg := fmt.Sprint("You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type.")
+		msg := "You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type."
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -224,6 +224,10 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 	var failures []FailedValidation
 	isValidSize := regexp.MustCompile(`^([1-9]\d+|[1-9])+[MGT]`).MatchString
 
+	if def.OperatingSystem.RawConfiguration.DiskSize == "" {
+		return nil
+	}
+
 	if def.Image.ImageType != image.TypeRAW && def.OperatingSystem.RawConfiguration.DiskSize != "" {
 		msg := fmt.Sprintf("The 'rawConfiguration/diskSize' field can only be used when 'image type' is '%s'.", image.TypeRAW)
 		failures = append(failures, FailedValidation{

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -229,7 +229,7 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 	}
 
 	if def.Image.ImageType != image.TypeRAW {
-		msg := fmt.Sprintf("The 'rawConfiguration/diskSize' field can only be used when 'image type' is '%s'.", image.TypeRAW)
+		msg := fmt.Sprintf("The 'rawConfiguration/diskSize' field can only be used when 'imageType' is '%s'.", image.TypeRAW)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})
@@ -243,7 +243,7 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 	}
 
 	if !isValidSize(def.OperatingSystem.RawConfiguration.DiskSize) {
-		msg := fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW)
+		msg := fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -592,7 +592,7 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 		},
-		`diskSize invalid`: {
+		`diskSize invalid as invalid suffix`: {
 			Definition: image.Definition{
 				Image: image.Image{
 					ImageType: image.TypeRAW,
@@ -600,6 +600,21 @@ func TestValidateRawConfiguration(t *testing.T) {
 				OperatingSystem: image.OperatingSystem{
 					RawConfiguration: image.RawConfiguration{
 						DiskSize: "130B",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW),
+			},
+		},
+		`diskSize invalid as zero`: {
+			Definition: image.Definition{
+				Image: image.Image{
+					ImageType: image.TypeRAW,
+				},
+				OperatingSystem: image.OperatingSystem{
+					RawConfiguration: image.RawConfiguration{
+						DiskSize: "0G",
 					},
 				},
 			},

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -80,6 +80,9 @@ func TestValidateOperatingSystem(t *testing.T) {
 						Unattended:    true,
 						InstallDevice: "/dev/sda",
 					},
+					RawConfiguration: image.RawConfiguration{
+						DiskSize: "64",
+					},
 				},
 			},
 			ExpectedFailedMessages: []string{
@@ -90,6 +93,8 @@ func TestValidateOperatingSystem(t *testing.T) {
 				"When including the 'packageList' field, either additional repositories or a registration code must be included.",
 				fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 				fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW),
+				"You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type.",
 			},
 		},
 	}
@@ -553,6 +558,61 @@ func TestValidateUnattended(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			def := test.Definition
 			failures := validateUnattended(&def)
+			assert.Len(t, failures, len(test.ExpectedFailedMessages))
+
+			var foundMessages []string
+			for _, foundValidation := range failures {
+				foundMessages = append(foundMessages, foundValidation.UserMessage)
+			}
+
+			for _, expectedMessage := range test.ExpectedFailedMessages {
+				assert.Contains(t, foundMessages, expectedMessage)
+			}
+		})
+	}
+}
+
+func TestValidateRawConfiguration(t *testing.T) {
+	tests := map[string]struct {
+		Definition             image.Definition
+		ExpectedFailedMessages []string
+	}{
+		`not included`: {
+			Definition: image.Definition{},
+		},
+		`diskSize specified and valid`: {
+			Definition: image.Definition{
+				Image: image.Image{
+					ImageType: image.TypeRAW,
+				},
+				OperatingSystem: image.OperatingSystem{
+					RawConfiguration: image.RawConfiguration{
+						DiskSize: "64G",
+					},
+				},
+			},
+		},
+		`diskSize invalid`: {
+			Definition: image.Definition{
+				Image: image.Image{
+					ImageType: image.TypeRAW,
+				},
+				OperatingSystem: image.OperatingSystem{
+					RawConfiguration: image.RawConfiguration{
+						DiskSize: "130B",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			def := test.Definition
+			failures := validateRawConfig(&def)
 			assert.Len(t, failures, len(test.ExpectedFailedMessages))
 
 			var foundMessages []string

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -93,7 +93,7 @@ func TestValidateOperatingSystem(t *testing.T) {
 				"When including the 'packageList' field, either additional repositories or a registration code must be included.",
 				fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 				fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
-				fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW),
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
 				"You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type.",
 			},
 		},
@@ -604,7 +604,7 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW),
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
 			},
 		},
 		`diskSize invalid as zero`: {
@@ -619,7 +619,52 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("the 'rawConfiguration/diskSize' field must require an integer followed by an 'M/G/T' suffix to indicate size when 'imageType' is '%s'.", image.TypeRAW),
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+			},
+		},
+		`diskSize invalid as lowercase character`: {
+			Definition: image.Definition{
+				Image: image.Image{
+					ImageType: image.TypeRAW,
+				},
+				OperatingSystem: image.OperatingSystem{
+					RawConfiguration: image.RawConfiguration{
+						DiskSize: "100g",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+			},
+		},
+		`diskSize invalid as negative number`: {
+			Definition: image.Definition{
+				Image: image.Image{
+					ImageType: image.TypeRAW,
+				},
+				OperatingSystem: image.OperatingSystem{
+					RawConfiguration: image.RawConfiguration{
+						DiskSize: "-100G",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+			},
+		},
+		`diskSize invalid as no number provided`: {
+			Definition: image.Definition{
+				Image: image.Image{
+					ImageType: image.TypeRAW,
+				},
+				OperatingSystem: image.OperatingSystem{
+					RawConfiguration: image.RawConfiguration{
+						DiskSize: "G",
+					},
+				},
+			},
+			ExpectedFailedMessages: []string{
+				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
 			},
 		},
 	}


### PR DESCRIPTION
This PR enables the user to specify a desired raw disk image size, this has two key benefits, firstly ensuring that the initial disk image is resized to accommodate the combustion directory accordingly, and secondly to set the size of the partitions for its first boot, noting that if there's any additional space the system will resize to the maximum block size automatically. This change also helps with automated testing and virtual setups, where there's no physical block device that's being used.