### PR TITLE
Allow custom network configuration scripts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,4 +3,5 @@
 ## Next
 
 * Added support for deploying user-provided Helm charts
+* Added support for custom network configuration scripts
 * Removed the `embeddedArtifactRegistry/images/supplyChainKey` attribute

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -199,7 +199,9 @@ There are a number of optional directories that may be included in the image con
     `30-suma-register.sh`). Unless absolutely sure the default flow should be interrupted, all custom scripts
     should be prefixed within the range 50-99 (e.g. `60-my-script.sh`).
   * `files` - If present, all the files in this directory will be included in the built image.
-* `network` - If present, network configurations will be generated from all desired states in this directory
+* `network` - May be included to inject custom network configuration script or desired network configurations.
+  * `configure-network.sh` - If present, this script will be used to initialize the network during the combustion phase.
+  Otherwise, network configurations will be generated from all desired states in this directory
   and will be included in the built image. The configurations relevant for the particular host will be identified
   and applied during the combustion phase. Check [nm-configurator](https://github.com/suse-edge/nm-configurator/)
   for more information.

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
 	"go.uber.org/zap"
 )
 
@@ -152,4 +153,13 @@ func isComponentConfigured(ctx *image.Context, componentDir string) bool {
 	}
 
 	return false
+}
+
+func logComponentStatus(component string, err error) {
+	if err != nil {
+		log.AuditComponentFailed(component)
+	} else {
+		log.AuditComponentSuccessful(component)
+		zap.S().Infof("Successfully configured %s component", component)
+	}
 }

--- a/pkg/combustion/network.go
+++ b/pkg/combustion/network.go
@@ -2,7 +2,9 @@ package combustion
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -20,6 +22,7 @@ const (
 	// output configurations subdirectory under combustion.
 	networkConfigDir        = "network"
 	networkConfigScriptName = "05-configure-network.sh"
+	networkCustomScriptName = "configure-network.sh"
 )
 
 //go:embed templates/05-configure-network.sh.tpl
@@ -27,9 +30,9 @@ var configureNetworkScript string
 
 // Configures the network component if enabled.
 //
-//  1. Generates network configurations
-//  2. Copies the NMC executable
-//  3. Writes the configuration script
+//  1. Copies the nmc executable
+//  2. Copies a custom network configuration script if provided
+//  3. Generates network configurations and writes the configuration script template otherwise
 //
 // Example result file layout:
 //
@@ -45,8 +48,8 @@ var configureNetworkScript string
 //	│   │   └── eth1.nmconnection
 //	│   └── host_config.yaml
 //	├── nmc
-//	└── 03-configure-network.sh
-func configureNetwork(ctx *image.Context) ([]string, error) {
+//	└── 05-configure-network.sh
+func configureNetwork(ctx *image.Context) (scripts []string, err error) {
 	zap.S().Info("Configuring network component...")
 
 	if !isComponentConfigured(ctx, networkConfigDir) {
@@ -55,26 +58,36 @@ func configureNetwork(ctx *image.Context) ([]string, error) {
 		return nil, nil
 	}
 
-	if err := generateNetworkConfig(ctx); err != nil {
-		log.AuditComponentFailed(networkComponentName)
-		return nil, fmt.Errorf("generating network config: %w", err)
-	}
+	defer func() {
+		logComponentStatus(networkComponentName, err)
+	}()
 
-	if err := installNetworkConfigurator(ctx); err != nil {
-		log.AuditComponentFailed(networkComponentName)
+	if err = installNetworkConfigurator(ctx); err != nil {
 		return nil, fmt.Errorf("installing configurator: %w", err)
 	}
 
-	scriptName, err := writeNetworkConfigurationScript(ctx)
-	if err != nil {
-		log.AuditComponentFailed(networkComponentName)
+	customScript := filepath.Join(generateComponentPath(ctx, networkConfigDir), networkCustomScriptName)
+	combustionScript := filepath.Join(ctx.CombustionDir, networkConfigScriptName)
+	scripts = append(scripts, networkConfigScriptName)
+
+	// Copy custom network script if provided.
+	// Proceed with generating configuration otherwise.
+	err = fileio.CopyFile(customScript, combustionScript, fileio.ExecutablePerms)
+	if err == nil {
+		return scripts, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("copying custom network script: %w", err)
+	}
+
+	if err = generateNetworkConfig(ctx); err != nil {
+		return nil, fmt.Errorf("generating network config: %w", err)
+	}
+
+	if err = writeNetworkConfigurationScript(combustionScript); err != nil {
 		return nil, fmt.Errorf("writing network configuration script: %w", err)
 	}
 
-	log.AuditComponentSuccessful(networkComponentName)
-	zap.S().Info("Successfully configured network component")
-
-	return []string{scriptName}, nil
+	return scripts, nil
 }
 
 func generateNetworkConfig(ctx *image.Context) error {
@@ -105,7 +118,7 @@ func installNetworkConfigurator(ctx *image.Context) error {
 	return ctx.NetworkConfiguratorInstaller.InstallConfigurator(sourcePath, installPath)
 }
 
-func writeNetworkConfigurationScript(ctx *image.Context) (string, error) {
+func writeNetworkConfigurationScript(scriptPath string) error {
 	values := struct {
 		ConfigDir string
 	}{
@@ -114,13 +127,12 @@ func writeNetworkConfigurationScript(ctx *image.Context) (string, error) {
 
 	data, err := template.Parse(networkConfigScriptName, configureNetworkScript, &values)
 	if err != nil {
-		return "", fmt.Errorf("parsing network template: %w", err)
+		return fmt.Errorf("parsing network template: %w", err)
 	}
 
-	filename := filepath.Join(ctx.CombustionDir, networkConfigScriptName)
-	if err = os.WriteFile(filename, []byte(data), fileio.ExecutablePerms); err != nil {
-		return "", fmt.Errorf("writing network script: %w", err)
+	if err = os.WriteFile(scriptPath, []byte(data), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing network script: %w", err)
 	}
 
-	return networkConfigScriptName, nil
+	return nil
 }

--- a/pkg/combustion/network_test.go
+++ b/pkg/combustion/network_test.go
@@ -159,10 +159,11 @@ func TestConfigureNetwork_CustomScript(t *testing.T) {
 }
 
 func TestWriteNetworkConfigurationScript(t *testing.T) {
-	ctx, teardown := setupContext(t)
-	defer teardown()
+	dir, err := os.MkdirTemp("", "network-config-script-")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
 
-	scriptPath := filepath.Join(ctx.CombustionDir, "script.sh")
+	scriptPath := filepath.Join(dir, "script.sh")
 
 	require.NoError(t, writeNetworkConfigurationScript(scriptPath))
 


### PR DESCRIPTION
- Use `network/configure-network.sh` script to configure the network @ Combustion phase if present
- Use any other `network/` files to generate configurations using nmc