### PR TITLE
added check for empty certificates directory

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@
 * [#374](https://github.com/suse-edge/edge-image-builder/issues/374) - Enable SELinux support for Kubernetes agents if servers enforce it
 * [#381](https://github.com/suse-edge/edge-image-builder/issues/381) - Empty gpg-keys directory passes GPG enablement only to fail during the dependency resolution
 * [#383](https://github.com/suse-edge/edge-image-builder/issues/383) - Criteria for validating the OS definition does not include RPM
+* [#372](https://github.com/suse-edge/edge-image-builder/issues/372) -  Empty certificates directory does not raise a build error but fails to boot the node
 
 ---
 

--- a/pkg/combustion/certificates.go
+++ b/pkg/combustion/certificates.go
@@ -47,6 +47,15 @@ func copyCertificates(ctx *image.Context) error {
 	srcDir := filepath.Join(ctx.ImageConfigDir, certsConfigDir)
 	destDir := filepath.Join(ctx.CombustionDir, certsConfigDir)
 
+	dirEntries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("reading the certificates directory at %s: %w", srcDir, err)
+	}
+
+	if len(dirEntries) == 0 {
+		return fmt.Errorf("no certificates found in directory %s", srcDir)
+	}
+
 	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
 		return fmt.Errorf("creating certificates directory '%s': %w", destDir, err)
 	}

--- a/pkg/combustion/certificates_test.go
+++ b/pkg/combustion/certificates_test.go
@@ -28,6 +28,23 @@ func setupCertificatesConfigDir(t *testing.T) (ctx *image.Context, teardown func
 	return
 }
 
+func TestCopyCertificatesEmptyDirectory(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	testCertsDir := filepath.Join(ctx.ImageConfigDir, certsConfigDir)
+	err := os.Mkdir(testCertsDir, 0o755)
+	require.NoError(t, err)
+	defer os.RemoveAll(testCertsDir)
+
+	// Test
+	err = copyCertificates(ctx)
+
+	// Verify
+	require.Error(t, err)
+}
+
 func TestCopyCertificates(t *testing.T) {
 	// Setup
 	ctx, teardown := setupCertificatesConfigDir(t)


### PR DESCRIPTION
This handling matches what we do in other cases for directories in the image configuration directory. Eventually we should add these sorts of checks to the validation step, but for now this is consistent with how it's handled elsewhere in EIB.

Closes: #372 

