### PR TITLE
213 - Added zypper clean to the EIB image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN zypper install -y \
     podman \
     createrepo_c \
     helm hauler \
-    nm-configurator
+    nm-configurator && \
+    zypper clean -a
 
 RUN curl -o rke2_installer.sh -L https://get.rke2.io && \
     curl -o k3s_installer.sh -L https://get.k3s.io


### PR DESCRIPTION
closes: #213 

Before:
```
$ podman images
REPOSITORY                           TAG         IMAGE ID      CREATED         SIZE
localhost/eib                        dev         4d52328cfaf2  11 minutes ago  1.57 GB
```

After:
```
$ podman images
REPOSITORY                           TAG         IMAGE ID      CREATED             SIZE
localhost/eib                        dev         438961b7e084  About a minute ago  1.18 GB
```