### PR TITLE
Use same SELinux config option for both server and agent nodes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@
 * [#359](https://github.com/suse-edge/edge-image-builder/issues/359) - Helm validation does not check if a chart uses an undefined repository
 * [#362](https://github.com/suse-edge/edge-image-builder/issues/362) - Helm templating failure
 * [#365](https://github.com/suse-edge/edge-image-builder/issues/365) - Unable to locate downloaded Helm charts
+* [#374](https://github.com/suse-edge/edge-image-builder/issues/374) - Enable SELinux support for Kubernetes agents if servers enforce it
 
 ---
 

--- a/pkg/kubernetes/cluster.go
+++ b/pkg/kubernetes/cluster.go
@@ -65,11 +65,9 @@ func NewCluster(kubernetes *image.Kubernetes, configPath string) (*Cluster, erro
 	// Ensure the agent uses the same cluster configuration values as the server
 	agentConfig[tokenKey] = serverConfig[tokenKey]
 	agentConfig[serverKey] = serverConfig[serverKey]
+	agentConfig[selinuxKey] = serverConfig[selinuxKey]
 	if strings.Contains(kubernetes.Version, image.KubernetesDistroRKE2) {
 		agentConfig[cniKey] = serverConfig[cniKey]
-	}
-	if selinux, ok := serverConfig[selinuxKey]; ok {
-		agentConfig[selinuxKey] = selinux
 	}
 
 	// Create the initialiser server config
@@ -168,6 +166,7 @@ func setMultiNodeConfigDefaults(kubernetes *image.Kubernetes, config map[string]
 
 	setClusterToken(config)
 	appendClusterTLSSAN(config, kubernetes.Network.APIVIP)
+	setSELinux(config)
 	if kubernetes.Network.APIHost != "" {
 		appendClusterTLSSAN(config, kubernetes.Network.APIHost)
 	}
@@ -204,6 +203,14 @@ func setClusterAPIAddress(config map[string]any, apiAddress string, port int) {
 	}
 
 	config[serverKey] = fmt.Sprintf("https://%s:%d", apiAddress, port)
+}
+
+func setSELinux(config map[string]any) {
+	if _, ok := config[selinuxKey].(bool); ok {
+		return
+	}
+
+	config[selinuxKey] = false
 }
 
 func appendClusterTLSSAN(config map[string]any, address string) {

--- a/pkg/kubernetes/cluster.go
+++ b/pkg/kubernetes/cluster.go
@@ -26,6 +26,7 @@ const (
 	tlsSANKey       = "tls-san"
 	disableKey      = "disable"
 	clusterInitKey  = "cluster-init"
+	selinuxKey      = "selinux"
 )
 
 type Cluster struct {
@@ -66,6 +67,9 @@ func NewCluster(kubernetes *image.Kubernetes, configPath string) (*Cluster, erro
 	agentConfig[serverKey] = serverConfig[serverKey]
 	if strings.Contains(kubernetes.Version, image.KubernetesDistroRKE2) {
 		agentConfig[cniKey] = serverConfig[cniKey]
+	}
+	if selinux, ok := serverConfig[selinuxKey]; ok {
+		agentConfig[selinuxKey] = selinux
 	}
 
 	// Create the initialiser server config

--- a/pkg/kubernetes/cluster_test.go
+++ b/pkg/kubernetes/cluster_test.go
@@ -176,8 +176,8 @@ func TestNewCluster_MultiNodeRKE2_ExistingConfig(t *testing.T) {
 	assert.Equal(t, "totally-not-generated-one", cluster.AgentConfig["token"])
 	assert.Equal(t, "https://192.168.122.50:9345", cluster.AgentConfig["server"])
 	assert.Equal(t, true, cluster.AgentConfig["debug"])
+	assert.Equal(t, true, cluster.AgentConfig["selinux"])
 	assert.Nil(t, cluster.AgentConfig["tls-san"])
-	assert.Nil(t, cluster.AgentConfig["selinux"])
 }
 
 func TestNewCluster_MultiNode_MissingInitialiser(t *testing.T) {

--- a/pkg/kubernetes/cluster_test.go
+++ b/pkg/kubernetes/cluster_test.go
@@ -113,20 +113,21 @@ func TestNewCluster_MultiNodeRKE2_MissingConfig(t *testing.T) {
 	})
 	assert.Equal(t, "cilium", cluster.InitialiserConfig["cni"])
 	assert.Equal(t, []string{"192.168.122.50", "api.suse.edge.com"}, cluster.InitialiserConfig["tls-san"])
+	assert.Equal(t, false, cluster.InitialiserConfig["selinux"])
 	assert.Nil(t, cluster.InitialiserConfig["server"])
-	assert.Nil(t, cluster.InitialiserConfig["selinux"])
 
 	require.NotNil(t, cluster.ServerConfig)
 	assert.Equal(t, "cilium", cluster.ServerConfig["cni"])
 	assert.Equal(t, []string{"192.168.122.50", "api.suse.edge.com"}, cluster.ServerConfig["tls-san"])
 	assert.Equal(t, clusterToken, cluster.ServerConfig["token"])
 	assert.Equal(t, "https://192.168.122.50:9345", cluster.ServerConfig["server"])
-	assert.Nil(t, cluster.ServerConfig["selinux"])
+	assert.Equal(t, false, cluster.ServerConfig["selinux"])
 
 	require.NotNil(t, cluster.AgentConfig)
 	assert.Equal(t, "cilium", cluster.AgentConfig["cni"])
 	assert.Equal(t, clusterToken, cluster.AgentConfig["token"])
 	assert.Equal(t, "https://192.168.122.50:9345", cluster.AgentConfig["server"])
+	assert.Equal(t, false, cluster.AgentConfig["selinux"])
 	assert.Nil(t, cluster.AgentConfig["tls-san"])
 	assert.Nil(t, cluster.AgentConfig["debug"])
 }


### PR DESCRIPTION
- Set agents' selinux config option to the one provided for servers
- Closes https://github.com/suse-edge/edge-image-builder/issues/374