### PR TITLE
renamed isoInstallation section to isoConfiguration

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -37,7 +37,7 @@ The operating system configuration section is entirely optional.
 The following describes the possible options for the operating system section:
 ```yaml
 operatingSystem:
-  isoInstallation:
+  isoConfiguration:
     installDevice: /path/to/disk
     unattended: false
   time:
@@ -85,7 +85,7 @@ operatingSystem:
     sccRegistrationCode: scc-reg-code
 ```
 
-* `isoInstallation` - Optional; configuration in this section only applies to ISO images.
+* `isoConfiguration` - Optional; configuration in this section only applies to ISO images.
   * `installDevice` - Optional; specifies the disk that should be used as the install
   device. This needs to be block special, and will default to automatically wipe any data found on the disk.
   If left omitted, the user will still have to select the disk to install to (if >1 found) and confirm wipe.

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -123,8 +123,8 @@ func (b *Builder) writeIsoScript(templateContents, outputFilename string) error 
 		IsoSource:           b.generateBaseImageFilename(),
 		OutputImageFilename: b.generateOutputImageFilename(),
 		CombustionDir:       b.context.CombustionDir,
-		InstallDevice:       b.context.ImageDefinition.OperatingSystem.IsoInstallation.InstallDevice,
-		Unattended:          b.context.ImageDefinition.OperatingSystem.IsoInstallation.Unattended,
+		InstallDevice:       b.context.ImageDefinition.OperatingSystem.IsoConfiguration.InstallDevice,
+		Unattended:          b.context.ImageDefinition.OperatingSystem.IsoConfiguration.Unattended,
 	}
 
 	contents, err := template.Parse("iso-script", templateContents, arguments)

