### PR TITLE
Change default behaviour for --config-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ The following example command attaches the directory and runs EIB:
 ```shell
 podman run --rm -it \
 -v $IMAGE_DIR:/eib eib:dev build \
---definition-file $DEFINITION_FILE.yaml \
---config-dir /eib
+--definition-file $DEFINITION_FILE.yaml
 ```
 
 **NOTE:**
@@ -61,8 +60,8 @@ which require it (e.g. Elemental, Kubernetes SELinux, etc.).
 * `--definition-file` - Specifies which image definition file to build. The path to this file will be relative to
   the image configuration directory. If the definition file is in the root of the configuration directory, simply 
   specify the name of the configuration file.
-* `--config-dir` - Specifies the image configuration directory. Keep in mind that this is relative to the running
-  container, so its value must match the mounted volume.
+* `--config-dir` - (Optional) Specifies the image configuration directory. This path is relative to the running container, so its
+  value must match the mounted volume. It defaults to `/eib` which matches the mounted volume `$IMAGE_DIR:/eib` in the example above.
 * `--build-dir` - (Optional) If unspecified, EIB will create a `_build` directory under the image configuration directory 
   for assembling/generating the components used in the build which will persist after EIB finishes. This may also be
   specified to another location within a mounted volume. The directory will contain subdirectories storing the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 
 * The `--config-file` argument to the EIB CLI has been renamed to `--definition-file`.
 * The `--build-dir` argument to the EIB CLI is now optional and defaults to `<config-dir>/_build`, creating it if it does not exist.
+* The `--config-dir` argument to the EIB CLI is now optional and defaults to `/eib` which is the most common mounted container volume.
 
 ### Image Definition Changes
 

--- a/docs/design/pkg-resolution.md
+++ b/docs/design/pkg-resolution.md
@@ -15,8 +15,7 @@ An example of the command can be seen below:
 ```shell
 podman run --rm --privileged -it \
 -v $IMAGE_DIR:/eib eib:dev build \
---definition-file $DEFINITION_FILE.yaml \
---config-dir /eib
+--definition-file $DEFINITION_FILE.yaml
 ```
 
 > **_NOTE:_** Depending on the `cgroupVersion` that Podman operates with, you might also need to run the command with `root` permissions. This is the case for `cgroupVersion: v1`. In this version, non-root usage of the `--privileged` option is not supported. For `cgroupVersion: v2`, non-root usage is supported. 

--- a/examples/README.md
+++ b/examples/README.md
@@ -69,7 +69,6 @@ to the desired definition. For example:
 ```bash
 podman run --rm --privileged -it \
   -v .:/eib eib:dev build \
-  --config-dir /eib \
   --definition-file ./definitions/iso/basic.yaml
 ```
 

--- a/pkg/cli/cmd/build.go
+++ b/pkg/cli/cmd/build.go
@@ -30,7 +30,7 @@ func NewBuildCommand(action func(*cli.Context) error) *cli.Command {
 			&cli.StringFlag{
 				Name:        "config-dir",
 				Usage:       "Full path to the image configuration directory",
-				Required:    true,
+				Value:       "/eib",
 				Destination: &BuildArgs.ConfigDir,
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
- The `--config-dir` flag is no longer required and now defaults to `/eib`
- Closes https://github.com/suse-edge/edge-image-builder/issues/303