### PR TITLE
[BUG FIX] SCC registration is not cleaned up if RPM resolution fails

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 
 ## Bug Fixes
 
+* [#259](https://github.com/suse-edge/edge-image-builder/issues/259) - SCC registration is not cleaned up if RPM resolution fails
+
 ---
 
 # v1.0.0-rc1

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -210,11 +210,7 @@ func (r *Resolver) writeRPMResolutionScript(localRPMConfig *image.LocalRPMConfig
 	}
 
 	filename := filepath.Join(r.generateBuildContextPath(), rpmResolutionScriptName)
-	if err = os.WriteFile(filename, []byte(data), fileio.ExecutablePerms); err != nil {
-		return fmt.Errorf("writing prepare base image script %s: %w", filename, err)
-	}
-
-	return nil
+	return os.WriteFile(filename, []byte(data), fileio.ExecutablePerms)
 }
 
 func (r *Resolver) writeDockerfile(localRPMConfig *image.LocalRPMConfig) error {
@@ -246,11 +242,7 @@ func (r *Resolver) writeDockerfile(localRPMConfig *image.LocalRPMConfig) error {
 	}
 
 	filename := filepath.Join(r.generateBuildContextPath(), dockerfileName)
-	if err = os.WriteFile(filename, []byte(data), fileio.NonExecutablePerms); err != nil {
-		return fmt.Errorf("writing prepare base image script %s: %w", filename, err)
-	}
-
-	return nil
+	return os.WriteFile(filename, []byte(data), fileio.NonExecutablePerms)
 }
 
 func (r *Resolver) generatePKGInstallList(packages *image.Packages) []string {

--- a/pkg/rpm/resolver/templates/Dockerfile.tpl
+++ b/pkg/rpm/resolver/templates/Dockerfile.tpl
@@ -1,69 +1,21 @@
 #  Template Fields
-#  BaseImage    - image to use as base for the build of this image
-#  FromRPMPath  - path to the custom RPM directory relative to the resolver image build context in the EIB container
-#  ToRPMPath    - path to the custom RPM directory relative to the resolver image
-#  FromGPGPath  - path to the directory holding the GPG keys for the custom RPMs relative to the resolver image build context in the EIB container
-#  ToGPGPath    - path to the directory holding the GPG keys for the custom RPMs relative to the resolver image
-#  RegCode      - scc.suse.com registration code
-#  AddRepo      - additional third-party repositories that will be used in the resolution process
-#  CacheDir     - zypper cache directory where all rpm dependencies will be downloaded to
-#  PKGList      - list of packages for which to do the dependency resolution
-#  LocalRPMList - list of local RPMs for which dependency resolution has to be done
-#  LocalGPGList - list of local GPG keys that will be imported in the resolver image
-#  NoGPGCheck   - when set to true skips the GPG validation for all third-party repositories and local RPMs
+#  BaseImage               - image to use as base for the build of this image
+#  FromRPMPath             - path to the custom RPM directory relative to the resolver image build context in the EIB container
+#  ToRPMPath               - path to the custom RPM directory relative to the resolver image
+#  FromGPGPath             - path to the directory holding the GPG keys for the custom RPMs relative to the resolver image build context in the EIB container
+#  ToGPGPath               - path to the directory holding the GPG keys for the custom RPMs relative to the resolver image
+#  RPMResolutionScriptName - name of the RPM resolution script
 FROM {{ .BaseImage }}
+
+COPY {{ .RPMResolutionScriptName }} {{ .RPMResolutionScriptName }}
 
 {{ if and .FromRPMPath .ToRPMPath -}}
 COPY {{ .FromRPMPath }} {{ .ToRPMPath }}
 {{ if and .FromGPGPath .ToGPGPath -}}
 COPY {{ .FromGPGPath }} {{ .ToGPGPath }}
 {{ end -}}
-{{ end -}}
+{{ end }}
 
-{{ if ne .RegCode "" }}
-RUN suseconnect -r {{ .RegCode }}
-RUN SLE_SP=$(cat /etc/rpm/macros.sle | awk '/sle/ {print $2};' | cut -c4) && suseconnect -p PackageHub/15.$SLE_SP/x86_64
-RUN zypper ref
-{{ end -}}
-
-{{- range $index, $repo := .AddRepo }}
-
-{{- $gpgCheck := "" -}}
-{{- if $.NoGPGCheck -}}
-{{ $gpgCheck = "--no-gpgcheck" }}
-{{- else if .Unsigned -}}
-{{ $gpgCheck = "--gpgcheck-allow-unsigned-repo" }}
-{{- end -}}
-
-RUN zypper ar {{ $gpgCheck }} -f {{ .URL }} addrepo {{- $index }}
-
-{{ end -}}
-
-{{ if and .LocalGPGList (not .NoGPGCheck) }}
-RUN rpm --import {{ .LocalGPGList }}
-{{ end -}}
-
-{{ if and .LocalRPMList (not .NoGPGCheck) }}
-RUN rpm -Kv {{ .LocalRPMList }}
-{{ end -}}
-
-RUN zypper \
-    --pkg-cache-dir {{.CacheDir}} \ 
-    --gpg-auto-import-keys \
-    {{ if .NoGPGCheck -}}
-    --no-gpg-checks \
-    {{ end -}}
-    install -y \
-    --download-only \
-    --force-resolution \
-    --auto-agree-with-licenses \
-    --allow-vendor-change \
-    -n {{.PKGList}} {{.LocalRPMList}}
-
-RUN touch {{.CacheDir}}/zypper-success
-
-{{ if ne .RegCode "" }}
-RUN suseconnect -d
-{{ end -}}
+RUN ./{{ .RPMResolutionScriptName }}
 
 CMD ["/bin/bash"]

--- a/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
+++ b/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
@@ -14,6 +14,7 @@ set -euo pipefail
 suseconnect -r {{ .RegCode }}
 SLE_SP=$(cat /etc/rpm/macros.sle | awk '/sle/ {print $2};' | cut -c4) && suseconnect -p PackageHub/15.$SLE_SP/x86_64
 zypper ref
+trap "suseconnect -d" EXIT
 {{ end -}}
 
 {{- range $index, $repo := .AddRepo }}
@@ -51,7 +52,3 @@ zypper \
   -n {{.PKGList}} {{.LocalRPMList}}
 
 touch {{.CacheDir}}/zypper-success
-
-{{ if ne .RegCode "" }}
-suseconnect -d
-{{ end -}}

--- a/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
+++ b/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+#  Template Fields
+#  RegCode      - scc.suse.com registration code
+#  AddRepo      - additional third-party repositories that will be used in the resolution process
+#  CacheDir     - zypper cache directory where all rpm dependencies will be downloaded to
+#  PKGList      - list of packages for which to do the dependency resolution
+#  LocalRPMList - list of local RPMs for which dependency resolution has to be done
+#  LocalGPGList - list of local GPG keys that will be imported in the resolver image
+#  NoGPGCheck   - when set to true skips the GPG validation for all third-party repositories and local RPMs
+
+{{ if ne .RegCode "" }}
+suseconnect -r {{ .RegCode }}
+SLE_SP=$(cat /etc/rpm/macros.sle | awk '/sle/ {print $2};' | cut -c4) && suseconnect -p PackageHub/15.$SLE_SP/x86_64
+zypper ref
+{{ end -}}
+
+{{- range $index, $repo := .AddRepo }}
+
+{{- $gpgCheck := "" -}}
+{{- if $.NoGPGCheck -}}
+{{ $gpgCheck = "--no-gpgcheck" }}
+{{- else if .Unsigned -}}
+{{ $gpgCheck = "--gpgcheck-allow-unsigned-repo" }}
+{{- end -}}
+
+zypper ar {{ $gpgCheck }} -f {{ .URL }} addrepo {{- $index }}
+
+{{ end -}}
+
+{{ if and .LocalGPGList (not .NoGPGCheck) }}
+rpm --import {{ .LocalGPGList }}
+{{ end -}}
+
+{{ if and .LocalRPMList (not .NoGPGCheck) }}
+rpm -Kv {{ .LocalRPMList }}
+{{ end -}}
+
+zypper \
+  --pkg-cache-dir {{.CacheDir}} \
+  --gpg-auto-import-keys \
+  {{ if .NoGPGCheck -}}
+  --no-gpg-checks \
+  {{ end -}}
+  install -y \
+  --download-only \breaking
+  --force-resolution \
+  --auto-agree-with-licenses \
+  --allow-vendor-change \
+  -n {{.PKGList}} {{.LocalRPMList}}
+
+touch {{.CacheDir}}/zypper-success
+
+{{ if ne .RegCode "" }}
+suseconnect -d
+{{ end -}}

--- a/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
+++ b/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
@@ -45,7 +45,7 @@ zypper \
   --no-gpg-checks \
   {{ end -}}
   install -y \
-  --download-only \breaking
+  --download-only \
   --force-resolution \
   --auto-agree-with-licenses \
   --allow-vendor-change \


### PR DESCRIPTION
If the RPM resolution run fails before getting to the registration data [cleanup](https://github.com/suse-edge/edge-image-builder/blob/main/pkg/rpm/resolver/templates/Dockerfile.tpl#L66), the registration stays visible on SCC. Users would then have to manually go and remove the failed system from their subscription. This bad user experience is fixed by the suggested changes in this PR.

**What does this PR introduce:**
1. Main resolution logic has been moved from the resolver image Dockerfile to a bash script
2. Script is executed through the resolver Dockerfile

**What does this achieve**

By doing this, we can ensure that we [`trap`](https://man7.org/linux/man-pages/man1/trap.1p.html) the `suseconnect -d` command inside the bash script, ensuring that it will always be executed no matter how the script exists.

Furthermore, these changes make the `podman-image-build.log` significantly easier to read. This is true, because the image layer debug information is only printed once, where previously it was printed on every `RUN` command.

closes: #259 