### PR TITLE
Prevent manifests and charts parsing if Kubernetes is not configured

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,9 +13,10 @@
 ### Image Configuration Directory Changes
 
 ## Bug Fixes
-* [#239](https://github.com/suse-edge/edge-image-builder/issues/239) - Incorrect warning when checking for both .yml and .yaml files
 
+* [#239](https://github.com/suse-edge/edge-image-builder/issues/239) - Incorrect warning when checking for both .yml and .yaml files
 * [#259](https://github.com/suse-edge/edge-image-builder/issues/259) - SCC registration is not cleaned up if RPM resolution fails
+* [#267](https://github.com/suse-edge/edge-image-builder/issues/267) - Embedded registry renders Kubernetes resources even when Kubernetes is not configured
 
 ---
 

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -317,8 +317,12 @@ func containerImages(embeddedImages []image.ContainerImage, manifestImages []str
 
 func parseManifests(ctx *image.Context) ([]string, error) {
 	var manifestSrcDir string
-	if componentDir := filepath.Join(k8sDir, "manifests"); isComponentConfigured(ctx, componentDir) {
+	if componentDir := filepath.Join(k8sDir, k8sManifestsDir); isComponentConfigured(ctx, componentDir) {
 		manifestSrcDir = filepath.Join(ctx.ImageConfigDir, componentDir)
+	}
+
+	if manifestSrcDir != "" && ctx.ImageDefinition.Kubernetes.Version == "" {
+		return nil, fmt.Errorf("kubernetes manifests are provided but kubernetes version is not configured")
 	}
 
 	return registry.ManifestImages(ctx.ImageDefinition.Kubernetes.Manifests.URLs, manifestSrcDir)

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -361,6 +361,10 @@ func storeComponentsHelmCharts(ctx *image.Context) (string, error) {
 }
 
 func parseComponentHelmCharts(ctx *image.Context) ([]*registry.HelmChart, error) {
+	if ctx.ImageDefinition.Kubernetes.Version == "" {
+		return nil, nil
+	}
+
 	chartsDir, err := storeComponentsHelmCharts(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("storing components' helm charts: %w", err)
@@ -382,6 +386,10 @@ func parseComponentHelmCharts(ctx *image.Context) ([]*registry.HelmChart, error)
 func parseConfiguredHelmCharts(ctx *image.Context) ([]*registry.HelmChart, error) {
 	if !isComponentConfigured(ctx, filepath.Join(k8sDir, helmDir)) {
 		return nil, nil
+	}
+
+	if ctx.ImageDefinition.Kubernetes.Version == "" {
+		return nil, fmt.Errorf("helm charts are provided but kubernetes version is not configured")
 	}
 
 	buildDir := filepath.Join(ctx.BuildDir, helmDir)


### PR DESCRIPTION
- Closes https://github.com/suse-edge/edge-image-builder/issues/267