### PR TITLE
Embedded artifact registry progress bar

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ## General
 
+* Added a progress bar showing the progress of pulling images into the embedded artifact registry
+
 ## API
 
 ### Image Definition Changes

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -10,15 +10,13 @@ import (
 	"strings"
 
 	"github.com/schollz/progressbar/v3"
-
-	"gopkg.in/yaml.v3"
-
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 	"github.com/suse-edge/edge-image-builder/pkg/log"
 	"github.com/suse-edge/edge-image-builder/pkg/registry"
 	"github.com/suse-edge/edge-image-builder/pkg/template"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -378,7 +376,7 @@ func populateRegistry(ctx *image.Context, images []string) error {
 		}
 
 		if err := bar.Add(1); err != nil {
-			zap.S().Errorf("Error incrementing the progress bar: %s", err)
+			zap.S().Debugf("Error incrementing the progress bar: %s", err)
 		}
 	}
 

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/schollz/progressbar/v3"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
@@ -360,7 +362,8 @@ func registryArtefactsPath(ctx *image.Context) string {
 }
 
 func populateRegistry(ctx *image.Context, images []string) error {
-	log.Audit("Populating Embedded Artifact Registry...")
+	bar := progressbar.Default(int64(len(images)), "Populating Embedded Artifact Registry...")
+
 	for _, i := range images {
 		if err := addImageToHauler(ctx, i); err != nil {
 			return fmt.Errorf("adding image to hauler: %w", err)
@@ -372,6 +375,10 @@ func populateRegistry(ctx *image.Context, images []string) error {
 		imageTarDest := filepath.Join(registryArtefactsPath(ctx), convertedImageName)
 		if err := generateRegistryTar(ctx, imageTarDest); err != nil {
 			return fmt.Errorf("generating hauler store tar: %w", err)
+		}
+
+		if err := bar.Add(1); err != nil {
+			zap.S().Errorf("Error incrementing the progress bar: %s", err)
 		}
 	}
 


### PR DESCRIPTION
A progress bar is now shown when populating the embedded artifact registry to demonstrate progress. Previously, the embedded artifact registry would just run in the background and it was difficult to tell if it was still going or if there was something wrong.

Example output:
```
Generating image customization components...
Identifier ................... [SUCCESS]
Custom Files ................. [SUCCESS]
Time ......................... [SKIPPED]
Network ...................... [SKIPPED]
Groups ....................... [SKIPPED]
Users ........................ [SUCCESS]
Proxy ........................ [SKIPPED]
Rpm .......................... [SKIPPED]
Systemd ...................... [SKIPPED]
Elemental .................... [SKIPPED]
Suma ......................... [SKIPPED]
Populating Embedded Artifact Registry... 100% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (2/2, 19 it/min)  
```