### PR TITLE
Change default behaviour for --build-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ The following example command attaches the directory and runs EIB:
 podman run --rm -it \
 -v $IMAGE_DIR:/eib eib:dev build \
 --definition-file $DEFINITION_FILE.yaml \
---config-dir /eib \
---build-dir /eib/_build
+--config-dir /eib
 ```
 
 **NOTE:**
@@ -64,11 +63,10 @@ which require it (e.g. Elemental, Kubernetes SELinux, etc.).
   specify the name of the configuration file.
 * `--config-dir` - Specifies the image configuration directory. Keep in mind that this is relative to the running
   container, so its value must match the mounted volume.
-* `--build-dir` - (optional) If unspecified, EIB will use a temporary directory inside the container for
-  assembling/generating the components used in the build. This may be specified to a location within the mounted
-  volume to make the build artifacts available after the container completes. In this example, a directory named
-  `_build` will be created in the image configuration directory and will persist after EIB finishes. This directory
-  will contain subdirectories storing the respective artifacts of the different builds.
+* `--build-dir` - (Optional) If unspecified, EIB will create a `_build` directory under the image configuration directory 
+  for assembling/generating the components used in the build which will persist after EIB finishes. This may also be
+  specified to another location within a mounted volume. The directory will contain subdirectories storing the
+  respective artifacts of the different builds.
 * `--validate` - If specified, the specified image definition and configuration directory will be checked to ensure
   the build can proceed, however the image will not actually be built.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ which require it (e.g. Elemental, Kubernetes SELinux, etc.).
 * `--build-dir` - (Optional) If unspecified, EIB will create a `_build` directory under the image configuration directory 
   for assembling/generating the components used in the build which will persist after EIB finishes. This may also be
   specified to another location within a mounted volume. The directory will contain subdirectories storing the
-  respective artifacts of the different builds.
+  respective artifacts of the different builds as well as cached copies of certain downloaded files.
 * `--validate` - If specified, the specified image definition and configuration directory will be checked to ensure
   the build can proceed, however the image will not actually be built.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,7 @@
 ## API
 
 * The `--config-file` argument to the EIB CLI has been renamed to `--definition-file`.
-* The `--build-dir` argument to the EIB CLI now defaults to `<config-dir>/_build`.
+* The `--build-dir` argument to the EIB CLI is now optional and defaults to `<config-dir>/_build`, creating it if it does not exist.
 
 ### Image Definition Changes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 ## API
 
 * The `--config-file` argument to the EIB CLI has been renamed to `--definition-file`.
+* The `--build-dir` argument to the EIB CLI now defaults to `<config-dir>/_build`.
 
 ### Image Definition Changes
 

--- a/docs/design/pkg-resolution.md
+++ b/docs/design/pkg-resolution.md
@@ -16,8 +16,7 @@ An example of the command can be seen below:
 podman run --rm --privileged -it \
 -v $IMAGE_DIR:/eib eib:dev build \
 --definition-file $DEFINITION_FILE.yaml \
---config-dir /eib \
---build-dir /eib/_build
+--config-dir /eib
 ```
 
 > **_NOTE:_** Depending on the `cgroupVersion` that Podman operates with, you might also need to run the command with `root` permissions. This is the case for `cgroupVersion: v1`. In this version, non-root usage of the `--privileged` option is not supported. For `cgroupVersion: v2`, non-root usage is supported. 

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,7 +70,6 @@ to the desired definition. For example:
 podman run --rm --privileged -it \
   -v .:/eib eib:dev build \
   --config-dir /eib \
-  --build-dir /eib/_build \
   --definition-file ./definitions/iso/basic.yaml
 ```
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -69,15 +69,7 @@ func (b *Builder) generateBaseImageFilename() string {
 	return filename
 }
 
-func SetupBuildDirectory(rootDir string) (buildDir string, combustionDir string, err error) {
-	if rootDir == "" {
-		tmpDir, tmpErr := os.MkdirTemp("", "eib-")
-		if tmpErr != nil {
-			return "", "", fmt.Errorf("creating a temporary root directory: %w", tmpErr)
-		}
-		rootDir = tmpDir
-	}
-
+func SetupBuildDirectory(rootDir string) (buildDir, combustionDir string, err error) {
 	timestamp := time.Now().Format("Jan02_15-04-05")
 	buildDir = filepath.Join(rootDir, fmt.Sprintf("build-%s", timestamp))
 	if err = os.MkdirAll(buildDir, os.ModePerm); err != nil {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -18,12 +18,10 @@ func TestSetupBuildDirectory_EmptyRootDir(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(buildDir))
 	}()
 
-	_, err = os.Stat(buildDir)
-	require.NoError(t, err)
+	require.DirExists(t, buildDir)
+	require.DirExists(t, combustionDir)
 
-	_, err = os.Stat(combustionDir)
-	require.NoError(t, err)
-
+	assert.Contains(t, buildDir, "build-")
 	assert.Equal(t, filepath.Join(buildDir, "combustion"), combustionDir)
 }
 
@@ -56,11 +54,8 @@ func TestSetupBuildDir_NonEmptyRootDir(t *testing.T) {
 			buildDir, combustionDir, err := SetupBuildDirectory(test.rootDir)
 			require.NoError(t, err)
 
-			_, err = os.Stat(buildDir)
-			require.NoError(t, err)
-
-			_, err = os.Stat(combustionDir)
-			require.NoError(t, err)
+			require.DirExists(t, buildDir)
+			require.DirExists(t, combustionDir)
 
 			assert.Contains(t, buildDir, filepath.Join(test.rootDir, "build-"))
 			assert.Equal(t, filepath.Join(buildDir, "combustion"), combustionDir)


### PR DESCRIPTION
- Omitting `--build-dir` no longer defaults to using a temporary directory within the container - it is now implicitly set to `<config-dir>/_build`
- Closes https://github.com/suse-edge/edge-image-builder/issues/284