### PR TITLE
Moved Elemental register to a systemd unit and updated temporary Elemental RPM location

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@
 * [#307](https://github.com/suse-edge/edge-image-builder/issues/307) - Helm chart parsing logic breaks if "---" is present in the chart's resources
 * [#272](https://github.com/suse-edge/edge-image-builder/issues/272) - Custom files should keep their permissions
 * [#209](https://github.com/suse-edge/edge-image-builder/issues/209) - Embedded artifact registry starting even when manifests don't have any images
+* [#315](https://github.com/suse-edge/edge-image-builder/issues/315) - If Elemental fails to register during Combustion we drop to emergency shell
 
 ---
 

--- a/pkg/combustion/elemental.go
+++ b/pkg/combustion/elemental.go
@@ -20,7 +20,7 @@ const (
 	elementalConfigName    = "elemental_config.yaml"
 
 	// TODO: Use an official repository URL once it's out
-	ElementalPackageRepository = "https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Staging/standard/"
+	ElementalPackageRepository = "https://download.opensuse.org/repositories/isv:/Rancher:/Elemental:/Maintenance:/5.5/standard/"
 )
 
 var (

--- a/pkg/combustion/elemental_test.go
+++ b/pkg/combustion/elemental_test.go
@@ -62,5 +62,5 @@ func TestWriteElementalCombustionScript(t *testing.T) {
 	foundBytes, err := os.ReadFile(scriptFilename)
 	require.NoError(t, err)
 	found := string(foundBytes)
-	assert.Contains(t, found, "elemental-register --config-path /etc/elemental/config.yaml")
+	assert.Contains(t, found, "/usr/sbin/elemental-register --debug --config-path /etc/elemental/config.yaml --state-path /etc/elemental/state.yaml --install --no-toolkit")
 }

--- a/pkg/combustion/templates/31-elemental-register.sh.tpl
+++ b/pkg/combustion/templates/31-elemental-register.sh.tpl
@@ -4,12 +4,29 @@ set -euo pipefail
 mkdir -p /etc/elemental
 cp ./{{ .ConfigFile }} /etc/elemental/config.yaml
 
-# Register --no-toolkit disables OS management
-elemental-register --config-path /etc/elemental/config.yaml --state-path /etc/elemental/state.yaml --install --no-toolkit
+# Enable systemd based Elemental registration
+# Register --no-toolkit disables OS management in Rancher
+cat <<- EOF > /etc/systemd/system/elemental-register-systemd.service
+[Unit]
+Description=Elemental Register Install via Systemd
+Wants=network-online.target
+After=network-online.target
+ConditionPathExists=!/etc/rancher/elemental/agent/elemental_connection.json
+
+[Install]
+WantedBy=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/proxy
+Type=oneshot
+ExecStart=/usr/sbin/elemental-register --debug --config-path /etc/elemental/config.yaml --state-path /etc/elemental/state.yaml --install --no-toolkit
+ExecStartPost=/usr/bin/cp /var/lib/elemental/agent/elemental_connection.json /etc/rancher/elemental/agent
+Restart=on-failure
+RestartSec=10
+EOF
 
 # Enable elemental-system-agent
-# On SLEMicro /var/lib is not persistent, so we copy elemental_connection.json in ExecStartPre
-cp /var/lib/elemental/agent/elemental_connection.json /etc/rancher/elemental/agent
+# On SLE Micro /var/lib is not persistent, so we copy elemental_connection.json in ExecStartPre
 cat <<- EOF > /etc/systemd/system/elemental-system-agent.service
 [Unit]
 Description=Elemental System Agent
@@ -20,16 +37,17 @@ After=time-sync.target
 
 [Install]
 WantedBy=multi-user.target
-Alias=elemental-system-agent.service
 
 [Service]
 Type=simple
 Restart=always
 RestartSec=5s
-StandardOutput=journal+console
-StandardError=journal+console
+StandardOutput=journal
+StandardError=journal
 Environment="CATTLE_AGENT_CONFIG=/etc/rancher/elemental/agent/config.yaml"
 ExecStartPre=/bin/sh -c "mkdir -p /var/lib/elemental/agent && cp /etc/rancher/elemental/agent/elemental_connection.json /var/lib/elemental/agent"
 ExecStart=/usr/sbin/elemental-system-agent sentinel
 EOF
+
+systemctl enable elemental-register-systemd.service || true
 systemctl enable elemental-system-agent.service || true

--- a/pkg/combustion/templates/31-elemental-register.sh.tpl
+++ b/pkg/combustion/templates/31-elemental-register.sh.tpl
@@ -26,7 +26,6 @@ RestartSec=10
 EOF
 
 # Enable elemental-system-agent
-# On SLE Micro /var/lib is not persistent, so we copy elemental_connection.json in ExecStartPre
 cat <<- EOF > /etc/systemd/system/elemental-system-agent.service
 [Unit]
 Description=Elemental System Agent
@@ -45,7 +44,6 @@ RestartSec=5s
 StandardOutput=journal
 StandardError=journal
 Environment="CATTLE_AGENT_CONFIG=/etc/rancher/elemental/agent/config.yaml"
-ExecStartPre=/bin/sh -c "mkdir -p /var/lib/elemental/agent && cp /etc/rancher/elemental/agent/elemental_connection.json /var/lib/elemental/agent"
 ExecStart=/usr/sbin/elemental-system-agent sentinel
 EOF
 


### PR DESCRIPTION
In this PR we move Elemental register to a systemd unit instead, that attempts to continually register rather than halting the boot and dropping to an emergency shell that requires manual intervention. We also move the package repo to the *other* temporary repo for 5.5 maintenance from OBS. This will get replaced with the proper repo in the coming days, but this unblocks folks wanting to try EIB+Elemental in the meantime.

Fixes: #315 