### PR TITLE
Fix helm template parsing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@
 * [#352](https://github.com/suse-edge/edge-image-builder/issues/352) - Resizing raw images results in dracut-pre-mount failure
 * [#355](https://github.com/suse-edge/edge-image-builder/issues/355) - Helm fails getting charts stored in unauthenticated OCI registries
 * [#359](https://github.com/suse-edge/edge-image-builder/issues/359) - Helm validation does not check if a chart uses an undefined repository
+* [#362](https://github.com/suse-edge/edge-image-builder/issues/362) - Helm templating failure
 
 ---
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -277,7 +277,8 @@ func parseChartContents(chartContents string) ([]map[string]any, error) {
 
 		source, content, found := strings.Cut(resource, "\n")
 		if !found {
-			return nil, fmt.Errorf("invalid resource: %s", resource)
+			zap.S().Warnf("Invalid Helm resource: %s", resource)
+			continue
 		}
 
 		var r map[string]any

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -265,12 +265,13 @@ func templateCommand(chart, repository, version, valuesFilePath, kubeVersion, ta
 func parseChartContents(chartContents string) ([]map[string]any, error) {
 	var resources []map[string]any
 
-	for _, resource := range strings.Split(chartContents, "---") {
+	for _, resource := range strings.Split(chartContents, "---\n") {
 		if resource == "" {
 			continue
 		}
 
-		if !strings.HasPrefix(strings.TrimSpace(resource), "# Source") {
+		resource = strings.TrimSpace(resource)
+		if !strings.HasPrefix(resource, "# Source") {
 			continue
 		}
 

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -559,14 +559,15 @@ func TestTemplateCommand(t *testing.T) {
 
 func TestParseChartContents_InvalidPayload(t *testing.T) {
 	contents := `---
-# Source
+# Source: some-invalid.yaml
 invalid-resource
 `
 
 	resources, err := parseChartContents(contents)
 	require.Error(t, err)
 
-	assert.ErrorContains(t, err, "yaml: unmarshal errors:\n  line 2: cannot unmarshal !!str `invalid...` into map[string]interface {}")
+	assert.ErrorContains(t, err, "decoding resource from source '# Source: some-invalid.yaml'")
+	assert.ErrorContains(t, err, "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `invalid...` into map[string]interface {}")
 	assert.Nil(t, resources)
 }
 


### PR DESCRIPTION
- Fixes an issue where the presence of `---` within a resource would falsely split it in half
- Fixes an issue where the `source` was not properly parsed
- Closes https://github.com/suse-edge/edge-image-builder/issues/362