### PR TITLE
Add validate subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,31 @@ For details on how to create the artifacts needed to build an image, see the
 
 The image configuration directory must be attached to the container at runtime. This serves as both the mechanism
 to introduce image definition files and provide a way to get the built image out of the container and onto
-the host machine. 
+the host machine.
 
-The following example command attaches the directory and runs EIB:
+#### Validating image definition
+
+The following example command attaches the image configuration directory and validates a definition:
 ```shell
-podman run --rm -it \
--v $IMAGE_DIR:/eib eib:dev build \
---definition-file $DEFINITION_FILE.yaml
+podman run --rm -it -v $IMAGE_DIR:/eib \
+eib:dev \
+validate --definition-file $DEFINITION_FILE.yaml
+```
+
+* `-v` - Used to mount a local directory (in this example, the value of $IMAGE_DIR) into the EIB container at `/eib`.
+* `--definition-file` - Specifies which image definition file to build. The path to this file will be relative to
+  the image configuration directory. If the definition file is in the root of the configuration directory, simply
+  specify the name of the configuration file.
+* `--config-dir` - (Optional) Specifies the image configuration directory. This path is relative to the running container, so its
+  value must match the mounted volume. It defaults to `/eib` which matches the mounted volume `$IMAGE_DIR:/eib` in the example above.
+
+#### Building image
+
+The following example command attaches the image configuration directory and builds an image:
+```shell
+podman run --rm -it -v $IMAGE_DIR:/eib \
+eib:dev \
+build --definition-file $DEFINITION_FILE.yaml
 ```
 
 **NOTE:**
@@ -66,8 +84,6 @@ which require it (e.g. Elemental, Kubernetes SELinux, etc.).
   for assembling/generating the components used in the build which will persist after EIB finishes. This may also be
   specified to another location within a mounted volume. The directory will contain subdirectories storing the
   respective artifacts of the different builds as well as cached copies of certain downloaded files.
-* `--validate` - If specified, the specified image definition and configuration directory will be checked to ensure
-  the build can proceed, however the image will not actually be built.
 
 
 ## Testing Images

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The image configuration directory must be attached to the container at runtime. 
 to introduce image definition files and provide a way to get the built image out of the container and onto
 the host machine.
 
-#### Validating image definition
+#### Validating an image definition
 
 The following example command attaches the image configuration directory and validates a definition:
 ```shell
@@ -60,7 +60,7 @@ validate --definition-file $DEFINITION_FILE.yaml
 * `--config-dir` - (Optional) Specifies the image configuration directory. This path is relative to the running container, so its
   value must match the mounted volume. It defaults to `/eib` which matches the mounted volume `$IMAGE_DIR:/eib` in the example above.
 
-#### Building image
+#### Building an image
 
 The following example command attaches the image configuration directory and builds an image:
 ```shell

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,12 +9,15 @@
 * Bumped Go Version to 1.22
 * Added support for using Helm charts from authenticated repositories/registries
 * Added support for skipping Helm chart TLS verification and for using Helm charts from plain HTTP repositories/registries
+* Added minor formatting improvements to the CLI output
 
 ## API
 
 * The `--config-file` argument to the EIB CLI has been renamed to `--definition-file`.
 * The `--build-dir` argument to the EIB CLI is now optional and defaults to `<config-dir>/_build`, creating it if it does not exist.
 * The `--config-dir` argument to the EIB CLI is now optional and defaults to `/eib` which is the most common mounted container volume.
+* New `validate` subcommand is introduced
+* The `--validate` argument to the `build` subcommand is now removed
 
 ### Image Definition Changes
 

