### PR TITLE
197 - Changed Dockerfile to use ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN curl -o rke2_installer.sh -L https://get.rke2.io && \
 
 COPY --from=0 /src/eib /bin/eib
 
-CMD ["/bin/eib"]
+ENTRYPOINT ["/bin/eib"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the host machine.
 The following example command attaches the directory and runs EIB:
 ```shell
 podman run --rm -it \
--v $IMAGE_DIR:/eib eib:dev /bin/eib build \
+-v $IMAGE_DIR:/eib eib:dev build \
 --config-file $CONFIG_FILE.yaml \
 --config-dir /eib \
 --build-dir /eib/_build

--- a/docs/design/pkg-resolution.md
+++ b/docs/design/pkg-resolution.md
@@ -14,7 +14,7 @@ After the desired specification has been made, the user runs the EIB container w
 An example of the command can be seen below:
 ```shell
 podman run --rm --privileged -it \
--v $IMAGE_DIR:/eib eib:dev /bin/eib build \
+-v $IMAGE_DIR:/eib eib:dev build \
 --config-file $CONFIG_FILE.yaml \
 --config-dir /eib \
 --build-dir /eib/_build


### PR DESCRIPTION
closes: #197 

I tested it and it works like Steve suggested, that we don't need to indicate `/bin/eib` in the podman run line. `ENTRYPOINT` makes more sense here since the only argument it includes is the location of the executable, which isn't something that changes.