### PR TITLE
Keep custom files' permissions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,7 @@
 * [#242](https://github.com/suse-edge/edge-image-builder/issues/242) - Empty rpms directory triggers resolution
 * [#283](https://github.com/suse-edge/edge-image-builder/issues/283) - Definition file argument to EIB is incorrect
 * [#245](https://github.com/suse-edge/edge-image-builder/issues/245) - Pass additional arguments to Helm resolver
+* [#272](https://github.com/suse-edge/edge-image-builder/issues/272) - Custom files should keep their permissions
 
 ---
 

--- a/pkg/combustion/custom.go
+++ b/pkg/combustion/custom.go
@@ -41,43 +41,47 @@ func configureCustomFiles(ctx *image.Context) ([]string, error) {
 
 func handleCustomFiles(ctx *image.Context) error {
 	fullFilesDir := generateComponentPath(ctx, filepath.Join(customDir, customFilesDir))
-	_, err := copyCustomFiles(fullFilesDir, ctx.CombustionDir, fileio.NonExecutablePerms)
+	_, err := copyCustomFiles(fullFilesDir, ctx.CombustionDir)
 	return err
 }
 
 func handleCustomScripts(ctx *image.Context) ([]string, error) {
 	fullScriptsDir := generateComponentPath(ctx, filepath.Join(customDir, customScriptsDir))
-	scripts, err := copyCustomFiles(fullScriptsDir, ctx.CombustionDir, fileio.ExecutablePerms)
+	scripts, err := copyCustomFiles(fullScriptsDir, ctx.CombustionDir)
 	return scripts, err
 }
 
-func copyCustomFiles(fromDir, combustionDir string, params os.FileMode) ([]string, error) {
+func copyCustomFiles(fromDir, toDir string) ([]string, error) {
 	if _, err := os.Stat(fromDir); os.IsNotExist(err) {
 		return nil, nil
 	}
 
-	dirListing, err := os.ReadDir(fromDir)
+	dirEntries, err := os.ReadDir(fromDir)
 	if err != nil {
 		return nil, fmt.Errorf("reading the custom directory at %s: %w", fromDir, err)
 	}
 
 	// If the directory exists but there's nothing in it, consider it an error case
-	if len(dirListing) == 0 {
+	if len(dirEntries) == 0 {
 		return nil, fmt.Errorf("no files found in directory %s", fromDir)
 	}
 
 	var copiedFiles []string
 
-	for _, scriptEntry := range dirListing {
-		copyMe := filepath.Join(fromDir, scriptEntry.Name())
-		copyTo := filepath.Join(combustionDir, scriptEntry.Name())
+	for _, entry := range dirEntries {
+		copyMe := filepath.Join(fromDir, entry.Name())
+		copyTo := filepath.Join(toDir, entry.Name())
 
-		err = fileio.CopyFile(copyMe, copyTo, params)
+		info, err := entry.Info()
 		if err != nil {
-			return nil, fmt.Errorf("copying script to %s: %w", copyTo, err)
+			return nil, fmt.Errorf("reading file info: %w", err)
 		}
 
-		copiedFiles = append(copiedFiles, scriptEntry.Name())
+		if err = fileio.CopyFile(copyMe, copyTo, info.Mode()); err != nil {
+			return nil, fmt.Errorf("copying file to %s: %w", copyTo, err)
+		}
+
+		copiedFiles = append(copiedFiles, entry.Name())
 	}
 
 	return copiedFiles, nil


### PR DESCRIPTION
- Uses the input custom files' permissions when copying to the combustion directory
- Closes https://github.com/suse-edge/edge-image-builder/issues/272