### PR TITLE
Introduce artefacts directory

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,8 @@
 
 ## Bug Fixes
 
+* [#319](https://github.com/suse-edge/edge-image-builder/issues/319) - Combustion fails when combustion directory content is larger than half of the RAM of the system
+
 ---
 
 # v1.0.0-rc2

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -69,17 +69,26 @@ func (b *Builder) generateBaseImageFilename() string {
 	return filename
 }
 
-func SetupBuildDirectory(rootDir string) (buildDir, combustionDir string, err error) {
+func SetupBuildDirectory(rootDir string) (string, error) {
 	timestamp := time.Now().Format("Jan02_15-04-05")
-	buildDir = filepath.Join(rootDir, fmt.Sprintf("build-%s", timestamp))
-	if err = os.MkdirAll(buildDir, os.ModePerm); err != nil {
-		return "", "", fmt.Errorf("creating a build directory: %w", err)
+	buildDir := filepath.Join(rootDir, fmt.Sprintf("build-%s", timestamp))
+	if err := os.MkdirAll(buildDir, os.ModePerm); err != nil {
+		return "", fmt.Errorf("creating a build directory: %w", err)
 	}
 
+	return buildDir, nil
+}
+
+func SetupCombustionDirectory(buildDir string) (combustionDir, artefactsDir string, err error) {
 	combustionDir = filepath.Join(buildDir, "combustion")
 	if err = os.MkdirAll(combustionDir, os.ModePerm); err != nil {
 		return "", "", fmt.Errorf("creating a combustion directory: %w", err)
 	}
 
-	return buildDir, combustionDir, nil
+	artefactsDir = filepath.Join(buildDir, "artefacts")
+	if err = os.MkdirAll(artefactsDir, os.ModePerm); err != nil {
+		return "", "", fmt.Errorf("creating an artefacts directory: %w", err)
+	}
+
+	return combustionDir, artefactsDir, nil
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSetupBuildDirectory_EmptyRootDir(t *testing.T) {
-	buildDir, combustionDir, err := SetupBuildDirectory("")
+	buildDir, err := SetupBuildDirectory("")
 	require.NoError(t, err)
 
 	defer func() {
@@ -19,10 +19,7 @@ func TestSetupBuildDirectory_EmptyRootDir(t *testing.T) {
 	}()
 
 	require.DirExists(t, buildDir)
-	require.DirExists(t, combustionDir)
-
 	assert.Contains(t, buildDir, "build-")
-	assert.Equal(t, filepath.Join(buildDir, "combustion"), combustionDir)
 }
 
 func TestSetupBuildDir_NonEmptyRootDir(t *testing.T) {
@@ -51,14 +48,11 @@ func TestSetupBuildDir_NonEmptyRootDir(t *testing.T) {
 				assert.NoError(t, os.RemoveAll(test.rootDir))
 			}()
 
-			buildDir, combustionDir, err := SetupBuildDirectory(test.rootDir)
+			buildDir, err := SetupBuildDirectory(test.rootDir)
 			require.NoError(t, err)
 
 			require.DirExists(t, buildDir)
-			require.DirExists(t, combustionDir)
-
 			assert.Contains(t, buildDir, filepath.Join(test.rootDir, "build-"))
-			assert.Equal(t, filepath.Join(buildDir, "combustion"), combustionDir)
 		})
 	}
 }

--- a/pkg/build/iso.go
+++ b/pkg/build/iso.go
@@ -115,6 +115,7 @@ func (b *Builder) writeIsoScript(templateContents, outputFilename string) error 
 		IsoSource           string
 		OutputImageFilename string
 		CombustionDir       string
+		ArtefactsDir        string
 		InstallDevice       string
 		Unattended          bool
 	}{
@@ -123,6 +124,7 @@ func (b *Builder) writeIsoScript(templateContents, outputFilename string) error 
 		IsoSource:           b.generateBaseImageFilename(),
 		OutputImageFilename: b.generateOutputImageFilename(),
 		CombustionDir:       b.context.CombustionDir,
+		ArtefactsDir:        b.context.ArtefactsDir,
 		InstallDevice:       b.context.ImageDefinition.OperatingSystem.IsoConfiguration.InstallDevice,
 		Unattended:          b.context.ImageDefinition.OperatingSystem.IsoConfiguration.Unattended,
 	}

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -83,6 +83,7 @@ func (b *Builder) writeModifyScript(imageFilename string, includeCombustion, ren
 	values := struct {
 		ImagePath           string
 		CombustionDir       string
+		ArtefactsDir        string
 		ConfigureGRUB       string
 		ConfigureCombustion bool
 		RenameFilesystem    bool
@@ -90,6 +91,7 @@ func (b *Builder) writeModifyScript(imageFilename string, includeCombustion, ren
 	}{
 		ImagePath:           imageFilename,
 		CombustionDir:       b.context.CombustionDir,
+		ArtefactsDir:        b.context.ArtefactsDir,
 		ConfigureGRUB:       grubConfiguration,
 		ConfigureCombustion: includeCombustion,
 		RenameFilesystem:    renameFilesystem,

--- a/pkg/build/templates/modify-raw-image.sh.tpl
+++ b/pkg/build/templates/modify-raw-image.sh.tpl
@@ -4,9 +4,10 @@ set -euo pipefail
 #  Template Fields
 #  ImagePath           - Full path to the image to modify
 #  CombustionDir       - Full path to the combustion directory
+#  ArtefactsDir        - Full path to the artefacts directory
 #  ConfigureGRUB       - Contains the guestfish command lines to run to manipulate GRUB configuration.
 #                        If there is no specific GRUB configuration to do, this will be an empty string.
-#  ConfigureCombustion - If true, the combustion directory will be included in the raw image
+#  ConfigureCombustion - If true, the combustion and artefacts directories will be included in the raw image
 #  RenameFilesystem    - If true, the filesystem of the image will be renamed (see below for information
 #                        on why this is needed)
 #
@@ -33,6 +34,7 @@ guestfish --format=raw --rw -a {{.ImagePath}} -i <<'EOF'
 
   {{ if .ConfigureCombustion }}
   copy-in {{.CombustionDir}} /
+  copy-in {{.ArtefactsDir}} /
   {{ end }}
 
   {{ if .RenameFilesystem }}

--- a/pkg/build/templates/rebuild-iso.sh.tpl
+++ b/pkg/build/templates/rebuild-iso.sh.tpl
@@ -7,12 +7,14 @@ set -euo pipefail
 #  IsoSource - Full path to the original ISO that was extracted
 #  OutputImageFilename - Full path and name of the ISO to create
 #  CombustionDir - Full path to the combustion directory to include in the new ISO
+#  ArtefactsDir - Full path to the artefacts directory to include in the new ISO
 
 ISO_EXTRACT_DIR={{.IsoExtractDir}}
 RAW_EXTRACT_DIR={{.RawExtractDir}}
 ISO_SOURCE={{.IsoSource}}
 OUTPUT_IMAGE={{.OutputImageFilename}}
 COMBUSTION_DIR={{.CombustionDir}}
+ARTEFACTS_DIR={{.ArtefactsDir}}
 
 cd ${ISO_EXTRACT_DIR}
 
@@ -45,7 +47,8 @@ xorriso -indev ${ISO_SOURCE} \
         -outdev ${OUTPUT_IMAGE} \
         -map ${NEW_SQUASH_FILE} /${SQUASH_BASENAME} \
         -map ${COMBUSTION_DIR} /combustion \
-{{ if .InstallDevice -}}
+        -map ${ARTEFACTS_DIR} /artefacts \
+{{- if .InstallDevice }}
         -map ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg /boot/grub2/grub.cfg \
-{{ end -}}
+{{- end }}
         -boot_image any replay -changes_pending yes

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -167,3 +167,7 @@ func logComponentStatus(component string, err error) {
 		zap.S().Infof("Successfully configured %s component", component)
 	}
 }
+
+func prependArtefactPath(path string) string {
+	return filepath.Join("$ARTEFACTS_DIR", path)
+}

--- a/pkg/combustion/combustion_test.go
+++ b/pkg/combustion/combustion_test.go
@@ -20,16 +20,21 @@ func setupContext(t *testing.T) (ctx *image.Context, teardown func()) {
 	combustionDir, err := os.MkdirTemp("", "eib-combustion-")
 	require.NoError(t, err)
 
+	artefactsDir, err := os.MkdirTemp("", "eib-artefacts-")
+	require.NoError(t, err)
+
 	ctx = &image.Context{
 		ImageConfigDir:  configDir,
 		BuildDir:        buildDir,
 		CombustionDir:   combustionDir,
+		ArtefactsDir:    artefactsDir,
 		ImageDefinition: &image.Definition{},
 	}
 
 	return ctx, func() {
 		assert.NoError(t, os.RemoveAll(combustionDir))
 		assert.NoError(t, os.RemoveAll(buildDir))
+		assert.NoError(t, os.RemoveAll(artefactsDir))
 		assert.NoError(t, os.RemoveAll(configDir))
 	}
 }

--- a/pkg/combustion/kubernetes.go
+++ b/pkg/combustion/kubernetes.go
@@ -150,7 +150,7 @@ func configureK3S(ctx *image.Context, cluster *kubernetes.Cluster) (string, erro
 		"imagesPath":      imagesPath,
 		"manifestsPath":   manifestsPath,
 		"configFilePath":  prependArtefactPath(K8sDir),
-		"registryMirrors": registryMirrorsFileName,
+		"registryMirrors": prependArtefactPath(filepath.Join(K8sDir, registryMirrorsFileName)),
 	}
 
 	singleNode := len(ctx.ImageDefinition.Kubernetes.Nodes) < 2
@@ -245,7 +245,7 @@ func configureRKE2(ctx *image.Context, cluster *kubernetes.Cluster) (string, err
 		"imagesPath":      imagesPath,
 		"manifestsPath":   manifestsPath,
 		"configFilePath":  prependArtefactPath(K8sDir),
-		"registryMirrors": registryMirrorsFileName,
+		"registryMirrors": prependArtefactPath(filepath.Join(K8sDir, registryMirrorsFileName)),
 	}
 
 	singleNode := len(ctx.ImageDefinition.Kubernetes.Nodes) < 2

--- a/pkg/combustion/kubernetes.go
+++ b/pkg/combustion/kubernetes.go
@@ -82,7 +82,12 @@ func configureKubernetes(ctx *image.Context) ([]string, error) {
 		return nil, fmt.Errorf("initialising cluster config: %w", err)
 	}
 
-	if err = storeKubernetesClusterConfig(cluster, ctx.CombustionDir); err != nil {
+	artefactsPath := kubernetesArtefactsPath(ctx)
+	if err = os.MkdirAll(artefactsPath, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("creating kubernetes artefacts path: %w", err)
+	}
+
+	if err = storeKubernetesClusterConfig(cluster, artefactsPath); err != nil {
 		log.AuditComponentFailed(k8sComponentName)
 		return nil, fmt.Errorf("storing cluster config: %w", err)
 	}
@@ -108,10 +113,21 @@ func kubernetesConfigurator(version string) func(*image.Context, *kubernetes.Clu
 	}
 }
 
+func downloadKubernetesInstallScript(ctx *image.Context, distribution string) (string, error) {
+	path := kubernetesArtefactsPath(ctx)
+
+	installScript, err := ctx.KubernetesScriptDownloader.DownloadInstallScript(distribution, path)
+	if err != nil {
+		return "", fmt.Errorf("downloading install script: %w", err)
+	}
+
+	return prependArtefactPath(filepath.Join(K8sDir, installScript)), nil
+}
+
 func configureK3S(ctx *image.Context, cluster *kubernetes.Cluster) (string, error) {
 	zap.S().Info("Configuring K3s cluster")
 
-	installScript, err := ctx.KubernetesScriptDownloader.DownloadInstallScript(image.KubernetesDistroK3S, ctx.CombustionDir)
+	installScript, err := downloadKubernetesInstallScript(ctx, image.KubernetesDistroK3S)
 	if err != nil {
 		return "", fmt.Errorf("downloading k3s install script: %w", err)
 	}
@@ -133,6 +149,7 @@ func configureK3S(ctx *image.Context, cluster *kubernetes.Cluster) (string, erro
 		"binaryPath":      binaryPath,
 		"imagesPath":      imagesPath,
 		"manifestsPath":   manifestsPath,
+		"configFilePath":  prependArtefactPath(K8sDir),
 		"registryMirrors": registryMirrorsFileName,
 	}
 
@@ -163,13 +180,13 @@ func configureK3S(ctx *image.Context, cluster *kubernetes.Cluster) (string, erro
 
 func downloadK3sArtefacts(ctx *image.Context) (binaryPath, imagesPath string, err error) {
 	imagesPath = filepath.Join(K8sDir, k8sImagesDir)
-	imagesDestination := filepath.Join(ctx.CombustionDir, imagesPath)
+	imagesDestination := filepath.Join(ctx.ArtefactsDir, imagesPath)
 	if err = os.MkdirAll(imagesDestination, os.ModePerm); err != nil {
 		return "", "", fmt.Errorf("creating kubernetes images dir: %w", err)
 	}
 
 	installPath := filepath.Join(K8sDir, k8sInstallDir)
-	installDestination := filepath.Join(ctx.CombustionDir, installPath)
+	installDestination := filepath.Join(ctx.ArtefactsDir, installPath)
 	if err = os.MkdirAll(installDestination, os.ModePerm); err != nil {
 		return "", "", fmt.Errorf("creating kubernetes install dir: %w", err)
 	}
@@ -199,13 +216,13 @@ func downloadK3sArtefacts(ctx *image.Context) (binaryPath, imagesPath string, er
 	}
 
 	binaryPath = filepath.Join(installPath, entries[0].Name())
-	return binaryPath, imagesPath, nil
+	return prependArtefactPath(binaryPath), prependArtefactPath(imagesPath), nil
 }
 
 func configureRKE2(ctx *image.Context, cluster *kubernetes.Cluster) (string, error) {
 	zap.S().Info("Configuring RKE2 cluster")
 
-	installScript, err := ctx.KubernetesScriptDownloader.DownloadInstallScript(image.KubernetesDistroRKE2, ctx.CombustionDir)
+	installScript, err := downloadKubernetesInstallScript(ctx, image.KubernetesDistroRKE2)
 	if err != nil {
 		return "", fmt.Errorf("downloading RKE2 install script: %w", err)
 	}
@@ -227,6 +244,7 @@ func configureRKE2(ctx *image.Context, cluster *kubernetes.Cluster) (string, err
 		"installPath":     installPath,
 		"imagesPath":      imagesPath,
 		"manifestsPath":   manifestsPath,
+		"configFilePath":  prependArtefactPath(K8sDir),
 		"registryMirrors": registryMirrorsFileName,
 	}
 
@@ -269,13 +287,13 @@ func downloadRKE2Artefacts(ctx *image.Context, cluster *kubernetes.Cluster) (ins
 	}
 
 	imagesPath = filepath.Join(K8sDir, k8sImagesDir)
-	imagesDestination := filepath.Join(ctx.CombustionDir, imagesPath)
+	imagesDestination := filepath.Join(ctx.ArtefactsDir, imagesPath)
 	if err = os.MkdirAll(imagesDestination, os.ModePerm); err != nil {
 		return "", "", fmt.Errorf("creating kubernetes images dir: %w", err)
 	}
 
 	installPath = filepath.Join(K8sDir, k8sInstallDir)
-	installDestination := filepath.Join(ctx.CombustionDir, installPath)
+	installDestination := filepath.Join(ctx.ArtefactsDir, installPath)
 	if err = os.MkdirAll(installDestination, os.ModePerm); err != nil {
 		return "", "", fmt.Errorf("creating kubernetes install dir: %w", err)
 	}
@@ -291,7 +309,7 @@ func downloadRKE2Artefacts(ctx *image.Context, cluster *kubernetes.Cluster) (ins
 		return "", "", fmt.Errorf("downloading artefacts: %w", err)
 	}
 
-	return installPath, imagesPath, nil
+	return prependArtefactPath(installPath), prependArtefactPath(imagesPath), nil
 }
 
 func kubernetesVIPManifest(k *image.Kubernetes) (string, error) {
@@ -345,7 +363,7 @@ func configureManifests(ctx *image.Context) (string, error) {
 	localManifestsConfigured := isComponentConfigured(ctx, filepath.Join(K8sDir, k8sManifestsDir))
 
 	manifestsPath := filepath.Join(K8sDir, k8sManifestsDir)
-	manifestDestDir := filepath.Join(ctx.CombustionDir, manifestsPath)
+	manifestDestDir := filepath.Join(ctx.ArtefactsDir, manifestsPath)
 
 	if ctx.ImageDefinition.Kubernetes.Network.APIVIP != "" {
 		if err := os.MkdirAll(manifestDestDir, os.ModePerm); err != nil {
@@ -367,7 +385,7 @@ func configureManifests(ctx *image.Context) (string, error) {
 		// The registry component would have already created and populated the manifests path if helm resources are configured
 		// or required. This is a hack until the dependencies between the different combustion components are resolved.
 		if _, err := os.Stat(manifestDestDir); err == nil {
-			return manifestsPath, nil
+			return prependArtefactPath(manifestsPath), nil
 		}
 
 		return "", nil
@@ -397,9 +415,13 @@ func configureManifests(ctx *image.Context) (string, error) {
 		}
 	}
 
-	return manifestsPath, nil
+	return prependArtefactPath(manifestsPath), nil
 }
 
 func KubernetesConfigPath(ctx *image.Context) string {
 	return filepath.Join(ctx.ImageConfigDir, K8sDir, k8sConfigDir, k8sServerConfigFile)
+}
+
+func kubernetesArtefactsPath(ctx *image.Context) string {
+	return filepath.Join(ctx.ArtefactsDir, K8sDir)
 }

--- a/pkg/combustion/kubernetes_integration_test.go
+++ b/pkg/combustion/kubernetes_integration_test.go
@@ -23,10 +23,10 @@ func TestConfigureManifestsValidDownload(t *testing.T) {
 		"https://k8s.io/examples/application/nginx-app.yaml",
 	}
 
-	k8sCombDir := filepath.Join(ctx.CombustionDir, K8sDir)
+	k8sCombDir := filepath.Join(ctx.ArtefactsDir, K8sDir)
 	require.NoError(t, os.Mkdir(k8sCombDir, os.ModePerm))
 
-	downloadedManifestsPath := filepath.Join(K8sDir, k8sManifestsDir)
+	downloadedManifestsPath := filepath.Join("$ARTEFACTS_DIR", K8sDir, k8sManifestsDir)
 	downloadedManifestsDestDir := filepath.Join(k8sCombDir, k8sManifestsDir)
 	expectedDownloadedFilePath := filepath.Join(downloadedManifestsDestDir, "dl-manifest-1.yaml")
 
@@ -74,7 +74,7 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 		"https://k8s.io/examples/application/nginx-app.yaml",
 	}
 
-	k8sCombDir := filepath.Join(ctx.CombustionDir, K8sDir)
+	k8sCombDir := filepath.Join(ctx.ArtefactsDir, K8sDir)
 	require.NoError(t, os.Mkdir(k8sCombDir, os.ModePerm))
 
 	localManifestsSrcDir := filepath.Join(ctx.ImageConfigDir, K8sDir, k8sManifestsDir)
@@ -100,18 +100,18 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 	require.NoError(t, err)
 
 	contents := string(b)
-	assert.Contains(t, contents, "cp kubernetes/images/* /var/lib/rancher/rke2/agent/images/")
-	assert.Contains(t, contents, "cp server.yaml /etc/rancher/rke2/config.yaml")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/images/* /var/lib/rancher/rke2/agent/images/")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/server.yaml /etc/rancher/rke2/config.yaml")
 	assert.Contains(t, contents, "echo \"192.168.122.100 api.cluster01.hosted.on.edge.suse.com\" >> /etc/hosts")
-	assert.Contains(t, contents, "export INSTALL_RKE2_ARTIFACT_PATH=kubernetes/install")
-	assert.Contains(t, contents, "./install-k8s.sh")
+	assert.Contains(t, contents, "export INSTALL_RKE2_ARTIFACT_PATH=$ARTEFACTS_DIR/kubernetes/install")
+	assert.Contains(t, contents, "sh $ARTEFACTS_DIR/kubernetes/install-k8s.sh")
 	assert.Contains(t, contents, "systemctl enable rke2-server.service")
 	assert.Contains(t, contents, "mkdir -p /var/lib/rancher/rke2/server/manifests/")
-	assert.Contains(t, contents, "cp kubernetes/manifests/* /var/lib/rancher/rke2/server/manifests/")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/manifests/* /var/lib/rancher/rke2/server/manifests/")
 	assert.Contains(t, contents, "cp "+registryMirrorsFileName+" /etc/rancher/rke2/registries.yaml")
 
 	// Config file assertions
-	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")
+	configPath := filepath.Join(ctx.ArtefactsDir, "kubernetes/server.yaml")
 
 	info, err = os.Stat(configPath)
 	require.NoError(t, err)

--- a/pkg/combustion/kubernetes_integration_test.go
+++ b/pkg/combustion/kubernetes_integration_test.go
@@ -74,8 +74,8 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 		"https://k8s.io/examples/application/nginx-app.yaml",
 	}
 
-	k8sCombDir := filepath.Join(ctx.ArtefactsDir, K8sDir)
-	require.NoError(t, os.Mkdir(k8sCombDir, os.ModePerm))
+	artefactsDir := filepath.Join(ctx.ArtefactsDir, K8sDir)
+	require.NoError(t, os.Mkdir(artefactsDir, os.ModePerm))
 
 	localManifestsSrcDir := filepath.Join(ctx.ImageConfigDir, K8sDir, k8sManifestsDir)
 	require.NoError(t, os.MkdirAll(localManifestsSrcDir, 0o755))
@@ -108,7 +108,7 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 	assert.Contains(t, contents, "systemctl enable rke2-server.service")
 	assert.Contains(t, contents, "mkdir -p /var/lib/rancher/rke2/server/manifests/")
 	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/manifests/* /var/lib/rancher/rke2/server/manifests/")
-	assert.Contains(t, contents, "cp "+registryMirrorsFileName+" /etc/rancher/rke2/registries.yaml")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/registries.yaml /etc/rancher/rke2/registries.yaml")
 
 	// Config file assertions
 	configPath := filepath.Join(ctx.ArtefactsDir, "kubernetes/server.yaml")
@@ -130,7 +130,7 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 	assert.Equal(t, []any{"192.168.122.100", "api.cluster01.hosted.on.edge.suse.com"}, configContents["tls-san"])
 
 	// Downloaded manifest assertions
-	manifestPath := filepath.Join(k8sCombDir, k8sManifestsDir, "dl-manifest-1.yaml")
+	manifestPath := filepath.Join(artefactsDir, k8sManifestsDir, "dl-manifest-1.yaml")
 	info, err = os.Stat(manifestPath)
 	require.NoError(t, err)
 	assert.Equal(t, fileio.NonExecutablePerms, info.Mode())
@@ -145,7 +145,7 @@ func TestConfigureKubernetes_SuccessfulRKE2ServerWithManifests(t *testing.T) {
 	assert.Contains(t, contents, "image: nginx:1.14.2")
 
 	// Local manifest assertions
-	manifest := filepath.Join(k8sCombDir, k8sManifestsDir, "sample-crd.yaml")
+	manifest := filepath.Join(artefactsDir, k8sManifestsDir, "sample-crd.yaml")
 	info, err = os.Stat(manifest)
 	require.NoError(t, err)
 	assert.Equal(t, fileio.NonExecutablePerms, info.Mode())

--- a/pkg/combustion/kubernetes_test.go
+++ b/pkg/combustion/kubernetes_test.go
@@ -95,7 +95,7 @@ func TestConfigureKubernetes_ScriptInstallerErrorK3s(t *testing.T) {
 
 	scripts, err := configureKubernetes(ctx)
 	require.Error(t, err)
-	assert.EqualError(t, err, "configuring kubernetes components: downloading k3s install script: some error")
+	assert.EqualError(t, err, "configuring kubernetes components: downloading k3s install script: downloading install script: some error")
 	assert.Nil(t, scripts)
 }
 
@@ -114,7 +114,7 @@ func TestConfigureKubernetes_ScriptInstallerErrorRKE2(t *testing.T) {
 
 	scripts, err := configureKubernetes(ctx)
 	require.Error(t, err)
-	assert.EqualError(t, err, "configuring kubernetes components: downloading RKE2 install script: some error")
+	assert.EqualError(t, err, "configuring kubernetes components: downloading RKE2 install script: downloading install script: some error")
 	assert.Nil(t, scripts)
 }
 
@@ -205,18 +205,18 @@ func TestConfigureKubernetes_SuccessfulSingleNodeK3sCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	contents := string(b)
-	assert.Contains(t, contents, "cp kubernetes/images/* /var/lib/rancher/k3s/agent/images/")
-	assert.Contains(t, contents, "cp server.yaml /etc/rancher/k3s/config.yaml")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/images/* /var/lib/rancher/k3s/agent/images/")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/server.yaml /etc/rancher/k3s/config.yaml")
 	assert.Contains(t, contents, "echo \"192.168.122.100 api.cluster01.hosted.on.edge.suse.com\" >> /etc/hosts")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/bin")
-	assert.Contains(t, contents, "chmod +x kubernetes/install/cool-k3s-binary")
-	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
-	assert.Contains(t, contents, "./install-kubernetes.sh")
+	assert.Contains(t, contents, "chmod +x $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
+	assert.Contains(t, contents, "sh $ARTEFACTS_DIR/kubernetes/install-kubernetes.sh")
 
 	// Config file assertions
-	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")
+	configPath := filepath.Join(ctx.ArtefactsDir, "kubernetes", "server.yaml")
 
 	info, err = os.Stat(configPath)
 	require.NoError(t, err)
@@ -300,7 +300,7 @@ func TestConfigureKubernetes_SuccessfulMultiNodeK3sCluster(t *testing.T) {
 	contents := string(b)
 	assert.Contains(t, contents, "hosts[node1.suse.com]=server")
 	assert.Contains(t, contents, "hosts[node2.suse.com]=agent")
-	assert.Contains(t, contents, "cp kubernetes/images/* /var/lib/rancher/k3s/agent/images/")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/images/* /var/lib/rancher/k3s/agent/images/")
 	assert.Contains(t, contents, "cp $CONFIGFILE /etc/rancher/k3s/config.yaml")
 	assert.Contains(t, contents, "if [ \"$HOSTNAME\" = node1.suse.com ]; then")
 	assert.Contains(t, contents, "echo \"192.168.122.100 api.cluster01.hosted.on.edge.suse.com\" >> /etc/hosts")
@@ -308,12 +308,12 @@ func TestConfigureKubernetes_SuccessfulMultiNodeK3sCluster(t *testing.T) {
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/bin")
-	assert.Contains(t, contents, "chmod +x kubernetes/install/cool-k3s-binary")
-	assert.Contains(t, contents, "cp kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
-	assert.Contains(t, contents, "./install-kubernetes.sh")
+	assert.Contains(t, contents, "chmod +x $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
+	assert.Contains(t, contents, "sh $ARTEFACTS_DIR/kubernetes/install-kubernetes.sh")
 
 	// Server config file assertions
-	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")
+	configPath := filepath.Join(ctx.ArtefactsDir, "kubernetes", "server.yaml")
 
 	info, err = os.Stat(configPath)
 	require.NoError(t, err)
@@ -333,7 +333,7 @@ func TestConfigureKubernetes_SuccessfulMultiNodeK3sCluster(t *testing.T) {
 	assert.Nil(t, configContents["cluster-init"])
 
 	// Initialising server config file assertions
-	configPath = filepath.Join(ctx.CombustionDir, "init_server.yaml")
+	configPath = filepath.Join(ctx.ArtefactsDir, "kubernetes", "init_server.yaml")
 
 	b, err = os.ReadFile(configPath)
 	require.NoError(t, err)
@@ -348,7 +348,7 @@ func TestConfigureKubernetes_SuccessfulMultiNodeK3sCluster(t *testing.T) {
 	assert.Equal(t, true, configContents["cluster-init"])
 
 	// Agent config file assertions
-	configPath = filepath.Join(ctx.CombustionDir, "agent.yaml")
+	configPath = filepath.Join(ctx.ArtefactsDir, "kubernetes", "agent.yaml")
 
 	b, err = os.ReadFile(configPath)
 	require.NoError(t, err)
@@ -401,15 +401,15 @@ func TestConfigureKubernetes_SuccessfulSingleNodeRKE2Cluster(t *testing.T) {
 	require.NoError(t, err)
 
 	contents := string(b)
-	assert.Contains(t, contents, "cp kubernetes/images/* /var/lib/rancher/rke2/agent/images/")
-	assert.Contains(t, contents, "cp server.yaml /etc/rancher/rke2/config.yaml")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/images/* /var/lib/rancher/rke2/agent/images/")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/server.yaml /etc/rancher/rke2/config.yaml")
 	assert.Contains(t, contents, "echo \"192.168.122.100 api.cluster01.hosted.on.edge.suse.com\" >> /etc/hosts")
-	assert.Contains(t, contents, "export INSTALL_RKE2_ARTIFACT_PATH=kubernetes/install")
-	assert.Contains(t, contents, "./install-kubernetes.sh")
+	assert.Contains(t, contents, "export INSTALL_RKE2_ARTIFACT_PATH=$ARTEFACTS_DIR/kubernetes/install")
+	assert.Contains(t, contents, "sh $ARTEFACTS_DIR/kubernetes/install-kubernetes.sh")
 	assert.Contains(t, contents, "systemctl enable rke2-server.service")
 
 	// Config file assertions
-	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")
+	configPath := filepath.Join(ctx.ArtefactsDir, "kubernetes", "server.yaml")
 
 	info, err = os.Stat(configPath)
 	require.NoError(t, err)
@@ -493,16 +493,16 @@ func TestConfigureKubernetes_SuccessfulMultiNodeRKE2Cluster(t *testing.T) {
 	contents := string(b)
 	assert.Contains(t, contents, "hosts[node1.suse.com]=server")
 	assert.Contains(t, contents, "hosts[node2.suse.com]=agent")
-	assert.Contains(t, contents, "cp kubernetes/images/* /var/lib/rancher/rke2/agent/images/")
+	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/images/* /var/lib/rancher/rke2/agent/images/")
 	assert.Contains(t, contents, "cp $CONFIGFILE /etc/rancher/rke2/config.yaml")
 	assert.Contains(t, contents, "if [ \"$HOSTNAME\" = node1.suse.com ]; then")
 	assert.Contains(t, contents, "echo \"192.168.122.100 api.cluster01.hosted.on.edge.suse.com\" >> /etc/hosts")
-	assert.Contains(t, contents, "export INSTALL_RKE2_ARTIFACT_PATH=kubernetes/install")
-	assert.Contains(t, contents, "./install-kubernetes.sh")
+	assert.Contains(t, contents, "export INSTALL_RKE2_ARTIFACT_PATH=$ARTEFACTS_DIR/kubernetes/install")
+	assert.Contains(t, contents, "sh $ARTEFACTS_DIR/kubernetes/install-kubernetes.sh")
 	assert.Contains(t, contents, "systemctl enable rke2-$NODETYPE.service")
 
 	// Server config file assertions
-	configPath := filepath.Join(ctx.CombustionDir, "server.yaml")
+	configPath := filepath.Join(ctx.ArtefactsDir, "kubernetes", "server.yaml")
 
 	info, err = os.Stat(configPath)
 	require.NoError(t, err)
@@ -521,7 +521,7 @@ func TestConfigureKubernetes_SuccessfulMultiNodeRKE2Cluster(t *testing.T) {
 	assert.Equal(t, []any{"192-168-122-100.sslip.io", "192.168.122.100", "api.cluster01.hosted.on.edge.suse.com"}, configContents["tls-san"])
 
 	// Initialising server config file assertions
-	configPath = filepath.Join(ctx.CombustionDir, "init_server.yaml")
+	configPath = filepath.Join(ctx.ArtefactsDir, "kubernetes", "init_server.yaml")
 
 	b, err = os.ReadFile(configPath)
 	require.NoError(t, err)
@@ -535,7 +535,7 @@ func TestConfigureKubernetes_SuccessfulMultiNodeRKE2Cluster(t *testing.T) {
 	assert.Equal(t, []any{"192-168-122-100.sslip.io", "192.168.122.100", "api.cluster01.hosted.on.edge.suse.com"}, configContents["tls-san"])
 
 	// Agent config file assertions
-	configPath = filepath.Join(ctx.CombustionDir, "agent.yaml")
+	configPath = filepath.Join(ctx.ArtefactsDir, "kubernetes", "agent.yaml")
 
 	b, err = os.ReadFile(configPath)
 	require.NoError(t, err)

--- a/pkg/combustion/kubernetes_test.go
+++ b/pkg/combustion/kubernetes_test.go
@@ -211,7 +211,7 @@ func TestConfigureKubernetes_SuccessfulSingleNodeK3sCluster(t *testing.T) {
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/bin")
-	assert.Contains(t, contents, "chmod +x $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary")
+	assert.Contains(t, contents, "chmod +x $INSTALL_K3S_BIN_DIR/k3s")
 	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
 	assert.Contains(t, contents, "sh $ARTEFACTS_DIR/kubernetes/install-kubernetes.sh")
 
@@ -308,7 +308,7 @@ func TestConfigureKubernetes_SuccessfulMultiNodeK3sCluster(t *testing.T) {
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_DOWNLOAD=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_SKIP_START=true")
 	assert.Contains(t, contents, "export INSTALL_K3S_BIN_DIR=/opt/bin")
-	assert.Contains(t, contents, "chmod +x $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary")
+	assert.Contains(t, contents, "chmod +x $INSTALL_K3S_BIN_DIR/k3s")
 	assert.Contains(t, contents, "cp $ARTEFACTS_DIR/kubernetes/install/cool-k3s-binary $INSTALL_K3S_BIN_DIR/k3s")
 	assert.Contains(t, contents, "sh $ARTEFACTS_DIR/kubernetes/install-kubernetes.sh")
 

--- a/pkg/combustion/script_test.go
+++ b/pkg/combustion/script_test.go
@@ -18,7 +18,16 @@ func TestAssembleScript_DynamicNetwork(t *testing.T) {
 	assert.NotContains(t, script, "./configure-network.sh")
 
 	// alphabetic ordering
-	assert.Contains(t, script, "echo \"Running bar.sh\"\n./bar.sh\necho \"Running baz.sh\"\n./baz.sh\necho \"Running foo.sh\"\n./foo.sh\n")
+	assert.Contains(t, script, `
+echo "Running bar.sh"
+./bar.sh
+
+echo "Running baz.sh"
+./baz.sh
+
+echo "Running foo.sh"
+./foo.sh
+`)
 }
 
 func TestAssembleScript_StaticNetwork(t *testing.T) {
@@ -32,5 +41,14 @@ func TestAssembleScript_StaticNetwork(t *testing.T) {
 	assert.Contains(t, script, "./configure-network.sh")
 
 	// alphabetic ordering
-	assert.Contains(t, script, "echo \"Running bar.sh\"\n./bar.sh\necho \"Running baz.sh\"\n./baz.sh\necho \"Running foo.sh\"\n./foo.sh\n")
+	assert.Contains(t, script, `
+echo "Running bar.sh"
+./bar.sh
+
+echo "Running baz.sh"
+./baz.sh
+
+echo "Running foo.sh"
+./foo.sh
+`)
 }

--- a/pkg/combustion/templates/10-rpm-install.sh.tpl
+++ b/pkg/combustion/templates/10-rpm-install.sh.tpl
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-#  Template Fields
-#  RepoName - name of the air-gapped repository that was created by the RPM resovler
-#  PKGList  - list of packages that will be installed
+{{/* Template Fields */ -}}
+{{/* RepoPath - path to the air-gapped repository that was created by the RPM resolver */ -}}
+{{/* RepoName - name of the air-gapped repository that was created by the RPM resolver */ -}}
+{{/* PKGList  - list of packages that will be installed */ -}}
 
-zypper ar file:///dev/shm/combustion/config/{{.RepoName}} {{.RepoName}}
+zypper ar file://{{.RepoPath}}/{{.RepoName}} {{.RepoName}}
 zypper --no-gpg-checks install -r {{.RepoName}} -y --force-resolution --auto-agree-with-licenses {{.PKGList}}
 zypper rr {{.RepoName}}

--- a/pkg/combustion/templates/26-embedded-registry.sh.tpl
+++ b/pkg/combustion/templates/26-embedded-registry.sh.tpl
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 mkdir /opt/hauler
-mv hauler /opt/hauler/hauler
-mv {{ .RegistryDir }}/{{ .EmbeddedRegistryTar }} /opt/hauler/
+cp {{ .RegistryDir }}/hauler /opt/hauler/hauler
+cp {{ .RegistryDir }}/{{ .EmbeddedRegistryTar }} /opt/hauler/
 
 cat <<- EOF > /etc/systemd/system/eib-embedded-registry.service
 [Unit]

--- a/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
@@ -24,10 +24,10 @@ mount /var
 mkdir -p /var/lib/rancher/k3s/agent/images/
 cp {{ .imagesPath }}/* /var/lib/rancher/k3s/agent/images/
 
-CONFIGFILE=$NODETYPE.yaml
+CONFIGFILE={{ .configFilePath }}/$NODETYPE.yaml
 
 if [ "$HOSTNAME" = {{ .initialiser }} ]; then
-    CONFIGFILE={{ .initialiserConfigFile }}
+    CONFIGFILE={{ .configFilePath }}/{{ .initialiserConfigFile }}
 
     {{- if .manifestsPath }}
     mkdir -p /var/lib/rancher/k3s/server/manifests/
@@ -57,4 +57,4 @@ mkdir -p $INSTALL_K3S_BIN_DIR
 chmod +x {{ .binaryPath }}
 cp {{ .binaryPath }} $INSTALL_K3S_BIN_DIR/k3s
 
-./{{ .installScript }}
+sh {{ .installScript }}

--- a/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
@@ -54,7 +54,7 @@ export INSTALL_K3S_SKIP_START=true
 export INSTALL_K3S_BIN_DIR=/opt/bin
 
 mkdir -p $INSTALL_K3S_BIN_DIR
-chmod +x {{ .binaryPath }}
 cp {{ .binaryPath }} $INSTALL_K3S_BIN_DIR/k3s
+chmod +x $INSTALL_K3S_BIN_DIR/k3s
 
 sh {{ .installScript }}

--- a/pkg/combustion/templates/k3s-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/k3s-single-node-installer.sh.tpl
@@ -18,7 +18,7 @@ echo "{{ .apiVIP }} {{ .apiHost }}" >> /etc/hosts
 {{- end }}
 
 mkdir -p /etc/rancher/k3s/
-cp {{ .configFile }} /etc/rancher/k3s/config.yaml
+cp {{ .configFilePath }}/{{ .configFile }} /etc/rancher/k3s/config.yaml
 
 if [ -f {{ .registryMirrors }} ]; then
 cp {{ .registryMirrors }} /etc/rancher/k3s/registries.yaml
@@ -32,4 +32,4 @@ mkdir -p $INSTALL_K3S_BIN_DIR
 chmod +x {{ .binaryPath }}
 cp {{ .binaryPath }} $INSTALL_K3S_BIN_DIR/k3s
 
-./{{ .installScript }}
+sh {{ .installScript }}

--- a/pkg/combustion/templates/k3s-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/k3s-single-node-installer.sh.tpl
@@ -29,7 +29,7 @@ export INSTALL_K3S_SKIP_START=true
 export INSTALL_K3S_BIN_DIR=/opt/bin
 
 mkdir -p $INSTALL_K3S_BIN_DIR
-chmod +x {{ .binaryPath }}
 cp {{ .binaryPath }} $INSTALL_K3S_BIN_DIR/k3s
+chmod +x $INSTALL_K3S_BIN_DIR/k3s
 
 sh {{ .installScript }}

--- a/pkg/combustion/templates/rke2-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/rke2-multi-node-installer.sh.tpl
@@ -24,10 +24,10 @@ mount /var
 mkdir -p /var/lib/rancher/rke2/agent/images/
 cp {{ .imagesPath }}/* /var/lib/rancher/rke2/agent/images/
 
-CONFIGFILE=$NODETYPE.yaml
+CONFIGFILE={{ .configFilePath }}/$NODETYPE.yaml
 
 if [ "$HOSTNAME" = {{ .initialiser }} ]; then
-    CONFIGFILE={{ .initialiserConfigFile }}
+    CONFIGFILE={{ .configFilePath }}/{{ .initialiserConfigFile }}
 
     {{- if .manifestsPath }}
     mkdir -p /var/lib/rancher/rke2/server/manifests/
@@ -55,6 +55,6 @@ export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 # rke2-selinux package, but isn't executed during combustion.
 mkdir -p /opt/cni
 
-./{{ .installScript }}
+sh {{ .installScript }}
 
 systemctl enable rke2-$NODETYPE.service

--- a/pkg/combustion/templates/rke2-single-node-installer.sh.tpl
+++ b/pkg/combustion/templates/rke2-single-node-installer.sh.tpl
@@ -18,7 +18,7 @@ echo "{{ .apiVIP }} {{ .apiHost }}" >> /etc/hosts
 {{- end }}
 
 mkdir -p /etc/rancher/rke2/
-cp {{ .configFile }} /etc/rancher/rke2/config.yaml
+cp {{ .configFilePath }}/{{ .configFile }} /etc/rancher/rke2/config.yaml
 
 if [ -f {{ .registryMirrors }} ]; then
 cp {{ .registryMirrors }} /etc/rancher/rke2/registries.yaml
@@ -31,6 +31,6 @@ export INSTALL_RKE2_ARTIFACT_PATH={{ .installPath }}
 # rke2-selinux package, but isn't executed during combustion.
 mkdir -p /opt/cni
 
-./{{ .installScript }}
+sh {{ .installScript }}
 
 systemctl enable rke2-server.service

--- a/pkg/combustion/templates/script-base.sh.tpl
+++ b/pkg/combustion/templates/script-base.sh.tpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+mount -o ro /dev/disk/by-label/INSTALL /mnt
+export ARTEFACTS_DIR=/mnt/artefacts
+
 {{ if .NetworkScript -}}
 # combustion: prepare network
 
@@ -16,3 +19,11 @@ fi
 exec > >(exec tee -a /dev/tty0) 2>&1
 
 cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+
+{{ range .Scripts -}}
+echo "Running {{ . }}"
+./{{ . }}
+
+{{ end -}}
+
+umount /mnt

--- a/pkg/image/context.go
+++ b/pkg/image/context.go
@@ -48,8 +48,10 @@ type Context struct {
 	ImageConfigDir string
 	// BuildDir is the directory used for assembling the different components used in a build.
 	BuildDir string
-	// CombustionDir is a subdirectory under BuildDir containing the Combustion script and all related files.
+	// CombustionDir is a subdirectory under BuildDir containing the Combustion script and its smaller related files.
 	CombustionDir string
+	// ArtefactsDir is a subdirectory under BuildDir containing the larger Combustion related files.
+	ArtefactsDir string
 	// ImageDefinition contains the image definition properties.
 	ImageDefinition              *Definition
 	NetworkConfigGenerator       networkConfigGenerator


### PR DESCRIPTION
- Moves the larger files for the RPM, Kubernetes and Embedded Registry components out of the combustion directory into a new artefacts one
- Network component is intentionally skipped due to it only using a couple of MBs (~5)
- Custom component is intentionally skipped due to:
  - Scripts ordering
  - Scripts referencing other custom files
  - Assumption that the files will not be that large
  - Potentially introducing https://github.com/suse-edge/edge-image-builder/issues/200 
- Closes https://github.com/suse-edge/edge-image-builder/issues/319