### PR TITLE
Fail if build artefacts size exceeds the available space on RAW images

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@
 * [#384](https://github.com/suse-edge/edge-image-builder/issues/384) - Improve RPM validation
 * [#392](https://github.com/suse-edge/edge-image-builder/issues/392) - Users script does not unmount /home
 * [#364](https://github.com/suse-edge/edge-image-builder/issues/364) - Kubernetes component output is jumbled when downloading the installer
+* [#361](https://github.com/suse-edge/edge-image-builder/issues/361) - Raw image build can fail silently due to lack of space
 
 ---
 

--- a/pkg/build/raw.go
+++ b/pkg/build/raw.go
@@ -99,7 +99,7 @@ func (b *Builder) writeModifyScript(imageFilename string, includeCombustion, ren
 		ConfigureGRUB:       grubConfiguration,
 		ConfigureCombustion: includeCombustion,
 		RenameFilesystem:    renameFilesystem,
-		DiskSize:            b.context.ImageDefinition.OperatingSystem.RawConfiguration.DiskSize,
+		DiskSize:            string(b.context.ImageDefinition.OperatingSystem.RawConfiguration.DiskSize),
 	}
 
 	data, err := template.Parse(modifyScriptName, modifyRawImageTemplate, &values)

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -3,6 +3,7 @@ package image
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -25,6 +26,10 @@ const (
 	CNITypeCilium = "cilium"
 	CNITypeCanal  = "canal"
 	CNITypeCalico = "calico"
+)
+
+var (
+	diskSizeRegexp = regexp.MustCompile(`^([1-9]\d+|[1-9])+[MGT]`)
 )
 
 type Definition struct {
@@ -74,8 +79,14 @@ type IsoConfiguration struct {
 	InstallDevice string `yaml:"installDevice"`
 }
 
+type DiskSize string
+
+func (d DiskSize) IsValid() bool {
+	return diskSizeRegexp.MatchString(string(d))
+}
+
 type RawConfiguration struct {
-	DiskSize string `yaml:"diskSize"`
+	DiskSize DiskSize `yaml:"diskSize"`
 }
 
 type Packages struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -247,3 +247,13 @@ func TestArch_Short(t *testing.T) {
 		arch.Short()
 	})
 }
+
+func TestDiskSize_ToMB(t *testing.T) {
+	assert.EqualValues(t, 50, DiskSize("50M").ToMB())
+	assert.EqualValues(t, 4096, DiskSize("4G").ToMB())
+	assert.EqualValues(t, 1024*1024, DiskSize("1T").ToMB())
+
+	assert.PanicsWithValue(t, "unknown disk size format", func() {
+		DiskSize("10K").ToMB()
+	})
+}

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -239,7 +238,6 @@ func validateIsoConfig(def *image.Definition) []FailedValidation {
 
 func validateRawConfig(def *image.Definition) []FailedValidation {
 	var failures []FailedValidation
-	isValidSize := regexp.MustCompile(`^([1-9]\d+|[1-9])+[MGT]`).MatchString
 
 	if def.OperatingSystem.RawConfiguration.DiskSize == "" {
 		return nil
@@ -259,8 +257,8 @@ func validateRawConfig(def *image.Definition) []FailedValidation {
 		})
 	}
 
-	if !isValidSize(def.OperatingSystem.RawConfiguration.DiskSize) {
-		msg := fmt.Sprintf("The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW)
+	if !def.OperatingSystem.RawConfiguration.DiskSize.IsValid() {
+		msg := "The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T'."
 		failures = append(failures, FailedValidation{
 			UserMessage: msg,
 		})

--- a/pkg/image/validation/os_test.go
+++ b/pkg/image/validation/os_test.go
@@ -104,7 +104,7 @@ func TestValidateOperatingSystem(t *testing.T) {
 				"User 'danny' must have either a password or at least one SSH key.",
 				"The 'host' field is required for the 'suma' section.",
 				fmt.Sprintf("The 'isoConfiguration/installDevice' field can only be used when 'imageType' is '%s'.", image.TypeISO),
-				fmt.Sprintf("The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+				"The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T'.",
 				"You cannot simultaneously configure rawConfiguration and isoConfiguration, regardless of image type.",
 			},
 		},
@@ -637,7 +637,7 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+				"The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T'.",
 			},
 		},
 		`diskSize invalid as zero`: {
@@ -652,7 +652,7 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+				"The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T'.",
 			},
 		},
 		`diskSize invalid as lowercase character`: {
@@ -667,7 +667,7 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+				"The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T'.",
 			},
 		},
 		`diskSize invalid as negative number`: {
@@ -682,7 +682,7 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+				"The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T'.",
 			},
 		},
 		`diskSize invalid as no number provided`: {
@@ -697,7 +697,7 @@ func TestValidateRawConfiguration(t *testing.T) {
 				},
 			},
 			ExpectedFailedMessages: []string{
-				fmt.Sprintf("The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T' when 'imageType' is '%s'.", image.TypeRAW),
+				"The 'rawConfiguration/diskSize' field must be an integer followed by a suffix of either 'M', 'G', or 'T'.",
 			},
 		},
 	}


### PR DESCRIPTION
- Prevents some of the builds which would result in a combustion failure
- Running a plethora of tests shows the following:
   - Including custom files (313 MB in total) requires expanding the base image (2188 MB) to 2502 MB (2188 + 313 + 1)
   - Including custom files (313 MB) + k3s (219 MB) (533 MB in total) requires expanding the base image (2188) to 3000 MB to bypass the combustion failure (but run into k3s failure) and to 4500 MB to properly start up
   - Including custom files (313 MB) + RKE2 (1126 MB) (1439 MB in total) requires expanding the base image (2188 MB) to roughly 5000 to bypass the combustion failure (but running into RKE2 failure) and to 10 000 MB to properly start up
- Further testing and more complex calculations need to take place for making good estimations for suggestions / automatic adjustments
- Closes https://github.com/suse-edge/edge-image-builder/issues/361