### PR TITLE
[Bug Fix] Add wait mechanism for Podman's API Listener service

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,6 +37,7 @@
 * [#272](https://github.com/suse-edge/edge-image-builder/issues/272) - Custom files should keep their permissions
 * [#209](https://github.com/suse-edge/edge-image-builder/issues/209) - Embedded artifact registry starting even when manifests don't have any images
 * [#315](https://github.com/suse-edge/edge-image-builder/issues/315) - If Elemental fails to register during Combustion we drop to emergency shell
+* [#289](https://github.com/suse-edge/edge-image-builder/issues/289) - The services for RPM dependency resolution failed to start
 
 ---
 

--- a/pkg/podman/listener.go
+++ b/pkg/podman/listener.go
@@ -7,17 +7,25 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+	"go.uber.org/zap"
 )
 
 const (
 	podmanArgsBase        = "--log-level=debug system service -t 0"
 	podmanExec            = "/usr/bin/podman"
 	podmanListenerLogFile = "podman-system-service.log"
+	podmanSocketPath      = "/run/podman/podman.sock"
 )
 
 // creates a listening service that answers API calls for Podman (https://docs.podman.io/en/v4.8.2/markdown/podman-system-service.1.html)
 // only way to start the service from within a container - https://github.com/containers/podman/tree/v4.8.2/pkg/bindings#starting-the-service-manually
 func setupAPIListener(out string) error {
+	log.Audit("Setting up Podman API listener...")
+	zap.L().Info("Setting up Podman API listener...")
+
 	logFile, err := os.Create(filepath.Join(out, podmanListenerLogFile))
 	if err != nil {
 		return fmt.Errorf("creating podman listener log file: %w", err)
@@ -31,7 +39,7 @@ func setupAPIListener(out string) error {
 		return fmt.Errorf("error running podman system service: %w", err)
 	}
 
-	return nil
+	return waitForPodmanSock()
 }
 
 func preparePodmanCommand(out io.Writer) *exec.Cmd {
@@ -41,4 +49,24 @@ func preparePodmanCommand(out io.Writer) *exec.Cmd {
 	cmd.Stderr = out
 
 	return cmd
+}
+
+func waitForPodmanSock() error {
+	const (
+		retries      = 5
+		sleepSeconds = 3
+	)
+
+	zap.S().Infof("Waiting for '%s' to be created", podmanSocketPath)
+	for i := 0; i < retries; i++ {
+		if _, err := os.Stat(podmanSocketPath); err == nil {
+			zap.S().Infof("'%s' file has been created successfully", podmanSocketPath)
+			return nil
+		}
+
+		zap.S().Infof("'%s' file is not yet created, retrying in %d seconds", podmanSocketPath, sleepSeconds)
+		time.Sleep(sleepSeconds * time.Second)
+	}
+
+	return fmt.Errorf("'%s' file was not created in the expected time", podmanSocketPath)
 }

--- a/pkg/podman/listener.go
+++ b/pkg/podman/listener.go
@@ -20,8 +20,8 @@ const (
 	podmanSocketPath      = "/run/podman/podman.sock"
 )
 
-// creates a listening service that answers API calls for Podman (https://docs.podman.io/en/v4.8.2/markdown/podman-system-service.1.html)
-// only way to start the service from within a container - https://github.com/containers/podman/tree/v4.8.2/pkg/bindings#starting-the-service-manually
+// creates a listening service that answers API calls for Podman (https://docs.podman.io/en/v4.8.3/markdown/podman-system-service.1.html)
+// only way to start the service from within a container - https://github.com/containers/podman/tree/v4.8.3/pkg/bindings#starting-the-service-manually
 func setupAPIListener(out string) error {
 	log.Audit("Setting up Podman API listener...")
 	zap.L().Info("Setting up Podman API listener...")

--- a/pkg/podman/listener.go
+++ b/pkg/podman/listener.go
@@ -23,8 +23,7 @@ const (
 // creates a listening service that answers API calls for Podman (https://docs.podman.io/en/v4.8.3/markdown/podman-system-service.1.html)
 // only way to start the service from within a container - https://github.com/containers/podman/tree/v4.8.3/pkg/bindings#starting-the-service-manually
 func setupAPIListener(out string) error {
-	log.Audit("Setting up Podman API listener...")
-	zap.L().Info("Setting up Podman API listener...")
+	log.AuditInfo("Setting up Podman API listener...")
 
 	logFile, err := os.Create(filepath.Join(out, podmanListenerLogFile))
 	if err != nil {

--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	podmanSock         = "unix:///run/podman/podman.sock"
+	podmanSocketURI    = "unix://%s"
 	dockerfile         = "Dockerfile"
 	podmanDirName      = "podman"
 	podmanBuildLogFile = "podman-image-build.log"
@@ -41,7 +41,7 @@ func New(out string) (*Podman, error) {
 		return nil, fmt.Errorf("creating new podman instance: %w", err)
 	}
 
-	conn, err := bindings.NewConnection(context.Background(), podmanSock)
+	conn, err := bindings.NewConnection(context.Background(), fmt.Sprintf(podmanSocketURI, podmanSocketPath))
 	if err != nil {
 		return nil, fmt.Errorf("creating new podman connection: %w", err)
 	}


### PR DESCRIPTION
Currently there is a race-condition that can happen where we start the [API Listener](https://github.com/suse-edge/edge-image-builder/blob/main/pkg/podman/listener.go#L29) and immediately attempt to make a [connection](https://github.com/suse-edge/edge-image-builder/blob/main/pkg/podman/podman.go#L44) with Podman. 

This sometimes results in the following error:
```bash
creating new podman connection: unable to connect to Podman socket: Get "http://d/v4.8.3/libpod/_ping": dial unix /run/podman/podman.sock: connect: no such file or directory
```
Mainly this happens, because we do not give enough time for the API Listener to create its `podman.sock` file. 

This PR introduces a waiting mechanism that waits for the `podman.sock` file to be created. The wait timeout for this file is 15 seconds, where the file is checked every 3 seconds. The `podman.sock` creation operation is very quick (hence why we didn't catch the race-condition sooner), so 15 seconds is a good timeout value for this file.

Fixes: #289 