### PR TITLE
Extract configurable Helm chart repository variable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 ## Bug Fixes
 
 * [#319](https://github.com/suse-edge/edge-image-builder/issues/319) - Combustion fails when combustion directory content is larger than half of the RAM of the system
+* [#233](https://github.com/suse-edge/edge-image-builder/issues/233) - Use different Helm chart sources for development and production builds
 
 ---
 

--- a/pkg/combustion/helm.go
+++ b/pkg/combustion/helm.go
@@ -1,6 +1,9 @@
 package combustion
 
-import "github.com/suse-edge/edge-image-builder/pkg/image"
+import (
+	"github.com/suse-edge/edge-image-builder/pkg/env"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
 
 func ComponentHelmCharts(ctx *image.Context) ([]image.HelmChart, []image.HelmRepository) {
 	if ctx.ImageDefinition.Kubernetes.Version == "" {
@@ -9,7 +12,6 @@ func ComponentHelmCharts(ctx *image.Context) ([]image.HelmChart, []image.HelmRep
 
 	const (
 		suseEdgeRepositoryName = "suse-edge"
-		suseEdgeRepositoryURL  = "https://suse-edge.github.io/charts"
 		installationNamespace  = "kube-system"
 	)
 
@@ -39,7 +41,7 @@ func ComponentHelmCharts(ctx *image.Context) ([]image.HelmChart, []image.HelmRep
 
 		suseEdgeRepo := image.HelmRepository{
 			Name: suseEdgeRepositoryName,
-			URL:  suseEdgeRepositoryURL,
+			URL:  env.SUSEEdgeRepository,
 		}
 
 		repos = append(repos, suseEdgeRepo)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,5 @@
+package env
+
+var (
+	SUSEEdgeRepository = "https://suse-edge.github.io/charts"
+)


### PR DESCRIPTION
- Extracts a SUSE Edge chart repository variable to a new `env` package
- Modifying the variable is as simple as adding a flag to the build:
   ```
   MODULE=github.com/suse-edge/edge-image-builder
   go build -ldflags "-X $MODULE/pkg/env.SUSEEdgeRepository=<repository-url>" ./cmd/eib
   ```
- Closes https://github.com/suse-edge/edge-image-builder/issues/233