### PR TITLE
Add warning message when missing registration code and additional repos for packageList

### DIFF
--- a/pkg/combustion/rpm.go
+++ b/pkg/combustion/rpm.go
@@ -37,13 +37,13 @@ func configureRPMs(ctx *image.Context) ([]string, error) {
 
 	packages := &ctx.ImageDefinition.OperatingSystem.Packages
 	if packages.NoGPGCheck {
-		log.Auditf("WARNING: Running EIB with disabled GPG validation is intended for development purposes only")
+		log.Audit("WARNING: Running EIB with disabled GPG validation is intended for development purposes only")
 		zap.S().Warn("Disabling GPG validation for the EIB RPM resolver")
 	}
 
 	// package list specified without either a sccRegistrationCode or an additionalRepos entry
 	if len(packages.PKGList) > 0 && (packages.RegCode == "" && len(packages.AdditionalRepos) == 0) {
-		log.Auditf("WARNING: No SUSE registration code or additional repositories provided, package resolution may fail if you're using SLE Micro as the base image")
+		log.Audit("WARNING: No SUSE registration code or additional repositories provided, package resolution may fail if you're using SLE Micro as the base image")
 		zap.S().Warn("Detected packages for installation with no sccRegistrationCode or additionalRepos provided")
 	}
 

--- a/pkg/combustion/rpm.go
+++ b/pkg/combustion/rpm.go
@@ -41,6 +41,12 @@ func configureRPMs(ctx *image.Context) ([]string, error) {
 		zap.S().Warn("Disabling GPG validation for the EIB RPM resolver")
 	}
 
+	// package list specified without either a sccRegistrationCode or an additionalRepos entry
+	if len(packages.PKGList) > 0 && (packages.RegCode == "" && len(packages.AdditionalRepos) == 0) {
+		log.Auditf("WARNING: No SUSE registration code or additional repositories provided, package resolution may fail if you're using SLE Micro as the base image")
+		zap.S().Warn("Detected packages for installation with no sccRegistrationCode or additionalRepos provided")
+	}
+
 	var localRPMConfig *image.LocalRPMConfig
 	if isComponentConfigured(ctx, userRPMsDir) {
 		rpmDir := RPMsPath(ctx)


### PR DESCRIPTION
Add a warning log to the RPM resolution process when a `packageList` has been provided without a `sccRegistrationCode` or and `additionalRepos` entry

Config:
```yaml
operatingSystem:
  packages:
    packageList:
    - git 
```

Sample output:
```shell
Generating image customization components...
Identifier ................... [SUCCESS]
Custom Files ................. [SKIPPED]
Time ......................... [SKIPPED]
Network ...................... [SKIPPED]
Users ........................ [SUCCESS]
Proxy ........................ [SKIPPED]
WARNING: No SUSE registration code or additional repositories provided, package resolution may fail if you're using SLE Micro as the base image
Resolving package dependencies...
```