### PR TITLE
Handling for manifests and charts with no images

### DIFF
--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -69,7 +69,7 @@ func configureRegistry(ctx *image.Context) ([]string, error) {
 
 	if !configured {
 		log.AuditComponentSkipped(registryComponentName)
-		log.Audit("Embedded Artifact Registry skipped: Provided manifests/helm charts contain no images.")
+		zap.S().Info("Skipping embedded artifact registry since the provided manifests/helm charts contain no images")
 		return nil, nil
 	}
 


### PR DESCRIPTION
This PR adds an additional check to the registry combustion component that proceeds with creating an embedded artifact registry and configuring its script only when there are images present in user specified manifests and helm charts.
