### PR TITLE
Add origin metadata to HelmChart CRs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ## General
 
 * Added a progress bar showing the progress of pulling images into the embedded artifact registry
+* Added annotations to Helm CRs
 
 ## API
 

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -290,7 +290,7 @@ func TestStoreHelmCharts(t *testing.T) {
 	charts := []*registry.HelmChart{
 		{
 			CRD: registry.NewHelmCRD(helmChart, "some-content", `
-values: content`),
+values: content`, "oci://registry-1.docker.io/bitnamicharts/apache"),
 		},
 	}
 
@@ -302,6 +302,9 @@ kind: HelmChart
 metadata:
     name: apache
     namespace: kube-system
+    annotations:
+        repositoryUrl: oci://registry-1.docker.io/bitnamicharts/apache
+        source: suse-edge-image-builder
 spec:
     version: 10.7.0
     valuesContent: |4-

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -303,8 +303,8 @@ metadata:
     name: apache
     namespace: kube-system
     annotations:
-        repositoryUrl: oci://registry-1.docker.io/bitnamicharts/apache
-        source: suse-edge-image-builder
+        edge.suse.com/repository-url: oci://registry-1.docker.io/bitnamicharts/apache
+        edge.suse.com/source: suse-edge-image-builder
 spec:
     version: 10.7.0
     valuesContent: |4-

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -304,7 +304,7 @@ metadata:
     namespace: kube-system
     annotations:
         edge.suse.com/repository-url: oci://registry-1.docker.io/bitnamicharts/apache
-        edge.suse.com/source: suse-edge-image-builder
+        edge.suse.com/source: edge-image-builder
 spec:
     version: 10.7.0
     valuesContent: |4-

--- a/pkg/registry/helm.go
+++ b/pkg/registry/helm.go
@@ -65,7 +65,7 @@ func handleChart(chart *image.HelmChart, repo *image.HelmRepository, valuesDir, 
 	}
 
 	helmChart := HelmChart{
-		CRD:             NewHelmCRD(chart, chartContent, string(valuesContent)),
+		CRD:             NewHelmCRD(chart, chartContent, string(valuesContent), repo.URL),
 		ContainerImages: images,
 	}
 

--- a/pkg/registry/helm_crd.go
+++ b/pkg/registry/helm_crd.go
@@ -36,8 +36,8 @@ func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent, repositoryU
 			Name:      chart.Name,
 			Namespace: chart.InstallationNamespace,
 			Annotations: map[string]string{
-				"source":        "suse-edge-image-builder",
-				"repositoryUrl": repositoryURL,
+				"edge.suse.com/source":         "suse-edge-image-builder",
+				"edge.suse.com/repository-url": repositoryURL,
 			},
 		},
 		Spec: struct {

--- a/pkg/registry/helm_crd.go
+++ b/pkg/registry/helm_crd.go
@@ -11,8 +11,9 @@ type HelmCRD struct {
 	APIVersion string `yaml:"apiVersion"`
 	Kind       string `yaml:"kind"`
 	Metadata   struct {
-		Name      string `yaml:"name"`
-		Namespace string `yaml:"namespace,omitempty"`
+		Name        string            `yaml:"name"`
+		Namespace   string            `yaml:"namespace,omitempty"`
+		Annotations map[string]string `yaml:"annotations"`
 	} `yaml:"metadata"`
 	Spec struct {
 		Version         string `yaml:"version"`
@@ -23,16 +24,21 @@ type HelmCRD struct {
 	} `yaml:"spec"`
 }
 
-func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent string) HelmCRD {
+func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent, repositoryURL string) HelmCRD {
 	return HelmCRD{
 		APIVersion: helmChartAPIVersion,
 		Kind:       helmChartKind,
 		Metadata: struct {
-			Name      string `yaml:"name"`
-			Namespace string `yaml:"namespace,omitempty"`
+			Name        string            `yaml:"name"`
+			Namespace   string            `yaml:"namespace,omitempty"`
+			Annotations map[string]string `yaml:"annotations"`
 		}{
 			Name:      chart.Name,
 			Namespace: chart.InstallationNamespace,
+			Annotations: map[string]string{
+				"source":        "suse-edge-image-builder",
+				"repositoryUrl": repositoryURL,
+			},
 		},
 		Spec: struct {
 			Version         string `yaml:"version"`

--- a/pkg/registry/helm_crd.go
+++ b/pkg/registry/helm_crd.go
@@ -4,8 +4,11 @@ import (
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 )
 
-const helmChartAPIVersion = "helm.cattle.io/v1"
-const helmChartKind = "HelmChart"
+const (
+	helmChartAPIVersion = "helm.cattle.io/v1"
+	helmChartKind       = "HelmChart"
+	helmChartSource     = "edge-image-builder"
+)
 
 type HelmCRD struct {
 	APIVersion string `yaml:"apiVersion"`
@@ -36,7 +39,7 @@ func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent, repositoryU
 			Name:      chart.Name,
 			Namespace: chart.InstallationNamespace,
 			Annotations: map[string]string{
-				"edge.suse.com/source":         "suse-edge-image-builder",
+				"edge.suse.com/source":         helmChartSource,
 				"edge.suse.com/repository-url": repositoryURL,
 			},
 		},


### PR DESCRIPTION
Added annotations to Helm Charts deployed by EIB.

Examples:

```
localhost:~ # /var/lib/rancher/rke2/bin/kubectl describe helmchart -n kube-system endpoint-copier-operator
Name:         endpoint-copier-operator
Namespace:    kube-system
Labels:       objectset.rio.cattle.io/hash=dff2ee5284ff87febe8538225e1f44cd38d991ea
Annotations:  helmcharts.cattle.io/managed-by: helm-controller
              objectset.rio.cattle.io/applied:
                H4sIAAAAAAAA/4yTQW/TQBCF/wqa83rtOAmklji0DVWjihwoTQS38Xpib7zeNbtjQ1vlv6MtpS2Ctvg2mudv3jx7bgF7vSEftLNQQEOmkwqZDUnt0nECAlptKyjgnEx32qBnENARY4...
              objectset.rio.cattle.io/id:
              objectset.rio.cattle.io/owner-gvk: k3s.cattle.io/v1, Kind=Addon
              objectset.rio.cattle.io/owner-name: endpoint-copier-operator
              objectset.rio.cattle.io/owner-namespace: kube-system
              repositoryUrl: https://suse-edge.github.io/charts
              source: suse-edge-image-builder
```

```

localhost:~ # /var/lib/rancher/rke2/bin/kubectl describe helmchart -n kube-system metallb
Name:         metallb
Namespace:    kube-system
Labels:       objectset.rio.cattle.io/hash=c345bfd4b8ef641f02b3ab0e14da026bc6102183
Annotations:  helmcharts.cattle.io/managed-by: helm-controller
              objectset.rio.cattle.io/applied:
                H4sIAAAAAAAA/4yTT0/cMBDFv0o1Z6/zd1c0Ug/AFrFC3UMpu2pvY2dIvHHs1HbSAtrvXpkCS0Upzc3yL2/evBnfAQ5qQ84ra6CClnTPJYagiSubTBkw6JSpoYJz0v1piy4Ag54C1h...
              objectset.rio.cattle.io/id:
              objectset.rio.cattle.io/owner-gvk: k3s.cattle.io/v1, Kind=Addon
              objectset.rio.cattle.io/owner-name: metallb
              objectset.rio.cattle.io/owner-namespace: kube-system
              repositoryUrl: https://suse-edge.github.io/charts
              source: suse-edge-image-builder
```

Closes: https://github.com/suse-edge/edge-image-builder/issues/373