### PR TITLE
Change location of Hauler bin

### DIFF
--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -98,9 +98,9 @@ func TestWriteRegistryScript(t *testing.T) {
 	assert.Contains(t, found, registryDir)
 	assert.Contains(t, found, registryPort)
 	assert.Contains(t, found, registryTarName)
-	assert.Contains(t, found, "mv hauler /usr/local/bin/hauler")
+	assert.Contains(t, found, "mv hauler /opt/hauler/hauler")
 	assert.Contains(t, found, "systemctl enable eib-embedded-registry.service")
-	assert.Contains(t, found, "ExecStartPre=/usr/local/bin/hauler store load")
+	assert.Contains(t, found, "ExecStartPre=/opt/hauler/hauler store load")
 }
 
 func TestCopyHaulerBinary(t *testing.T) {

--- a/pkg/combustion/templates/26-embedded-registry.sh.tpl
+++ b/pkg/combustion/templates/26-embedded-registry.sh.tpl
@@ -2,11 +2,8 @@
 set -euo pipefail
 
 mkdir /opt/hauler
-
-mount /usr/local
+mv hauler /opt/hauler/hauler
 mv {{ .RegistryDir }}/{{ .EmbeddedRegistryTar }} /opt/hauler/
-mv hauler /usr/local/bin/hauler
-umount /usr/local
 
 cat <<- EOF > /etc/systemd/system/eib-embedded-registry.service
   [Unit]
@@ -17,8 +14,8 @@ cat <<- EOF > /etc/systemd/system/eib-embedded-registry.service
   Type=simple
   User=root
   WorkingDirectory=/opt/hauler
-  ExecStartPre=/usr/local/bin/hauler store load {{ .EmbeddedRegistryTar }}
-  ExecStart=/usr/local/bin/hauler store serve registry -p {{ .RegistryPort }}
+  ExecStartPre=/opt/hauler/hauler store load {{ .EmbeddedRegistryTar }}
+  ExecStart=/opt/hauler/hauler store serve registry -p {{ .RegistryPort }}
   Restart=on-failure
 
   [Install]


### PR DESCRIPTION
Instead of mounting `/usr/local/` we instead put in the hauler binary in `/opt/hauler/` 