### PR TITLE
corrected go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/suse-edge/edge-image-builder
 
-go 1.22
+go 1.22.0
 
 require (
 	// version should match buildah version in the


### PR DESCRIPTION
Not entirely sure what happened, but the project just stopped working on my Mac overnight with the following:

```
$ go mod tidy
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

I looked around and found [1] which talks about the issue. The fix works and I don't _think_ there are any other implications in changing this.

[1] https://github.com/golang/go/issues/65568