--- a/cmd/eib/main.go
+++ b/cmd/eib/main.go
@@ -13,6 +13,7 @@ func main() {
 	app := cmd.NewApp()
 	app.Commands = []*cli.Command{
 		cmd.NewBuildCommand(build.Run),
+		cmd.NewValidateCommand(build.Validate),
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/pkg/cli/build/build.go
+++ b/pkg/cli/build/build.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	buildLogFilename = "eib-build.log"
-	checkLogMessage  = "Please check the eib-build.log file under the build directory for more information."
+	buildLogFilename     = "eib-build.log"
+	checkBuildLogMessage = "Please check the eib-build.log file under the build directory for more information."
 )
 
 func Run(_ *cli.Context) error {
@@ -51,25 +51,26 @@ func Run(_ *cli.Context) error {
 	// This needs to occur as early as possible so that the subsequent calls can use the log
 	log.ConfigureGlobalLogger(filepath.Join(buildDir, buildLogFilename))
 
-	configDirExists := imageConfigDirExists(args.ConfigDir)
-	if !configDirExists {
+	if cmdErr := imageConfigDirExists(args.ConfigDir); cmdErr != nil {
+		cmd.LogError(cmdErr, checkBuildLogMessage)
 		os.Exit(1)
 	}
 
-	imageDefinition := parseImageDefinition(args.ConfigDir, args.DefinitionFile)
-	if imageDefinition == nil {
+	imageDefinition, cmdErr := parseImageDefinition(args.ConfigDir, args.DefinitionFile)
+	if cmdErr != nil {
+		cmd.LogError(cmdErr, checkBuildLogMessage)
 		os.Exit(1)
 	}
 
 	ctx := buildContext(buildDir, combustionDir, args.ConfigDir, imageDefinition)
 
-	isDefinitionValid := isImageDefinitionValid(ctx)
-	if !isDefinitionValid {
+	if cmdErr = validateImageDefinition(ctx); cmdErr != nil {
+		cmd.LogError(cmdErr, checkBuildLogMessage)
 		os.Exit(1)
 	}
 
 	if err = appendKubernetesSELinuxRPMs(ctx); err != nil {
-		log.Auditf("Configuring Kubernetes failed. %s", checkLogMessage)
+		log.Auditf("Configuring Kubernetes failed. %s", checkBuildLogMessage)
 		zap.S().Fatalf("Failed to configure Kubernetes SELinux policy: %s", err)
 	}
 
@@ -77,7 +78,8 @@ func Run(_ *cli.Context) error {
 
 	appendHelm(ctx)
 
-	if !bootstrapDependencyServices(ctx, rootBuildDir) {
+	if cmdErr = bootstrapDependencyServices(ctx, rootBuildDir); cmdErr != nil {
+		cmd.LogError(cmdErr, checkBuildLogMessage)
 		os.Exit(1)
 	}
 
@@ -96,51 +98,50 @@ func Run(_ *cli.Context) error {
 	return nil
 }
 
-// Returns whether the image configuration directory can be read, displaying
-// the appropriate messages to the user. Returns 'true' if the directory exists and execution can proceed,
-// 'false' otherwise.
-func imageConfigDirExists(configDir string) bool {
+func imageConfigDirExists(configDir string) *cmd.Error {
 	_, err := os.Stat(configDir)
 	if err == nil {
-		return true
+		return nil
 	}
 
 	if errors.Is(err, fs.ErrNotExist) {
-		log.AuditInfof("The specified image configuration directory '%s' could not be found.", configDir)
-	} else {
-		log.AuditInfof("Unable to check the filesystem for the image configuration directory '%s'. %s",
-			configDir, checkLogMessage)
-
-		zap.S().Errorf("Reading config dir failed: %v", err)
+		return &cmd.Error{
+			UserMessage: fmt.Sprintf("The specified image configuration directory '%s' could not be found.", configDir),
+		}
 	}
 
-	return false
+	return &cmd.Error{
+		UserMessage: fmt.Sprintf("Unable to check the filesystem for the image configuration directory '%s'.", configDir),
+		LogMessage:  fmt.Sprintf("Reading image config dir failed: %v", err),
+	}
 }
 
-// Attempts to parse the specified image definition file, displaying the appropriate messages to the user.
-// Returns a populated `image.Context` struct if successful, `nil` if the definition could not be parsed.
-func parseImageDefinition(configDir, definitionFile string) *image.Definition {
+func parseImageDefinition(configDir, definitionFile string) (*image.Definition, *cmd.Error) {
 	definitionFilePath := filepath.Join(configDir, definitionFile)
 
 	configData, err := os.ReadFile(definitionFilePath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			log.AuditInfof("The specified definition file '%s' could not be found.", definitionFilePath)
-		} else {
-			log.AuditInfof("The specified definition file '%s' could not be read. %s", definitionFilePath, checkLogMessage)
-			zap.S().Error(err)
+			return nil, &cmd.Error{
+				UserMessage: fmt.Sprintf("The specified definition file '%s' could not be found.", definitionFilePath),
+			}
 		}
-		return nil
+
+		return nil, &cmd.Error{
+			UserMessage: fmt.Sprintf("The specified definition file '%s' could not be read.", definitionFilePath),
+			LogMessage:  fmt.Sprintf("Reading definition file failed: %v", err),
+		}
 	}
 
 	imageDefinition, err := image.ParseDefinition(configData)
 	if err != nil {
-		log.AuditInfof("The image definition file '%s' could not be parsed. %s", definitionFilePath, checkLogMessage)
-		zap.S().Error(err)
-		return nil
+		return nil, &cmd.Error{
+			UserMessage: fmt.Sprintf("The image definition file '%s' could not be parsed.", definitionFilePath),
+			LogMessage:  fmt.Sprintf("Parsing definition file failed: %v", err),
+		}
 	}
 
-	return imageDefinition
+	return imageDefinition, nil
 }
 
 // Assembles the image build context with user-provided values and implementation defaults.
@@ -232,16 +233,15 @@ func appendHelm(ctx *image.Context) {
 	ctx.ImageDefinition.Kubernetes.Helm.Repositories = append(ctx.ImageDefinition.Kubernetes.Helm.Repositories, componentRepos...)
 }
 
-// If the image definition requires it, starts the necessary services, displaying appropriate messages
-// to users in the event of an error. Returns 'true' if execution should proceed given that all dependencies
-// are satisfied; 'false' otherwise.
-func bootstrapDependencyServices(ctx *image.Context, rootDir string) bool {
+// If the image definition requires it, starts the necessary services, returning an error in the event of failure.
+func bootstrapDependencyServices(ctx *image.Context, rootDir string) *cmd.Error {
 	if !combustion.SkipRPMComponent(ctx) {
 		p, err := podman.New(ctx.BuildDir)
 		if err != nil {
-			log.AuditInfof("The services for RPM dependency resolution failed to start. %s", checkLogMessage)
-			zap.S().Error(err)
-			return false
+			return &cmd.Error{
+				UserMessage: "The services for RPM dependency resolution failed to start.",
+				LogMessage:  fmt.Sprintf("Setting up Podman instance failed: %v", err),
+			}
 		}
 
 		imgPath := filepath.Join(ctx.ImageConfigDir, "base-images", ctx.ImageDefinition.Image.BaseImage)
@@ -260,9 +260,10 @@ func bootstrapDependencyServices(ctx *image.Context, rootDir string) bool {
 	if ctx.ImageDefinition.Kubernetes.Version != "" {
 		c, err := cache.New(rootDir)
 		if err != nil {
-			log.AuditInfof("Failed to initialise file caching. %s", checkLogMessage)
-			zap.S().Error(err)
-			return false
+			return &cmd.Error{
+				UserMessage: "Setting up file caching failed.",
+				LogMessage:  fmt.Sprintf("Initialising cache instance failed: %v", err),
+			}
 		}
 
 		ctx.KubernetesScriptDownloader = kubernetes.ScriptDownloader{}
@@ -271,5 +272,5 @@ func bootstrapDependencyServices(ctx *image.Context, rootDir string) bool {
 		}
 	}
 
-	return true
+	return nil
 }

--- a/pkg/cli/build/build.go
+++ b/pkg/cli/build/build.go
@@ -71,12 +71,6 @@ func Run(_ *cli.Context) error {
 		os.Exit(1)
 	}
 
-	if args.Validate {
-		// If we got this far, the image is valid. If we're in this block, the user wants execution to stop.
-		log.AuditInfo("The specified image definition is valid.")
-		return nil
-	}
-
 	if err = appendKubernetesSELinuxRPMs(ctx); err != nil {
 		log.Auditf("Configuring Kubernetes failed. %s", checkLogMessage)
 		zap.S().Fatalf("Failed to configure Kubernetes SELinux policy: %s", err)

--- a/pkg/cli/build/build.go
+++ b/pkg/cli/build/build.go
@@ -104,18 +104,20 @@ func Run(_ *cli.Context) error {
 // 'false' otherwise.
 func imageConfigDirExists(configDir string) bool {
 	_, err := os.Stat(configDir)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			log.AuditInfof("The specified image configuration directory '%s' could not be found.", configDir)
-			return false
-		}
-		log.AuditInfof("Unable to check the filesystem for the image configuration directory '%s'. %s",
-			configDir, checkLogMessage)
-		zap.S().Error(err)
-		return false
+	if err == nil {
+		return true
 	}
 
-	return true
+	if errors.Is(err, fs.ErrNotExist) {
+		log.AuditInfof("The specified image configuration directory '%s' could not be found.", configDir)
+	} else {
+		log.AuditInfof("Unable to check the filesystem for the image configuration directory '%s'. %s",
+			configDir, checkLogMessage)
+
+		zap.S().Errorf("Reading config dir failed: %v", err)
+	}
+
+	return false
 }
 
 // Attempts to parse the specified image definition file, displaying the appropriate messages to the user.

--- a/pkg/cli/build/validate.go
+++ b/pkg/cli/build/validate.go
@@ -84,13 +84,13 @@ func validateImageDefinition(ctx *image.Context) *cmd.Error {
 	slices.Sort(orderedComponentNames)
 
 	for _, componentName := range orderedComponentNames {
-		userMessageBuilder.WriteString("\t" + componentName + "\n")
+		userMessageBuilder.WriteString("  " + componentName + "\n")
 
 		for _, cf := range failedValidations[componentName] {
-			userMessageBuilder.WriteString("\t\t" + cf.UserMessage + "\n")
-			logMessageBuilder.WriteString("\t" + cf.UserMessage + "\n")
+			userMessageBuilder.WriteString("    " + cf.UserMessage + "\n")
+			logMessageBuilder.WriteString("  " + cf.UserMessage + "\n")
 			if cf.Error != nil {
-				logMessageBuilder.WriteString("\t\t" + cf.Error.Error() + "\n")
+				logMessageBuilder.WriteString("    " + cf.Error.Error() + "\n")
 			}
 		}
 	}

--- a/pkg/cli/build/validate.go
+++ b/pkg/cli/build/validate.go
@@ -1,0 +1,53 @@
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/suse-edge/edge-image-builder/pkg/cli/cmd"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	validateLogFile = "eib-validate.log"
+)
+
+func Validate(_ *cli.Context) error {
+	args := &cmd.BuildArgs
+
+	timestamp := time.Now().Format("Jan02_15-04-05")
+	validationDir := filepath.Join(args.ConfigDir, fmt.Sprintf("validate-%s", timestamp))
+	if err := os.MkdirAll(validationDir, os.ModePerm); err != nil {
+		log.Auditf("The validation directory could not be setup under the configuration directory '%s'.", args.ConfigDir)
+		return err
+	}
+
+	// This needs to occur as early as possible so that the subsequent calls can use the log
+	log.ConfigureGlobalLogger(filepath.Join(validationDir, validateLogFile))
+
+	if !imageConfigDirExists(args.ConfigDir) {
+		os.Exit(1)
+	}
+
+	imageDefinition := parseImageDefinition(args.ConfigDir, args.DefinitionFile)
+	if imageDefinition == nil {
+		os.Exit(1)
+	}
+
+	ctx := &image.Context{
+		ImageConfigDir:  args.ConfigDir,
+		ImageDefinition: imageDefinition,
+	}
+
+	if !isImageDefinitionValid(ctx) {
+		os.Exit(1)
+	}
+
+	log.AuditInfo("The specified image definition is valid.")
+
+	return nil
+}

--- a/pkg/cli/build/validate.go
+++ b/pkg/cli/build/validate.go
@@ -16,22 +16,19 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	validateLogFile = "eib-validate.log"
-)
-
 func Validate(_ *cli.Context) error {
 	args := &cmd.BuildArgs
 
-	timestamp := time.Now().Format("Jan02_15-04-05")
-	validationDir := filepath.Join(args.ConfigDir, fmt.Sprintf("validate-%s", timestamp))
+	validationDir := filepath.Join(args.ConfigDir, "_validation")
 	if err := os.MkdirAll(validationDir, os.ModePerm); err != nil {
 		log.Auditf("The validation directory could not be setup under the configuration directory '%s'.", args.ConfigDir)
 		return err
 	}
 
 	// This needs to occur as early as possible so that the subsequent calls can use the log
-	log.ConfigureGlobalLogger(filepath.Join(validationDir, validateLogFile))
+	timestamp := time.Now().Format("Jan02_15-04-05")
+	logFilename := filepath.Join(validationDir, fmt.Sprintf("eib-validate-%s.log", timestamp))
+	log.ConfigureGlobalLogger(logFilename)
 
 	if !imageConfigDirExists(args.ConfigDir) {
 		os.Exit(1)

--- a/pkg/cli/build/validate.go
+++ b/pkg/cli/build/validate.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/suse-edge/edge-image-builder/pkg/cli/cmd"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/image/validation"
 	"github.com/suse-edge/edge-image-builder/pkg/log"
 	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
 )
 
 const (
@@ -50,4 +54,43 @@ func Validate(_ *cli.Context) error {
 	log.AuditInfo("The specified image definition is valid.")
 
 	return nil
+}
+
+// Runs the image definition validation, displaying the appropriate messages to the user in the event
+// of a failure. Returns 'true' if the definition is valid; 'false' otherwise.
+func isImageDefinitionValid(ctx *image.Context) bool {
+	failedValidations := validation.ValidateDefinition(ctx)
+	if len(failedValidations) == 0 {
+		return true
+	}
+
+	log.Audit("Image definition validation found the following errors:")
+
+	logMessageBuilder := strings.Builder{}
+
+	orderedComponentNames := make([]string, 0, len(failedValidations))
+	for c := range failedValidations {
+		orderedComponentNames = append(orderedComponentNames, c)
+	}
+	slices.Sort(orderedComponentNames)
+
+	for _, componentName := range orderedComponentNames {
+		failures := failedValidations[componentName]
+		log.Audit(fmt.Sprintf("  %s", componentName))
+		for _, cf := range failures {
+			log.Audit(fmt.Sprintf("    %s", cf.UserMessage))
+			logMessageBuilder.WriteString(cf.UserMessage + "\n")
+			if cf.Error != nil {
+				logMessageBuilder.WriteString("\t" + cf.Error.Error() + "\n")
+			}
+		}
+	}
+
+	if s := logMessageBuilder.String(); s != "" {
+		zap.S().Errorf("Image definition validation failures:\n%s", s)
+	}
+
+	log.AuditInfo(checkLogMessage)
+
+	return false
 }

--- a/pkg/cli/cmd/build.go
+++ b/pkg/cli/cmd/build.go
@@ -13,7 +13,21 @@ type BuildFlags struct {
 	Validate       bool
 }
 
-var BuildArgs BuildFlags
+var (
+	BuildArgs BuildFlags
+
+	DefinitionFileFlag = &cli.StringFlag{
+		Name:        "definition-file",
+		Usage:       "Name of the image definition file",
+		Destination: &BuildArgs.DefinitionFile,
+	}
+	ConfigDirFlag = &cli.StringFlag{
+		Name:        "config-dir",
+		Usage:       "Full path to the image configuration directory",
+		Value:       "/eib",
+		Destination: &BuildArgs.ConfigDir,
+	}
+)
 
 func NewBuildCommand(action func(*cli.Context) error) *cli.Command {
 	return &cli.Command{
@@ -22,17 +36,8 @@ func NewBuildCommand(action func(*cli.Context) error) *cli.Command {
 		UsageText: fmt.Sprintf("%s build [OPTIONS]", appName),
 		Action:    action,
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:        "definition-file",
-				Usage:       "Name of the image definition file",
-				Destination: &BuildArgs.DefinitionFile,
-			},
-			&cli.StringFlag{
-				Name:        "config-dir",
-				Usage:       "Full path to the image configuration directory",
-				Value:       "/eib",
-				Destination: &BuildArgs.ConfigDir,
-			},
+			DefinitionFileFlag,
+			ConfigDirFlag,
 			&cli.StringFlag{
 				Name:        "build-dir",
 				Usage:       "Full path to the directory to store build artifacts",

--- a/pkg/cli/cmd/build.go
+++ b/pkg/cli/cmd/build.go
@@ -10,7 +10,6 @@ type BuildFlags struct {
 	DefinitionFile string
 	ConfigDir      string
 	RootBuildDir   string
-	Validate       bool
 }
 
 var (
@@ -42,11 +41,6 @@ func NewBuildCommand(action func(*cli.Context) error) *cli.Command {
 				Name:        "build-dir",
 				Usage:       "Full path to the directory to store build artifacts",
 				Destination: &BuildArgs.RootBuildDir,
-			},
-			&cli.BoolFlag{
-				Name:        "validate",
-				Usage:       "If specified, the image definition will be validated but not built",
-				Destination: &BuildArgs.Validate,
 			},
 		},
 	}

--- a/pkg/cli/cmd/build.go
+++ b/pkg/cli/cmd/build.go
@@ -12,21 +12,7 @@ type BuildFlags struct {
 	RootBuildDir   string
 }
 
-var (
-	BuildArgs BuildFlags
-
-	DefinitionFileFlag = &cli.StringFlag{
-		Name:        "definition-file",
-		Usage:       "Name of the image definition file",
-		Destination: &BuildArgs.DefinitionFile,
-	}
-	ConfigDirFlag = &cli.StringFlag{
-		Name:        "config-dir",
-		Usage:       "Full path to the image configuration directory",
-		Value:       "/eib",
-		Destination: &BuildArgs.ConfigDir,
-	}
-)
+var BuildArgs BuildFlags
 
 func NewBuildCommand(action func(*cli.Context) error) *cli.Command {
 	return &cli.Command{

--- a/pkg/cli/cmd/error.go
+++ b/pkg/cli/cmd/error.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+)
+
+type Error struct {
+	UserMessage string
+	LogMessage  string
+}
+
+func LogError(err *Error, checkLogMessage string) {
+	if err.LogMessage == "" {
+		log.AuditError(err.UserMessage)
+		return
+	}
+
+	log.Audit(err.UserMessage)
+	log.Audit(checkLogMessage)
+	zap.S().Error(err.LogMessage)
+}

--- a/pkg/cli/cmd/flags.go
+++ b/pkg/cli/cmd/flags.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "github.com/urfave/cli/v2"
+
+var (
+	DefinitionFileFlag = &cli.StringFlag{
+		Name:        "definition-file",
+		Usage:       "Name of the image definition file",
+		Destination: &BuildArgs.DefinitionFile,
+	}
+	ConfigDirFlag = &cli.StringFlag{
+		Name:        "config-dir",
+		Usage:       "Full path to the image configuration directory",
+		Value:       "/eib",
+		Destination: &BuildArgs.ConfigDir,
+	}
+)

--- a/pkg/cli/cmd/validate.go
+++ b/pkg/cli/cmd/validate.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+func NewValidateCommand(action func(*cli.Context) error) *cli.Command {
+	return &cli.Command{
+		Name:      "validate",
+		Usage:     "Validate image configuration",
+		UsageText: fmt.Sprintf("%s validate [OPTIONS]", appName),
+		Action:    action,
+		Flags: []cli.Flag{
+			DefinitionFileFlag,
+			ConfigDirFlag,
+		},
+	}
+}

--- a/pkg/log/audit.go
+++ b/pkg/log/audit.go
@@ -37,6 +37,10 @@ func AuditInfof(message string, args ...any) {
 	doAudit(auditMe, zap.S().Info)
 }
 
+func AuditError(message string) {
+	doAudit(message, zap.S().Error)
+}
+
 func AuditComponentSuccessful(component string) {
 	message := formatComponentStatus(component, messageSuccess)
 	Audit(message)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,20 @@
+package log
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func ConfigureGlobalLogger(logFilename string) {
+	logConfig := zap.NewProductionConfig()
+	logConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	logConfig.Encoding = "console"
+	logConfig.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	logConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logConfig.OutputPaths = []string{logFilename}
+
+	logger := zap.Must(logConfig.Build())
+
+	// Set our configured logger to be accessed globally by zap.L()
+	zap.ReplaceGlobals(logger)
+}


### PR DESCRIPTION
- Introduces new `validate` subcommand
- Drops the `--validate` argument from the `build` subcommand
- Improves CLI error handling
- Closes https://github.com/suse-edge/edge-image-builder/issues/302

**Successful validation:**
```
suse-edge380@edge380:~/atanas/eib> podman run --rm -it -v /home/suse-edge380/atanas/eib:/eib eib:dev validate --definition-file k3s-single-node.yaml
Checking image config dir...
Parsing image definition...
Validating image definition...
The specified image definition is valid.
```

**Unsuccessful validation:**
```
suse-edge380@edge380:~/atanas/eib> podman run --rm -it -v /home/suse-edge380/atanas/eib:/eib eib:dev validate --definition-file k3s-single-node.yaml
Checking image config dir...
Parsing image definition...
Validating image definition...
Image definition validation found the following errors:
	Image
		The 'imageType' field must be one of: iso, raw
		The 'arch' field must be one of: aarch64, x86_64
	Operating System
		User 'root' must have either a password or at least one SSH key.
		Duplicate username found: root

Please check the log file under the validation directory for more information.
```