### PR TITLE
Remove package list validation

### DIFF
--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -191,12 +191,6 @@ func validatePackages(os *image.OperatingSystem) []FailedValidation {
 		}
 	}
 
-	if len(os.Packages.PKGList) > 0 && len(os.Packages.AdditionalRepos) == 0 && os.Packages.RegCode == "" {
-		failures = append(failures, FailedValidation{
-			UserMessage: "When including the 'packageList' field, either additional repositories or a registration code must be included.",
-		})
-	}
-
 	return failures
 }
 

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -90,7 +90,6 @@ func TestValidateOperatingSystem(t *testing.T) {
 				"Systemd conflict found, 'confusedUser' is both enabled and disabled.",
 				"User 'danny' must have either a password or SSH key.",
 				"The 'host' field is required for the 'suma' section.",
-				"When including the 'packageList' field, either additional repositories or a registration code must be included.",
 				fmt.Sprintf("The 'isoConfiguration/unattended' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 				fmt.Sprintf("The 'isoConfiguration/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
 				fmt.Sprintf("the 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
@@ -430,14 +429,6 @@ func TestPackages(t *testing.T) {
 					},
 				},
 				RegCode: "regcode",
-			},
-		},
-		`package list only`: {
-			Packages: image.Packages{
-				PKGList: []string{"foo", "bar"},
-			},
-			ExpectedFailedMessages: []string{
-				"When including the 'packageList' field, either additional repositories or a registration code must be included.",
 			},
 		},
 		`duplicate packages`: {


### PR DESCRIPTION
Remove the validation for the `packageList` RPM resolution property.

Use-case for this is that we want to be able to install packages on openSUSE images without having to provide a third-party repository or a registration code.