### PR TITLE
Support unsigned RPM repositories

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -80,6 +80,8 @@ operatingSystem:
       - pkg2
     additionalRepos:
       - url: https://foo.bar
+      - url: https://foo.baz
+        unsigned: true
     sccRegistrationCode: scc-reg-code
 ```
 
@@ -118,7 +120,7 @@ operatingSystem:
 * `packages` - Optional; Defines packages that should have their dependencies determined and pre-loaded into the built image. For detailed information on how to use this configuration, see the [Installing pacakges](installing-packages.md) guide.
   * `noGPGCheck` - Optional; Defines whether GPG validation should be disabled for all additional repositories and side-loaded RPMs. **Disabling GPG validation is intended for development purposes only!**
   * `packageList` - Optional; List of packages that are to be installed from SUSE's internal RPM repositories or from additionally provided third-party repositories.
-  * `additionalRepos` - Optional; List of third-party RPM repository URLs that will be added to the package manager of the OS.
+  * `additionalRepos` - Optional; List of third-party RPM repositories that will be added to the package manager of the OS.
   * `sccRegistrationCode` - Optional; SUSE Customer Center registration code, used to connect to SUSE's internal RPM repositories.
 
 ## SUSE Manager (SUMA)

--- a/docs/installing-packages.md
+++ b/docs/installing-packages.md
@@ -26,8 +26,11 @@ operatingSystem:
       - reiserfs-kmp-default-debuginfo
     additionalRepos:
       - url: https://download.opensuse.org/repositories/Kernel:/SLE15-SP5/pool
+      - url: https://rpm.rancher.io/rke2/stable/common/slemicro/noarch
+        unsigned: true
 ```
-> **_NOTE:_** Before adding any repositories under `additionalRepos`, make sure that they are signed with a valid GPG key. **All non-signed additional repositories will cause EIB to fail.**
+> **_NOTE:_** Before adding any repositories under `additionalRepos`, make sure that they are signed with a valid GPG key.
+> **All non-signed additional repositories will cause EIB to fail unless they are explicitly labeled as `unsigned`.**
 
 #### Install a package from SUSE's internal repositories
 ```yaml
@@ -51,10 +54,10 @@ EIB configuration directory tree:
 .
 ├── eib-config-iso.yaml
 ├── base-images
-│   └── SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw
+│   └── SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw
 └── rpms
     ├── gpg-keys
-    │   └── reiserfs-kpm-default-debuginfo.key
+    │   └── reiserfs-kpm-default-debuginfo.key
     └── reiserfs-kmp-default-debuginfo-5.14.21-150500.205.1.g8725a95.x86_64.rpm
 ```
 
@@ -62,7 +65,7 @@ EIB config file `packages` configuration:
 ```yaml
 operatingSystem:
   packages:
-    sccRegistrationCode:
+    additionalRepos:
       - url: https://download.opensuse.org/repositories/Kernel:/SLE15-SP5/pool
 ```
 
@@ -72,10 +75,10 @@ EIB configuration directory tree:
 .
 ├── eib-config-iso.yaml
 ├── base-images
-│   └── SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw
+│   └── SLE-Micro.x86_64-5.5.0-Default-RT-GM.raw
 └── rpms
     ├── gpg-keys
-    │   └── git.key
+    │   └── git.key
     └── git-2.35.3-150300.10.33.1.x86_64.rpm
 ```
 
@@ -83,11 +86,12 @@ EIB config file `packages` configuration:
 ```yaml
 operatingSystem:
   packages:
-    additionalRepos: <your-reg-code>
+    sccRegistrationCode: <your-reg-code>
 ```
 
 ### Installing unsigned packages
-By default EIB does GPG validation for every **additional repository** and **side-loaded RPM**. If you wish to use unsigned additional repositories and/or unsigned RPMs you must add the `noGPGCheck: true` property to EIB's `packages` configuration, like so:
+By default, EIB does GPG validation for every **additional repository** and **side-loaded RPM**.
+If you wish to use unsigned additional repositories and/or unsigned RPMs you must add the `noGPGCheck: true` property to EIB's `packages` configuration, like so:
 ```yaml
 operatingSystem:
   packages:

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -80,7 +80,8 @@ type Packages struct {
 }
 
 type AddRepo struct {
-	URL string `yaml:"url"`
+	URL      string `yaml:"url"`
+	Unsigned bool   `yaml:"unsigned"`
 }
 
 type OperatingSystemUser struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -82,7 +82,8 @@ func TestParse(t *testing.T) {
 			URL: "https://download.nvidia.com/suse/sle15sp5/",
 		},
 		{
-			URL: "https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/",
+			URL:      "https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/",
+			Unsigned: true,
 		},
 	}
 	assert.Equal(t, expectedAddRepos, pkgConfig.AdditionalRepos)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -57,6 +57,7 @@ operatingSystem:
     additionalRepos:
       - url: https://download.nvidia.com/suse/sle15sp5/
       - url: https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/
