### PR TITLE
Drop OS validation criteria

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@
 * [#365](https://github.com/suse-edge/edge-image-builder/issues/365) - Unable to locate downloaded Helm charts
 * [#374](https://github.com/suse-edge/edge-image-builder/issues/374) - Enable SELinux support for Kubernetes agents if servers enforce it
 * [#381](https://github.com/suse-edge/edge-image-builder/issues/381) - Empty gpg-keys directory passes GPG enablement only to fail during the dependency resolution
+* [#383](https://github.com/suse-edge/edge-image-builder/issues/383) - Criteria for validating the OS definition does not include RPM
 
 ---
 

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -17,29 +17,17 @@ func validateOperatingSystem(ctx *image.Context) []FailedValidation {
 
 	var failures []FailedValidation
 
-	if !isOperatingSystemDefined(&def.OperatingSystem) {
-		return failures
-	}
-
 	failures = append(failures, validateKernelArgs(&def.OperatingSystem)...)
 	failures = append(failures, validateSystemd(&def.OperatingSystem)...)
 	failures = append(failures, validateGroups(&def.OperatingSystem)...)
 	failures = append(failures, validateUsers(&def.OperatingSystem)...)
 	failures = append(failures, validateSuma(&def.OperatingSystem)...)
 	failures = append(failures, validatePackages(&def.OperatingSystem)...)
-	failures = append(failures, validateTimesync(&def.OperatingSystem)...)
-	failures = append(failures, validateUnattended(def)...)
+	failures = append(failures, validateTimeSync(&def.OperatingSystem)...)
+	failures = append(failures, validateIsoConfig(def)...)
 	failures = append(failures, validateRawConfig(def)...)
 
 	return failures
-}
-
-func isOperatingSystemDefined(os *image.OperatingSystem) bool {
-	return !(len(os.KernelArgs) == 0 &&
-		len(os.Users) == 0 &&
-		len(os.Systemd.Enable) == 0 &&
-		len(os.Systemd.Disable) == 0 &&
-		os.Suma == (image.Suma{}))
 }
 
 func validateKernelArgs(os *image.OperatingSystem) []FailedValidation {
@@ -221,7 +209,7 @@ func validatePackages(os *image.OperatingSystem) []FailedValidation {
 	return failures
 }
 
-func validateUnattended(def *image.Definition) []FailedValidation {
+func validateIsoConfig(def *image.Definition) []FailedValidation {
 	var failures []FailedValidation
 
 	if def.Image.ImageType != image.TypeISO && def.OperatingSystem.IsoConfiguration.InstallDevice != "" {
@@ -266,7 +254,7 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 	return failures
 }
 
-func validateTimesync(os *image.OperatingSystem) []FailedValidation {
+func validateTimeSync(os *image.OperatingSystem) []FailedValidation {
 	var failures []FailedValidation
 
 	if !os.Time.NtpConfiguration.ForceWait {

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -130,56 +130,6 @@ func TestValidateOperatingSystem(t *testing.T) {
 	}
 }
 
-func TestIsOperatingSystemDefined(t *testing.T) {
-	tests := map[string]struct {
-		OS       image.OperatingSystem
-		Expected bool
-	}{
-		`empty operating system`: {
-			OS:       image.OperatingSystem{},
-			Expected: false,
-		},
-		`with kernel args`: {
-			OS: image.OperatingSystem{
-				KernelArgs: []string{"foo=bar"},
-			},
-			Expected: true,
-		},
-		`with users`: {
-			OS: image.OperatingSystem{
-				Users: []image.OperatingSystemUser{
-					{Username: "jdob"},
-				},
-			},
-			Expected: true,
-		},
-		`with systemd enable list`: {
-			OS: image.OperatingSystem{
-				Systemd: image.Systemd{
-					Enable: []string{"foo"},
-				},
-			},
-			Expected: true,
-		},
-		`with systemd disable list`: {
-			OS: image.OperatingSystem{
-				Systemd: image.Systemd{
-					Disable: []string{"bar"},
-				},
-			},
-			Expected: true,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			os := test.OS
-			result := isOperatingSystemDefined(&os)
-			assert.Equal(t, test.Expected, result)
-		})
-	}
-}
-
 func TestValidateKernelArgs(t *testing.T) {
 	tests := map[string]struct {
 		OS                     image.OperatingSystem
@@ -614,7 +564,7 @@ func TestValidateUnattended(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			def := test.Definition
-			failures := validateUnattended(&def)
+			failures := validateIsoConfig(&def)
 			assert.Len(t, failures, len(test.ExpectedFailedMessages))
 
 			var foundMessages []string
@@ -788,7 +738,7 @@ func TestValidateTimeSync(t *testing.T) {
 			os := image.OperatingSystem{
 				Time: test.Time,
 			}
-			failures := validateTimesync(&os)
+			failures := validateTimeSync(&os)
 			assert.Len(t, failures, len(test.ExpectedFailedMessages))
 
 			var foundMessages []string


### PR DESCRIPTION
- The conditionals to check the OS section in the definition file was left far behind all of the current functionality
- Those are now completely removed in order not to have them forgotten in the future
- Closes https://github.com/suse-edge/edge-image-builder/issues/383