### PR TITLE
239 - Reduce log message for files not matching the given extension

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ### Image Configuration Directory Changes
 
 ## Bug Fixes
+* [#239](https://github.com/suse-edge/edge-image-builder/issues/239)
 
 ---
 

--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -103,7 +103,7 @@ func CopyFiles(src, dest, ext string, copySubDir bool) error {
 			}
 		} else {
 			if ext != "" && filepath.Ext(file.Name()) != ext {
-				zap.S().Warnf("Skipping %s as it is not a '%s' file", file.Name(), ext)
+				zap.S().Debugf("Skipping %s as it is not a '%s' file", file.Name(), ext)
 				continue
 			}
 


### PR DESCRIPTION
There's potentially a larger fix needed to allow multiple extensions to be specified in a single call. But for now, reducing this to debug should help prevent user confusion of why they were being "warned" about a situation that isn't necessarily a problem.

closes: #239 