### PR TITLE
Update base image in examples readme and definition file

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ and the results of performing multiple builds:
 .
 ├── base-images
 │   ├── SLE-Micro.x86_64-5.5.0-Default-GM.raw
-│   ├── SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso
+│   ├── SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso
 ├── definitions
 │   ├── iso
 │   │   └── basic.yaml

--- a/examples/iso/basic.yaml
+++ b/examples/iso/basic.yaml
@@ -2,7 +2,7 @@ apiVersion: 1.0
 image:
   arch: x86_64
   imageType: iso
-  baseImage: SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso
+  baseImage: SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso
   outputImageName: ./out/basic.iso
 operatingSystem:
   isoConfiguration:


### PR DESCRIPTION
This commit updates the readme as well as the corresponding definition file, replacing the image SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM.install.iso with SLE-Micro.x86_64-5.5.0-Default-SelfInstall-GM2.install.iso as documented in SUSE Edge EIB quickstart. [0]

[0] https://suse-edge.github.io/quickstart-eib.html#id-creating-the-image-configuration-directory