### PR TITLE
Install Hauler from RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,22 +27,15 @@ RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:Edge
 # 2. RAW image modification on x86_64
 # 3. Podman EIB library
 # 4. RPM resolution logic
-# 5. Network configurator
+# 5. Embedded artefact registry
+# 6. Network configuration
 RUN zypper install -y \
     xorriso squashfs  \
     libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs guestfs-tools lvm2 \
     podman \
     createrepo_c \
-    helm \
+    helm hauler \
     nm-configurator
-
-RUN curl -o hauler-amd64.tar -L https://github.com/rancherfederal/hauler/releases/download/v0.4.3/hauler_0.4.3_linux_amd64.tar.gz && \
-    tar -xf hauler-amd64.tar && \
-    mv hauler hauler-x86_64 && \
-    curl -o hauler-arm64.tar -L https://github.com/rancherfederal/hauler/releases/download/v0.4.3/hauler_0.4.3_linux_arm64.tar.gz && \
-    tar -xf hauler-arm64.tar && \
-    mv hauler hauler-aarch64 && \
-    cp hauler-$(uname -m) /usr/local/bin/hauler
 
 RUN curl -o rke2_installer.sh -L https://get.rke2.io && \
     curl -o k3s_installer.sh -L https://get.k3s.io

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -271,7 +271,7 @@ func configureEmbeddedArtifactRegistry(ctx *image.Context) (bool, error) {
 		return false, fmt.Errorf("generating hauler store tar: %w", err)
 	}
 
-	haulerBinaryPath := fmt.Sprintf("hauler-%s", string(ctx.ImageDefinition.Image.Arch))
+	haulerBinaryPath := "/usr/bin/hauler"
 	if err = copyHaulerBinary(ctx, haulerBinaryPath); err != nil {
 		return false, fmt.Errorf("copying hauler binary: %w", err)
 	}


### PR DESCRIPTION
- Drops Hauler Github release references in favour of RPM installation
- Closes https://github.com/suse-edge/edge-image-builder/issues/203 (the RPM is already using v1.0.0)