### PR TITLE
Check if local manifests dir is configured

### DIFF
--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -211,7 +211,8 @@ func createRegistryCommand(ctx *image.Context, commandName string, args []string
 func IsEmbeddedArtifactRegistryConfigured(ctx *image.Context) bool {
 	return len(ctx.ImageDefinition.EmbeddedArtifactRegistry.ContainerImages) != 0 ||
 		len(ctx.ImageDefinition.Kubernetes.Manifests.URLs) != 0 ||
-		isComponentConfigured(ctx, filepath.Join(k8sDir, helmDir))
+		isComponentConfigured(ctx, filepath.Join(k8sDir, helmDir)) ||
+		isComponentConfigured(ctx, filepath.Join(k8sDir, k8sManifestsDir))
 }
 
 func getImageHostnames(containerImages []image.ContainerImage) []string {


### PR DESCRIPTION
Fixes an issue where the embedded artifact registry is not configured when only local manifests are specified.
Closes #209 