### PR TITLE
added basic schema version validation for 1.0

### DIFF
--- a/pkg/image/validation/api_version.go
+++ b/pkg/image/validation/api_version.go
@@ -2,6 +2,10 @@ package validation
 
 import "github.com/suse-edge/edge-image-builder/pkg/image"
 
+const (
+	apiVersionComponent = "Definition Schema"
+)
+
 func validateAPIVersion(ctx *image.Context) *FailedValidation {
 	definitionVersion := ctx.ImageDefinition.APIVersion
 

--- a/pkg/image/validation/api_version.go
+++ b/pkg/image/validation/api_version.go
@@ -1,0 +1,15 @@
+package validation
+
+import "github.com/suse-edge/edge-image-builder/pkg/image"
+
+func validateAPIVersion(ctx *image.Context) *FailedValidation {
+	definitionVersion := ctx.ImageDefinition.APIVersion
+
+	if definitionVersion != "1.0" {
+		return &FailedValidation{
+			UserMessage: "This version of Edge Image Builder only supports version '1.0' of the definition schema.",
+		}
+	}
+
+	return nil
+}

--- a/pkg/image/validation/api_version_test.go
+++ b/pkg/image/validation/api_version_test.go
@@ -1,0 +1,42 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestValidateApiVersion(t *testing.T) {
+	tests := map[string]struct {
+		Definition            image.Definition
+		ExpectedFailedMessage string
+	}{
+		`valid`: {
+			Definition: image.Definition{
+				APIVersion: "1.0",
+			},
+		},
+		`invalid`: {
+			Definition: image.Definition{
+				APIVersion: "1.1",
+			},
+			ExpectedFailedMessage: "This version of Edge Image Builder only supports version '1.0' of the definition schema.",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			def := test.Definition
+			ctx := image.Context{
+				ImageDefinition: &def,
+			}
+			failure := validateAPIVersion(&ctx)
+			if test.ExpectedFailedMessage == "" {
+				assert.Nil(t, failure)
+			} else {
+				assert.Equal(t, test.ExpectedFailedMessage, failure.UserMessage)
+			}
+		})
+	}
+}

--- a/pkg/image/validation/validation.go
+++ b/pkg/image/validation/validation.go
@@ -14,6 +14,14 @@ type validateComponent func(ctx *image.Context) []FailedValidation
 func ValidateDefinition(ctx *image.Context) map[string][]FailedValidation {
 	failures := map[string][]FailedValidation{}
 
+	schemaValidationFailure := validateAPIVersion(ctx)
+	if schemaValidationFailure != nil {
+		// If the schema is invalid, there's no reason to even attempt the rest of
+		// the validation
+		failures["Definition Schema"] = []FailedValidation{*schemaValidationFailure}
+		return failures
+	}
+
 	validations := map[string]validateComponent{
 		imageComponent:    validateImage,
 		osComponent:       validateOperatingSystem,

--- a/pkg/image/validation/validation.go
+++ b/pkg/image/validation/validation.go
@@ -18,7 +18,7 @@ func ValidateDefinition(ctx *image.Context) map[string][]FailedValidation {
 	if schemaValidationFailure != nil {
 		// If the schema is invalid, there's no reason to even attempt the rest of
 		// the validation
-		failures["Definition Schema"] = []FailedValidation{*schemaValidationFailure}
+		failures[apiVersionComponent] = []FailedValidation{*schemaValidationFailure}
 		return failures
 	}
 


### PR DESCRIPTION
I'm writing up a design doc detailing the rules we're going to follow when it comes to changing the schema version, but in the interest of getting the first RC built, I'm going to do that in a separate PR in case we go back and forth on the phrasing and handling.