### PR TITLE
Remove RAW_EXTRACT_DIR creation in order to conform to BCI image unsquashfs requirements

### DIFF
--- a/pkg/build/templates/extract-iso.sh.tpl
+++ b/pkg/build/templates/extract-iso.sh.tpl
@@ -12,7 +12,7 @@ RAW_EXTRACT_DIR={{.RawExtractDir}}
 ISO_SOURCE={{.IsoSource}}
 
 # Create the extract directories
-mkdir -p ${ISO_EXTRACT_DIR} ${RAW_EXTRACT_DIR}
+mkdir -p ${ISO_EXTRACT_DIR}
 
 # Extract the contents of the ISO to the build directory
 xorriso -osirrox on -indev ${ISO_SOURCE} extract / ${ISO_EXTRACT_DIR}


### PR DESCRIPTION
Currently when attempting to build an EIB image using `registry.suse.com/bci/bci-base:15.5` as base, the EIB image build fails and the following error can be seen in the `iso-extract.log` file:

```bash
xorriso 1.4.6 : RockRidge filesystem manipulator, libburnia project.

Copying of file objects from ISO image to disk filesystem is: Enabled
xorriso : NOTE : ISO image bears MBR with  -boot_image any partition_offset=16
xorriso : NOTE : Loading ISO image tree from LBA 0
xorriso : UPDATE : 367 nodes read in 1 seconds
libisofs: WARNING : Found hidden El-Torito image. Its size could not be figured out, so image modify or boot image patching may lead to bad results.
xorriso : NOTE : Detected El-Torito boot information which currently is set to be discarded
Drive current: -indev '/eib/base-images/SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso'
Media current: stdio file, overwriteable
Media status : is written , is appendable
Boot record  : El Torito , MBR grub2-mbr cyl-align-off
Media summary: 1 session, 575710 data blocks, 1124m data,  136g free
Volume id    : 'INSTALL'
xorriso : UPDATE : 366 files restored ( 882.4m) in 1 seconds , 668.0xD
xorriso : UPDATE : 367 files restored (1123.8m) in 1 seconds = 707.0xD
Extracted from ISO image: file '/'='/eib/_build/build-Feb26_14-55-54/iso-extract'

FATAL ERROR:dir_scan: failed to make directory /eib/_build/build-Feb26_14-55-54/raw-extract, because File exists
Parallel unsquashfs: Using 8 processors
2 inodes (2189 blocks) to write
```

IIUC [`unsquashfs -d ${RAW_EXTRACT_DIR}` ](https://github.com/suse-edge/edge-image-builder/blob/main/pkg/build/templates/extract-iso.sh.tpl#L22) expects for `RAW_EXTRACT_DIR` to not be created beforehand on BCI images, resulting in the "File exists" error. Furthermore there is a significant difference between the `unsquashfs` version for Leap and BCI 15.5.
```bash
# BCI
8abadd37531d:/ # unsquashfs -version
unsquashfs version 4.4 (2019/08/29)
copyright (C) 2019 Phillip Lougher <phillip@squashfs.org.uk>
8abadd37531d:/ # cat /etc/os-release 
NAME="SLES"
VERSION="15-SP5"
VERSION_ID="15.5"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP5"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp5"
DOCUMENTATION_URL="https://documentation.suse.com/"
```

```bash
# Leap
4c611bce1e37:/ # unsquashfs -version
unsquashfs version 4.6.1 (2023/03/25)
copyright (C) 2023 Phillip Lougher <phillip@squashfs.org.uk>
4c611bce1e37:/ # cat /etc/os-release 
NAME="openSUSE Leap"
VERSION="15.5"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.5"
PRETTY_NAME="openSUSE Leap 15.5"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.5"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
LOGO="distributor-logo-Leap"
```

This PR introduces a workaround to the problem by letting `unsquashfs` create the `RAW_EXTRACT_DIR` itself. Works well on both BCI and Leap. While I understand that the correct approach would be to update the `unsquashfs` tool on the BCI side, IMO we should let `unsquashfs` handle the `RAW_EXTRACT_DIR` creation. That way we will be able to continue with the EIB BCI build and not have to wait (be blocked) by a tool version upgrade.