--- a/pkg/build/iso_test.go
+++ b/pkg/build/iso_test.go
@@ -131,7 +131,7 @@ func TestWriteIsoScript_Rebuild(t *testing.T) {
 
 	ctx.ImageDefinition = &image.Definition{
 		OperatingSystem: image.OperatingSystem{
-			IsoInstallation: image.IsoInstallation{
+			IsoConfiguration: image.IsoConfiguration{
 				InstallDevice: "/dev/vda",
 				Unattended:    true,
 			},

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -61,14 +61,14 @@ type OperatingSystem struct {
 	Systemd          Systemd               `yaml:"systemd"`
 	Suma             Suma                  `yaml:"suma"`
 	Packages         Packages              `yaml:"packages"`
-	IsoInstallation  IsoInstallation       `yaml:"isoInstallation"`
+	IsoConfiguration IsoConfiguration      `yaml:"isoConfiguration"`
 	RawConfiguration RawConfiguration      `yaml:"rawConfiguration"`
 	Time             Time                  `yaml:"time"`
 	Proxy            Proxy                 `yaml:"proxy"`
 	Keymap           string                `yaml:"keymap"`
 }
 
-type IsoInstallation struct {
+type IsoConfiguration struct {
 	InstallDevice string `yaml:"installDevice"`
 	Unattended    bool   `yaml:"unattended"`
 }

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -89,11 +89,11 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, expectedAddRepos, pkgConfig.AdditionalRepos)
 	assert.Equal(t, "INTERNAL-USE-ONLY-foo-bar", pkgConfig.RegCode)
 
-	// Operating System -> IsoInstallation
-	installDevice := definition.OperatingSystem.IsoInstallation.InstallDevice
+	// Operating System -> IsoConfiguration
+	installDevice := definition.OperatingSystem.IsoConfiguration.InstallDevice
 	assert.Equal(t, "/dev/sda", installDevice)
 
-	unattended := definition.OperatingSystem.IsoInstallation.Unattended
+	unattended := definition.OperatingSystem.IsoConfiguration.Unattended
 	assert.Equal(t, true, unattended)
 
 	// Operating System -> Time

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -5,7 +5,7 @@ image:
   baseImage: slemicro5.5.iso
   outputImageName: eibimage.iso
 operatingSystem:
-  isoInstallation:
+  isoConfiguration:
     installDevice: /dev/sda
     unattended: true
   rawConfiguration:

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -204,14 +204,14 @@ func validateUnattended(def *image.Definition) []FailedValidation {
 	var failures []FailedValidation
 
 	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoConfiguration.Unattended {
-		msg := fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO)
+		msg := fmt.Sprintf("The 'isoConfiguration/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})
 	}
 
 	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoConfiguration.InstallDevice != "" {
-		msg := fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO)
+		msg := fmt.Sprintf("The 'isoConfiguration/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})
@@ -236,7 +236,7 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 	}
 
 	if def.OperatingSystem.IsoConfiguration.InstallDevice != "" {
-		msg := "You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type."
+		msg := "You cannot simultaneously configure rawConfiguration and isoConfiguration, regardless of image type."
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -203,14 +203,14 @@ func validatePackages(os *image.OperatingSystem) []FailedValidation {
 func validateUnattended(def *image.Definition) []FailedValidation {
 	var failures []FailedValidation
 
-	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoInstallation.Unattended {
+	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoConfiguration.Unattended {
 		msg := fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})
 	}
 
-	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoInstallation.InstallDevice != "" {
+	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoConfiguration.InstallDevice != "" {
 		msg := fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO)
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
@@ -235,7 +235,7 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 		})
 	}
 
-	if def.OperatingSystem.IsoInstallation.InstallDevice != "" {
+	if def.OperatingSystem.IsoConfiguration.InstallDevice != "" {
 		msg := "You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type."
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -91,10 +91,10 @@ func TestValidateOperatingSystem(t *testing.T) {
 				"User 'danny' must have either a password or SSH key.",
 				"The 'host' field is required for the 'suma' section.",
 				"When including the 'packageList' field, either additional repositories or a registration code must be included.",
-				fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
-				fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoConfiguration/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoConfiguration/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
-				"You cannot simultaneously configure rawConfiguration and isoInstallation, regardless of image type.",
+				"You cannot simultaneously configure rawConfiguration and isoConfiguration, regardless of image type.",
 			},
 		},
 	}
@@ -534,7 +534,7 @@ func TestValidateUnattended(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'isoInstallation/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoConfiguration/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 			},
 		},
 		`not iso install device`: {
@@ -549,7 +549,7 @@ func TestValidateUnattended(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'isoInstallation/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
+				fmt.Sprintf("The 'isoConfiguration/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 			},
 		},
 	}

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -47,7 +47,7 @@ func TestValidateOperatingSystem(t *testing.T) {
 						},
 						RegCode: "letMeIn",
 					},
-					IsoInstallation: image.IsoInstallation{
+					IsoConfiguration: image.IsoConfiguration{
 						Unattended:    true,
 						InstallDevice: "/dev/sda",
 					},
@@ -76,7 +76,7 @@ func TestValidateOperatingSystem(t *testing.T) {
 					Packages: image.Packages{
 						PKGList: []string{"zsh", "git"},
 					},
-					IsoInstallation: image.IsoInstallation{
+					IsoConfiguration: image.IsoConfiguration{
 						Unattended:    true,
 						InstallDevice: "/dev/sda",
 					},
@@ -515,7 +515,7 @@ func TestValidateUnattended(t *testing.T) {
 					ImageType: image.TypeISO,
 				},
 				OperatingSystem: image.OperatingSystem{
-					IsoInstallation: image.IsoInstallation{
+					IsoConfiguration: image.IsoConfiguration{
 						Unattended:    true,
 						InstallDevice: "/dev/sda",
 					},
@@ -528,7 +528,7 @@ func TestValidateUnattended(t *testing.T) {
 					ImageType: image.TypeRAW,
 				},
 				OperatingSystem: image.OperatingSystem{
-					IsoInstallation: image.IsoInstallation{
+					IsoConfiguration: image.IsoConfiguration{
 						Unattended: true,
 					},
 				},
@@ -543,7 +543,7 @@ func TestValidateUnattended(t *testing.T) {
 					ImageType: image.TypeRAW,
 				},
 				OperatingSystem: image.OperatingSystem{
-					IsoInstallation: image.IsoInstallation{
+					IsoConfiguration: image.IsoConfiguration{
 						InstallDevice: "/dev/sda",
 					},
 				},


### PR DESCRIPTION
When `rawConfiguration` was added, we talked about renaming this field to match for consistency.