### PR TITLE
Disable Podman auto-mounts when running RPM resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	// version should match buildah version in the
 	// podman mod file https://github.com/containers/podman/blob/v4.8.3/go.mod#L14
 	github.com/containers/buildah v1.33.2
+	github.com/containers/common v0.57.1
 	github.com/containers/podman/v4 v4.8.3
 	github.com/google/uuid v1.6.0
 	github.com/schollz/progressbar/v3 v3.14.1
@@ -33,7 +34,6 @@ require (
 	github.com/containerd/containerd v1.7.9 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
-	github.com/containers/common v0.57.1 // indirect
 	github.com/containers/image/v5 v5.29.0 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.1.9 // indirect

--- a/pkg/cli/build/build.go
+++ b/pkg/cli/build/build.go
@@ -292,7 +292,7 @@ func bootstrapDependencyServices(ctx *image.Context, rootDir string) bool {
 		imgType := ctx.ImageDefinition.Image.ImageType
 		baseBuilder := resolver.NewTarballBuilder(ctx.BuildDir, imgPath, imgType, p)
 
-		rpmResolver := resolver.New(ctx.BuildDir, p, baseBuilder)
+		rpmResolver := resolver.New(ctx.BuildDir, p, baseBuilder, "")
 		ctx.RPMResolver = rpmResolver
 		ctx.RPMRepoCreator = rpm.NewRepoCreator(ctx.BuildDir)
 	}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/containers/common/pkg/subscriptions"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 )
 
 const (
@@ -33,7 +34,7 @@ func DisableDefaultMounts(overrideMountFilepath string) (revert func() error, er
 			return nil, fmt.Errorf("renaming existing %s mount override file: %w", mountFile, err)
 		}
 
-		if err = createEmptyFile(mountFile); err != nil {
+		if err = os.WriteFile(mountFile, []byte{}, fileio.NonExecutablePerms); err != nil {
 			return nil, fmt.Errorf("creating empty %s mount override file: %w", mountFile, err)
 		}
 
@@ -48,8 +49,8 @@ func DisableDefaultMounts(overrideMountFilepath string) (revert func() error, er
 			return nil
 		}, nil
 	case errors.Is(err, fs.ErrNotExist):
-		if err = createEmptyFile(mountFile); err != nil {
-			return nil, fmt.Errorf("creating empty %s file: %w", mountFile, err)
+		if err = os.WriteFile(mountFile, []byte{}, fileio.NonExecutablePerms); err != nil {
+			return nil, fmt.Errorf("creating empty %s mount override file: %w", mountFile, err)
 		}
 
 		return func() error {
@@ -61,17 +62,4 @@ func DisableDefaultMounts(overrideMountFilepath string) (revert func() error, er
 	default:
 		return nil, fmt.Errorf("describing file %s: %w", mountFile, err)
 	}
-}
-
-func createEmptyFile(name string) error {
-	emptyFile, err := os.Create(name)
-	if err != nil {
-		return fmt.Errorf("creating %s: %w", name, err)
-	}
-
-	if err = emptyFile.Close(); err != nil {
-		return fmt.Errorf("closing %s: %w", emptyFile.Name(), err)
-	}
-
-	return nil
 }

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,0 +1,77 @@
+package mount
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/containers/common/pkg/subscriptions"
+)
+
+const (
+	disableSuffix = "-disable"
+)
+
+// DisableDefaultMounts disables default mounts for all containers by creating an empty
+// "mounts.conf" file at the override mount filepath provided by the user. Returns a function
+// that can revert to the previous mount setup if needed, or an error if a problem has occured.
+// If no filepath was provided, the default container override mount filepath will be used ("/etc/containers/mounts.conf").
+// For more info - https://github.com/containers/common/blob/main/docs/containers-mounts.conf.5.md
+func DisableDefaultMounts(overrideMountFilepath string) (revert func() error, err error) {
+	mountFile := overrideMountFilepath
+	if mountFile == "" {
+		mountFile = subscriptions.OverrideMountsFile
+	}
+
+	disableMountFile := mountFile + disableSuffix
+
+	_, err = os.Stat(mountFile)
+	switch {
+	case err == nil:
+		if err = os.Rename(mountFile, disableMountFile); err != nil {
+			return nil, fmt.Errorf("renaming existing %s mount override file: %w", mountFile, err)
+		}
+
+		if err = createEmptyFile(mountFile); err != nil {
+			return nil, fmt.Errorf("creating empty %s mount override file: %w", mountFile, err)
+		}
+
+		return func() error {
+			if err = os.Remove(mountFile); err != nil {
+				return fmt.Errorf("removing empty %s file: %w", mountFile, err)
+			}
+
+			if err = os.Rename(disableMountFile, mountFile); err != nil {
+				return fmt.Errorf("renaming original mounts.conf file from %s: %w", disableMountFile, err)
+			}
+			return nil
+		}, nil
+	case errors.Is(err, fs.ErrNotExist):
+		if err = createEmptyFile(mountFile); err != nil {
+			return nil, fmt.Errorf("creating empty %s file: %w", mountFile, err)
+		}
+
+		return func() error {
+			if err = os.Remove(mountFile); err != nil {
+				return fmt.Errorf("removing empty %s file: %w", mountFile, err)
+			}
+			return nil
+		}, nil
+	default:
+		return nil, fmt.Errorf("describing file %s: %w", mountFile, err)
+	}
+}
+
+func createEmptyFile(name string) error {
+	emptyFile, err := os.Create(name)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", name, err)
+	}
+
+	if err = emptyFile.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", emptyFile.Name(), err)
+	}
+
+	return nil
+}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	disableSuffix = "-disable"
+	disableSuffix = ".orig"
 )
 
 // DisableDefaultMounts disables default mounts for all containers by creating an empty

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -17,7 +17,7 @@ const (
 // "mounts.conf" file at the override mount filepath provided by the user. Returns a function
 // that can revert to the previous mount setup if needed, or an error if a problem has occured.
 // If no filepath was provided, the default container override mount filepath will be used ("/etc/containers/mounts.conf").
-// For more info - https://github.com/containers/common/blob/main/docs/containers-mounts.conf.5.md
+// For more info - https://github.com/containers/common/blob/v0.57/docs/containers-mounts.conf.5.md
 func DisableDefaultMounts(overrideMountFilepath string) (revert func() error, err error) {
 	mountFile := overrideMountFilepath
 	if mountFile == "" {

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -1,0 +1,138 @@
+package mount
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mountsConfContent = "/foo/bar:/foo/bar"
+)
+
+func TestDisableDefaultMountsRevertFunc(t *testing.T) {
+	tests := []struct {
+		name                     string
+		dirName                  string
+		overrideMountsConfExists bool
+	}{
+		{
+			name:                     "Revert to the original mounts.conf override mount configuration",
+			dirName:                  "disable-default-mounts-revert-to-existing-override-mounts-conf-",
+			overrideMountsConfExists: true,
+		},
+		{
+			name:    "Rever to the default mounts.conf configuration",
+			dirName: "disable-default-mounts-revert-to-default-mounts-conf-",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", test.dirName)
+			require.NoError(t, err)
+
+			mountsConfPath := filepath.Join(dir, "mounts.conf")
+			if test.overrideMountsConfExists {
+				mountsConfPath = createMountConf(t, dir)
+			}
+
+			revert, err := DisableDefaultMounts(mountsConfPath)
+			require.NoError(t, err)
+			err = revert()
+			require.NoError(t, err)
+
+			if test.overrideMountsConfExists {
+				disabledMountsConfigPath := mountsConfPath + disableSuffix
+				_, err = os.Stat(disabledMountsConfigPath)
+				require.ErrorIs(t, err, fs.ErrNotExist)
+
+				var content []byte
+				content, err = os.ReadFile(mountsConfPath)
+				require.NoError(t, err)
+				assert.Equal(t, []byte(mountsConfContent), content)
+			} else {
+				_, err = os.Stat(mountsConfPath)
+				require.ErrorIs(t, err, fs.ErrNotExist)
+			}
+
+			require.NoError(t, os.RemoveAll(dir))
+		})
+	}
+}
+
+func TestDisableDefaultMounts(t *testing.T) {
+	tests := []struct {
+		name                     string
+		dirName                  string
+		overrideMountsConfExists bool
+	}{
+		{
+			name:                     "Replace existing mounts.conf file at mount override filepath",
+			dirName:                  "disable-default-mounts-replace-existing-mounts-conf-",
+			overrideMountsConfExists: true,
+		},
+		{
+			name:    "Create new mounts.conf file at mount override filepath",
+			dirName: "disable-default-mounts-create-new-mounts-conf-file-",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", test.dirName)
+			require.NoError(t, err)
+
+			mountsConfPath := filepath.Join(dir, "mounts.conf")
+			if test.overrideMountsConfExists {
+				mountsConfPath = createMountConf(t, dir)
+			}
+
+			_, err = DisableDefaultMounts(mountsConfPath)
+			require.NoError(t, err)
+
+			if test.overrideMountsConfExists {
+				disabledMountsConfigPath := mountsConfPath + disableSuffix
+
+				_, err = os.Stat(disabledMountsConfigPath)
+				require.NoError(t, err)
+
+				var content []byte
+				content, err = os.ReadFile(disabledMountsConfigPath)
+				require.NoError(t, err)
+				assert.Equal(t, []byte(mountsConfContent), content)
+			}
+
+			mountsFile, err := os.Stat(mountsConfPath)
+			require.NoError(t, err)
+			assert.Equal(t, int64(0), mountsFile.Size())
+
+			require.NoError(t, os.RemoveAll(dir))
+		})
+	}
+}
+
+func TestDisableDefaultMountsMissingMountPath(t *testing.T) {
+	expectedErr := "creating empty /missing/file/path file: creating /missing/file/path: open /missing/file/path: no such file or directory"
+
+	_, err := DisableDefaultMounts("/missing/file/path")
+	require.Error(t, err)
+	assert.EqualError(t, err, expectedErr)
+}
+
+func createMountConf(t *testing.T, localtion string) string {
+	mountsConf, err := os.Create(filepath.Join(localtion, "mounts.conf"))
+	require.NoError(t, err)
+
+	_, err = mountsConf.WriteString(mountsConfContent)
+	require.NoError(t, err)
+
+	err = mountsConf.Close()
+	require.NoError(t, err)
+
+	return mountsConf.Name()
+}

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	mountsConfName    = "mounts.conf"
 	mountsConfContent = "/foo/bar:/foo/bar"
 )
 
