### PR TITLE
Reject unknown image definition fields

### DIFF
--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -150,7 +151,10 @@ type Manifests struct {
 func ParseDefinition(data []byte) (*Definition, error) {
 	var definition Definition
 
-	if err := yaml.Unmarshal(data, &definition); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+
+	if err := decoder.Decode(&definition); err != nil {
 		return nil, fmt.Errorf("could not parse the image definition: %w", err)
 	}
 	definition.Image.ImageType = strings.ToLower(definition.Image.ImageType)

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -155,7 +155,7 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "https://k8s.io/examples/application/nginx-app.yaml", kubernetes.Manifests.URLs[0])
 }
 
-func TestParseBadConfig(t *testing.T) {
+func TestParseBadConfig_InvalidFormat(t *testing.T) {
 	// Setup
 	badData := []byte("Not actually YAML")
 
@@ -165,6 +165,25 @@ func TestParseBadConfig(t *testing.T) {
 	// Verify
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "could not parse the image definition")
+	assert.ErrorContains(t, err, "line 1: cannot unmarshal !!str")
+}
+
+func TestParseBadConfig_UnknownFields(t *testing.T) {
+	badConfig := `
+apiVersion: 1.0
+image:
+  type: iso
+operatingSystem:
+  time:
+    zone: Europe/London
+`
+
+	_, err := ParseDefinition([]byte(badConfig))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "could not parse the image definition")
+	assert.ErrorContains(t, err, "line 4: field type not found in type image.Image")
+	assert.ErrorContains(t, err, "line 7: field zone not found in type image.Time")
 }
 
 func TestArch_Short(t *testing.T) {


### PR DESCRIPTION
- Rejects unknown / mistyped fields in the image definition
- A better validation / schema versioning approach can be revisited later (from a UX perspective)