### PR TITLE
Fix locating downloaded Helm charts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@
 * [#355](https://github.com/suse-edge/edge-image-builder/issues/355) - Helm fails getting charts stored in unauthenticated OCI registries
 * [#359](https://github.com/suse-edge/edge-image-builder/issues/359) - Helm validation does not check if a chart uses an undefined repository
 * [#362](https://github.com/suse-edge/edge-image-builder/issues/362) - Helm templating failure
+* [#365](https://github.com/suse-edge/edge-image-builder/issues/365) - Unable to locate downloaded Helm charts
 
 ---
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -150,7 +150,12 @@ func (h *Helm) Pull(chart string, repo *image.HelmRepository, version, destDir s
 		}
 	}()
 
-	cmd := pullCommand(chart, repo, version, destDir, h.certsDir, file)
+	chartDir := filepath.Join(destDir, chart)
+	if err = os.MkdirAll(chartDir, os.ModePerm); err != nil {
+		return "", fmt.Errorf("creating chart dir %q: %w", chartDir, err)
+	}
+
+	cmd := pullCommand(chart, repo, version, chartDir, h.certsDir, file)
 
 	if _, err = fmt.Fprintf(file, "command: %s\n", cmd); err != nil {
 		return "", fmt.Errorf("writing command prefix to log file: %w", err)
@@ -160,7 +165,7 @@ func (h *Helm) Pull(chart string, repo *image.HelmRepository, version, destDir s
 		return "", fmt.Errorf("executing command: %w", err)
 	}
 
-	chartPathPattern := fmt.Sprintf("%s-*.tgz", filepath.Join(destDir, chart))
+	chartPathPattern := fmt.Sprintf("%s/%s-*.tgz", chartDir, chart)
 
 	matches, err := filepath.Glob(chartPathPattern)
 	if err != nil {


### PR DESCRIPTION
- Adjusts the Helm build directory to use chart subdirectories
- Closes https://github.com/suse-edge/edge-image-builder/issues/365
- New layout:
```
suse-edge380@edge380:~/atanas/eib> ls _build/build-Apr09_16-05-27/helm -l
total 0
drwxr-xr-x 1 suse-edge380 users 26 Apr  9 12:05 cdi
drwxr-xr-x 1 suse-edge380 users 48 Apr  9 12:05 cert-manager
drwxr-xr-x 1 suse-edge380 users 28 Apr  9 12:05 core
drwxr-xr-x 1 suse-edge380 users 38 Apr  9 12:05 elemental
drwxr-xr-x 1 suse-edge380 users 68 Apr  9 12:05 elemental-operator-chart
drwxr-xr-x 1 suse-edge380 users 78 Apr  9 12:05 elemental-operator-crds-chart
drwxr-xr-x 1 suse-edge380 users 68 Apr  9 12:05 endpoint-copier-operator
drwxr-xr-x 1 suse-edge380 users 36 Apr  9 12:05 kubevirt
drwxr-xr-x 1 suse-edge380 users 76 Apr  9 12:05 kubevirt-dashboard-extension
drwxr-xr-x 1 suse-edge380 users 36 Apr  9 12:05 longhorn
drwxr-xr-x 1 suse-edge380 users 32 Apr  9 12:05 metal3
drwxr-xr-x 1 suse-edge380 users 36 Apr  9 12:05 metallb
drwxr-xr-x 1 suse-edge380 users 34 Apr  9 12:05 rancher
drwxr-xr-x 1 suse-edge380 users 76 Apr  9 12:05 ui-plugin-operator
drwxr-xr-x 1 suse-edge380 users 84 Apr  9 12:05 ui-plugin-operator-crd
```