+        unsigned: true
     sccRegistrationCode: INTERNAL-USE-ONLY-foo-bar
 embeddedArtifactRegistry:
   images:

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -157,7 +157,7 @@ func (r *Resolver) writeDockerfile(localRPMConfig *image.LocalRPMConfig, package
 	values := struct {
 		BaseImage    string
 		RegCode      string
-		AddRepo      string
+		AddRepo      []image.AddRepo
 		CacheDir     string
 		PKGList      string
 		LocalRPMList string
@@ -170,7 +170,7 @@ func (r *Resolver) writeDockerfile(localRPMConfig *image.LocalRPMConfig, package
 	}{
 		BaseImage:  r.baseImageRef,
 		RegCode:    packages.RegCode,
-		AddRepo:    r.generateAddRepoStr(packages.AdditionalRepos),
+		AddRepo:    packages.AdditionalRepos,
 		CacheDir:   r.generateResolverImgRPMRepoPath(),
 		NoGPGCheck: packages.NoGPGCheck,
 	}
@@ -202,15 +202,6 @@ func (r *Resolver) writeDockerfile(localRPMConfig *image.LocalRPMConfig, package
 	}
 
 	return nil
-}
-
-func (r *Resolver) generateAddRepoStr(repos []image.AddRepo) string {
-	list := []string{}
-	for _, repo := range repos {
-		list = append(list, repo.URL)
-	}
-
-	return strings.Join(list, " ")
 }
 
 func (r *Resolver) generatePKGInstallList(packages *image.Packages) []string {

--- a/pkg/rpm/resolver/templates/Dockerfile.tpl
+++ b/pkg/rpm/resolver/templates/Dockerfile.tpl
@@ -26,17 +26,17 @@ RUN SLE_SP=$(cat /etc/rpm/macros.sle | awk '/sle/ {print $2};' | cut -c4) && sus
 RUN zypper ref
 {{ end -}}
 
-{{ if ne .AddRepo "" }}
-RUN counter=1 && \
-    for i in {{.AddRepo}}; \
-    do \
-      {{ if not .NoGPGCheck -}}
-      zypper ar -f $i addrepo$counter; \
-      {{ else -}}
-      zypper ar --no-gpgcheck -f $i addrepo$counter; \
-      {{ end -}}
-      counter=$((counter+1)); \
-    done
+{{- range $index, $repo := .AddRepo }}
+
+{{- $gpgCheck := "" -}}
+{{- if $.NoGPGCheck -}}
+{{ $gpgCheck = "--no-gpgcheck" }}
+{{- else if .Unsigned -}}
+{{ $gpgCheck = "--gpgcheck-allow-unsigned-repo" }}
+{{- end -}}
+
+RUN zypper ar {{ $gpgCheck }} -f {{ .URL }} addrepo {{- $index }}
+
 {{ end -}}
 
 {{ if and .LocalGPGList (not .NoGPGCheck) }}


### PR DESCRIPTION
- Adjusts the templating to allow unsigned RPM repositories

- Example 1: 

```
AddRepo:
 - URL: https://rpm.rancher.io/rke2/stable/common/slemicro/noarch
   Unsigned: true
 - URL: https://download.nvidia.com/suse/sle15sp5/
NoGPGCheck: false
```

=>

```
RUN zypper ar --gpgcheck-allow-unsigned-repo -f https://rpm.rancher.io/rke2/stable/common/slemicro/noarch addrepo0

RUN zypper ar  -f https://download.nvidia.com/suse/sle15sp5/ addrepo1
```

- Example 2:

```
AddRepo:
 - URL: https://rpm.rancher.io/rke2/stable/common/slemicro/noarch
   Unsigned: true
 - URL: https://download.nvidia.com/suse/sle15sp5/
NoGPGCheck: true
```

=>

```
RUN zypper ar --no-gpgcheck -f https://rpm.rancher.io/rke2/stable/common/slemicro/noarch addrepo0

RUN zypper ar --no-gpgcheck -f https://download.nvidia.com/suse/sle15sp5/ addrepo1
```