### PR TITLE
Fix hostname evaluation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 * [#95](https://github.com/suse-edge/edge-image-builder/issues/95) - Compressed images are not supported
 * [#343](https://github.com/suse-edge/edge-image-builder/issues/343) - Embedded Artifact Registry is memory bound
 * [#341](https://github.com/suse-edge/edge-image-builder/issues/341) - Make Elemental registry configurable for production builds
+* [#258](https://github.com/suse-edge/edge-image-builder/issues/258) - Kubernetes installation doesn't work with DHCP given hostname
 
 ---
 

--- a/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
@@ -10,7 +10,7 @@ hosts[{{ .Hostname }}]={{ .Type }}
 HOSTNAME=$(cat /etc/hostname)
 if [ ! "$HOSTNAME" ]; then
     HOSTNAME=$(cat /proc/sys/kernel/hostname)
-    if [ ! "$HOSTNAME" ]; then
+    if [ ! "$HOSTNAME" ] || [ "$HOSTNAME" = "localhost.localdomain" ]; then
         echo "ERROR: Could not identify whether the host is a k3s server or agent due to missing hostname"
         exit 1
     fi

--- a/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/k3s-multi-node-installer.sh.tpl
@@ -9,8 +9,11 @@ hosts[{{ .Hostname }}]={{ .Type }}
 
 HOSTNAME=$(cat /etc/hostname)
 if [ ! "$HOSTNAME" ]; then
-    echo "ERROR: Could not identify whether the host is a k3s server or agent due to missing hostname"
-    exit 1
+    HOSTNAME=$(cat /proc/sys/kernel/hostname)
+    if [ ! "$HOSTNAME" ]; then
+        echo "ERROR: Could not identify whether the host is a k3s server or agent due to missing hostname"
+        exit 1
+    fi
 fi
 
 NODETYPE="${hosts[$HOSTNAME]:-none}"

--- a/pkg/combustion/templates/rke2-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/rke2-multi-node-installer.sh.tpl
@@ -10,7 +10,7 @@ hosts[{{ .Hostname }}]={{ .Type }}
 HOSTNAME=$(cat /etc/hostname)
 if [ ! "$HOSTNAME" ]; then
     HOSTNAME=$(cat /proc/sys/kernel/hostname)
-    if [ ! "$HOSTNAME" ]; then
+    if [ ! "$HOSTNAME" ] || [ "$HOSTNAME" = "localhost.localdomain" ]; then
         echo "ERROR: Could not identify whether the host is an RKE2 server or agent due to missing hostname"
         exit 1
     fi

--- a/pkg/combustion/templates/rke2-multi-node-installer.sh.tpl
+++ b/pkg/combustion/templates/rke2-multi-node-installer.sh.tpl
@@ -9,8 +9,11 @@ hosts[{{ .Hostname }}]={{ .Type }}
 
 HOSTNAME=$(cat /etc/hostname)
 if [ ! "$HOSTNAME" ]; then
-    echo "ERROR: Could not identify whether the host is an RKE2 server or agent due to missing hostname"
-    exit 1
+    HOSTNAME=$(cat /proc/sys/kernel/hostname)
+    if [ ! "$HOSTNAME" ]; then
+        echo "ERROR: Could not identify whether the host is an RKE2 server or agent due to missing hostname"
+        exit 1
+    fi
 fi
 
 NODETYPE="${hosts[$HOSTNAME]:-none}"


### PR DESCRIPTION
- Evaluates both `/etc/hostname` and `/proc/sys/kernel/hostname` as sources of hostnames
- Tried using `hostnamectl` but it is not available during the combustion phase
- Closes https://github.com/suse-edge/edge-image-builder/issues/258