@@ -36,7 +37,7 @@ func TestDisableDefaultMountsRevertFunc(t *testing.T) {
 			dir, err := os.MkdirTemp("", test.dirName)
 			require.NoError(t, err)
 
-			mountsConfPath := filepath.Join(dir, "mounts.conf")
+			mountsConfPath := filepath.Join(dir, mountsConfName)
 			if test.overrideMountsConfExists {
 				mountsConfPath = createMountConf(t, dir)
 			}
@@ -87,7 +88,7 @@ func TestDisableDefaultMounts(t *testing.T) {
 			dir, err := os.MkdirTemp("", test.dirName)
 			require.NoError(t, err)
 
-			mountsConfPath := filepath.Join(dir, "mounts.conf")
+			mountsConfPath := filepath.Join(dir, mountsConfName)
 			if test.overrideMountsConfExists {
 				mountsConfPath = createMountConf(t, dir)
 			}
@@ -125,7 +126,7 @@ func TestDisableDefaultMountsMissingMountPath(t *testing.T) {
 }
 
 func createMountConf(t *testing.T, localtion string) string {
-	mountsConf, err := os.Create(filepath.Join(localtion, "mounts.conf"))
+	mountsConf, err := os.Create(filepath.Join(localtion, mountsConfName))
 	require.NoError(t, err)
 
 	_, err = mountsConf.WriteString(mountsConfContent)

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -118,7 +118,7 @@ func TestDisableDefaultMounts(t *testing.T) {
 }
 
 func TestDisableDefaultMountsMissingMountPath(t *testing.T) {
-	expectedErr := "creating empty /missing/file/path file: creating /missing/file/path: open /missing/file/path: no such file or directory"
+	expectedErr := "creating empty /missing/file/path mount override file: open /missing/file/path: no such file or directory"
 
 	_, err := DisableDefaultMounts("/missing/file/path")
 	require.Error(t, err)

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -125,8 +125,8 @@ func TestDisableDefaultMountsMissingMountPath(t *testing.T) {
 	assert.EqualError(t, err, expectedErr)
 }
 
-func createMountConf(t *testing.T, localtion string) string {
-	mountsConf, err := os.Create(filepath.Join(localtion, mountsConfName))
+func createMountConf(t *testing.T, location string) string {
+	mountsConf, err := os.Create(filepath.Join(location, mountsConfName))
 	require.NoError(t, err)
 
 	_, err = mountsConf.WriteString(mountsConfContent)

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -83,7 +83,7 @@ func (r *Resolver) Resolve(packages *image.Packages, localRPMConfig *image.Local
 	}
 	defer func() {
 		if err = revert(); err != nil {
-			zap.S().Warnf("failed to enable default mounts: %w", err)
+			zap.S().Warnf("failed to enable default mounts: %s", err)
 		}
 	}()
 

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -82,8 +82,8 @@ func (r *Resolver) Resolve(packages *image.Packages, localRPMConfig *image.Local
 		return "", nil, fmt.Errorf("temporary disabling automatic volume mounts: %w", err)
 	}
 	defer func() {
-		if err = revert(); err != nil {
-			zap.S().Warnf("failed to enable default mounts: %s", err)
+		if revertErr := revert(); revertErr != nil {
+			zap.S().Warnf("failed to enable default mounts: %s", revertErr)
 		}
 	}()
 

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -49,13 +49,17 @@ type Resolver struct {
 	// helper property; contains the paths to the gpgKeys that will be used to validate
 	// the RPM signatures in the resolver image
 	gpgKeyPaths []string
+	// path to the mounts.conf filepath that overrides the default mounts.conf configuration;
+	// if left empty the default override path will be used. For more info - https://github.com/containers/common/blob/v0.57/docs/containers-mounts.conf.5.md
+	overrideMountsPath string
 }
 
-func New(workDir string, podman Podman, baseImageBuilder BaseResolverImageBuilder) *Resolver {
+func New(workDir string, podman Podman, baseImageBuilder BaseResolverImageBuilder, overrideMountsPath string) *Resolver {
 	return &Resolver{
 		dir:                      workDir,
 		podman:                   podman,
 		baseResolverImageBuilder: baseImageBuilder,
+		overrideMountsPath:       overrideMountsPath,
 	}
 }
 
@@ -73,7 +77,7 @@ func New(workDir string, podman Podman, baseImageBuilder BaseResolverImageBuilde
 func (r *Resolver) Resolve(packages *image.Packages, localRPMConfig *image.LocalRPMConfig, outputDir string) (rpmDirPath string, pkgList []string, err error) {
 	zap.L().Info("Resolving package dependencies...")
 
-	revert, err := mount.DisableDefaultMounts("")
+	revert, err := mount.DisableDefaultMounts(r.overrideMountsPath)
 	if err != nil {
 		return "", nil, fmt.Errorf("temporary disabling automatic volume mounts: %w", err)
 	}


### PR DESCRIPTION
This PR offers the functionality to disable any automatic container volume mounts configured through the [`mounts.conf`](https://github.com/containers/common/blob/main/docs/containers-mounts.conf.5.md) configuration logic offered by the [`containers/common`](https://github.com/containers/common/tree/main) shared library. 

This is a non-invasive way of fixing the RPM resolution problem that occurs when the EIB image is using BCI as base. In the TL;DR you can find a detailed explanation of the problem, what was tried and why the current approach was taken.. 

## TL;DR
### Problem
During the RPM resolution process, when an `sccRegistrationCode` is provided, the RPM resolver attempts to register the system to `https://scc.suse.com` using `SUSEConnect`. However, if the EIB image runs on top of [`bci-base`](https://registry.suse.com/categories/bci/repositories/bci-bci-base-15sp5), then instead of trying to connect to `https://scc.suse.com` it tries to connect to an RMT server and fails with the following error:
```bash
Registering system to registration proxy https://rmt.devlab.pgu1.suse.com/

Announcing system to https://rmt.devlab.pgu1.suse.com/ ...
SUSEConnect error: Post "https://rmt.devlab.pgu1.suse.com/connect/subscriptions/systems": x509: certificate signed by unknown authority
```  
IIUC, Podman installed on a SLE OS comes with a `mounts.conf` file preconfigured on both the default (`/usr/share/containers/mounts.conf`) and override (`/etc/containers/mounts.conf`) container file paths of the system. This file instructs Podman to auto-mount the `/etc/SUSEConnect` and `/etc/zypp/credentials.d/SCCcredentials` from the host to any container created inside of the system. 

This results in the following failing workflow:
1. User runs a registered SLE OS as host
1. User builds the EIB image (using `bci-base` as the base image) on the host. The build is done as `root`. If the build is not done as `root` there will not be enough permissions to auto-mount the `mounts.conf` files and this use-case will not be hit
1. During the EIB image build, the files configured in the `mount.conf` file are auto-mounted to the image
1. User runs the EIB container from the built image with RPM resolution enabled
1. Inside the EIB container, the RPM resolver image building process starts
1. Because the EIB image runs on top of `bci-base` and has Podman installed, it also has the `mounts.conf` configuration, resulting in the `/etc/SUSEConnect` and `/etc/zypp/credentials.d/SCCcredentials` files being auto-mounted on top of the Resolver image that is currently being built.
1. Because the Resolver image runs a different OS and does not have the needed permissions to the RTM server configured in the mounted `/etc/SUSEConnect` and `/etc/zypp/credentials.d/SCCcredentials` files, the RPM resolution process fails with the aforementioned error..

**_Note: The above workflow can happen not only for RTM server configs, but for regular registrations, we just caught the problem in this specific scenario._**

### Solution
The least invasive solution offered here is to programatically create an empty `mounts.conf` file at the expected `containers/common` override file path, which is `/etc/containers/mounts.conf`. When a `mounts.conf` file is present here it automatically overrides any other existing auto-mounts configured at the default mount place (`/usr/share/containers/mounts.conf`). 

The code works as follows:
1. Checks whether there is an existing `mounts.conf` under `/etc/containers/mounts.conf`
2. If there is, it renames the `mounts.conf` file to `mounts.conf-disabled`
3. Creates an empty `mounts.conf` file

The functionality also offers a way to re-enable the default auto-mounts by either returning the original `mounts.conf` file under `/etc/containers/mounts.conf`, or if this file does not exists, removing the empty blocking `mounts.conf` file. 

Since the `mounts.conf` file is not mounted, but present on each OS, we can safely do manipulations over this file without having to worry that we are breaking different systems. Furthermore, by not explicitly removing the original files we can ensure that even at code failure we will be able to revert to the original file configurations ensuring the least invasive manipulations possible.

### Q&A
#### Why don't we just use `suseconnect --url` property to specify the correct registration server? Isn't this enough?
Sadly this is not enough. Specifying the `suseconnect --url https://scc.suse.com` is enough to change the registration server, but because the `/etc/SUSEConnect` and `/etc/zypp/credentials.d/SCCcredentials` files are still there, `suseconnect` treats the system as registered and we get the following error:
```bash
Error: Invalid system credentials, probably because the registered system was deleted in SUSE Customer Center. Check https://scc.suse.com whether your system appears there. If it does not, please call SUSEConnect --cleanup and re-register this system.
```    

#### Why can't we just call `suseconnect --cleanup` and re-register the system?
Because the `/etc/SUSEConnect` and `/etc/zypp/credentials.d/SCCcredentials` files are mounted, they cannot be removed and the following error can be seen:
```bash
SUSEConnect error: remove /etc/zypp/credentials.d/SCCcredentials: device or resource busy
```  

#### Why not just unmount the files?
Files seem to be mounted during the `podman build ...` command of the RPM resolver image. So unmounting them from within the Dockerfile will always result in an `umount: /etc/zypp/credentials.d/SCCcredentials: must be superuser to unmount.` error. The only way to do the unmount would be to unmount the files from within the EIB container before starting the Resolver image build. IMO this is very disruptive, as we cannot revert the state once we are finished with the Resolver image build.

#### Can't we add some configuration to [`containers.conf`](https://github.com/containers/common/blob/main/docs/containers.conf.5.md) file to change the default auto-mounts?
From what I understand there is such a property in this file, however it applies to the Podman VM machine. So a Podman machine would have to be created, but because we are running a rootful container we get the `Error: cannot run command "podman machine init" as root` error. Theoretically this might be achievable, but again this is too disruptive IMO, because we would have to write to a config file that contains much more configurations than just the auto-mount onеs and we could accidentally brake something else..

#### Doesn't the `podman` CLI have a flag to change the default auto-mounts?
Yes and no.. Podman offers the **hidden** [`--default-mounts-file`](https://github.com/containers/podman/blob/main/cmd/podman/root.go#L541) global flag (hidden [here](https://github.com/containers/podman/blob/main/cmd/podman/root.go#L602)), that is not documented anywhere inside of Podman's documentation. When you pass the aforementioned flag to Podman's build command (`podman --default-mounts-file build ..`) the auto-mounts are overridden and the build process passes successfully. However, this flag is hidden, because it is intended for development/testing purposes only. Without going into the full code implementation, this flag translates to the [`MountsWithUIDGID`](https://github.com/containers/common/blob/main/pkg/subscriptions/subscriptions.go#L168C6-L168C22) function (when running it through the CLI), which clearly states that the change of the default auto-mount points is for [testing](https://github.com/containers/common/blob/main/pkg/subscriptions/subscriptions.go#L175C5-L175C35) purposes only. Furthermore, even if this was possible, it is only possible through the CLI. The same property is not enabled (parsed) from within the public podman library. Again without going too much into Podman's implementation, the public podman image build [function](https://github.com/containers/podman/blob/main/pkg/bindings/images/build.go#L53C6-L53C11) accepts  [types.BuildOptions](https://github.com/containers/podman/blob/main/pkg/domain/entities/types/types.go#L63) which provides the  [buildah.BuildOptions](https://github.com/containers/buildah/blob/main/define/build.go#L115) configuration which offers a property that overrides the auto-mount directory([here](https://github.com/containers/buildah/blob/main/define/build.go#L246)) however this property is not added as a `parameter` in Podman's build function. Mainly because this property is for testing purposes only..

#### Doesn't the `podman` CLI offer some other way of achiving the auto-mount override?
Since for the RPM resolution this needs to happen during the image build, I was not able to find any other way, apart from the `--default-mounts-file` to stop the files from the `mounts.conf` from being mounted.