### PR TITLE
[Release 1.0] Fix OCI repository URL handling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,14 @@
 
 ---
 
+# v1.0.1
+
+## Bug Fixes
+
+* [#405](https://github.com/suse-edge/edge-image-builder/issues/405) - OCI registries are assumed to include the chart name
+
+---
+
 # v1.0.0
 
 ## General

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -204,7 +204,7 @@ kubernetes:
       - name: suse-edge
         url: https://suse-edge.github.io/charts
       - name: apache-repo
-        url: oci://registry-1.docker.io/bitnamicharts/apache
+        url: oci://registry-1.docker.io/bitnamicharts
         plainHTTP: false
         skipTLSVerify: true
         authentication:

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -263,7 +263,7 @@ func TestStoreHelmCharts(t *testing.T) {
 	charts := []*registry.HelmChart{
 		{
 			CRD: registry.NewHelmCRD(helmChart, "some-content", `
-values: content`, "oci://registry-1.docker.io/bitnamicharts/apache"),
+values: content`, "oci://registry-1.docker.io/bitnamicharts"),
 		},
 	}
 
@@ -276,7 +276,7 @@ metadata:
     name: apache
     namespace: kube-system
     annotations:
-        edge.suse.com/repository-url: oci://registry-1.docker.io/bitnamicharts/apache
+        edge.suse.com/repository-url: oci://registry-1.docker.io/bitnamicharts
         edge.suse.com/source: edge-image-builder
 spec:
     version: 10.7.0

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -36,12 +36,13 @@ func New(outputDir, certsDir string) *Helm {
 	}
 }
 
-func repositoryName(repoName, repoURL, chart string) string {
+func chartPath(repoName, repoURL, chart string) string {
 	if strings.HasPrefix(repoURL, "http") {
 		return fmt.Sprintf("%s/%s", repoName, chart)
 	}
 
-	return repoURL
+	path, _ := url.JoinPath(repoURL, chart)
+	return path
 }
 
 func (h *Helm) AddRepo(repo *image.HelmRepository) error {
@@ -179,10 +180,10 @@ func (h *Helm) Pull(chart string, repo *image.HelmRepository, version, destDir s
 }
 
 func pullCommand(chart string, repo *image.HelmRepository, version, destDir, certsDir string, output io.Writer) *exec.Cmd {
-	repository := repositoryName(repo.Name, repo.URL, chart)
+	path := chartPath(repo.Name, repo.URL, chart)
 
 	var args []string
-	args = append(args, "pull", repository)
+	args = append(args, "pull", path)
 
 	if version != "" {
 		args = append(args, "--version", version)

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -13,7 +13,7 @@ const (
 	certsDir = "certs"
 )
 
-func TestHelmRepositoryName(t *testing.T) {
+func TestHelmChartPath(t *testing.T) {
 	tests := []struct {
 		name           string
 		repoName       string
@@ -24,7 +24,7 @@ func TestHelmRepositoryName(t *testing.T) {
 		{
 			name:           "OCI",
 			repoName:       "apache-repo",
-			repoURL:        "oci://registry-1.docker.io/bitnamicharts/apache",
+			repoURL:        "oci://registry-1.docker.io/bitnamicharts",
 			chart:          "apache",
 			expectedOutput: "oci://registry-1.docker.io/bitnamicharts/apache",
 		},
@@ -39,8 +39,8 @@ func TestHelmRepositoryName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repoName := repositoryName(test.repoName, test.repoURL, test.chart)
-			assert.Equal(t, test.expectedOutput, repoName)
+			path := chartPath(test.repoName, test.repoURL, test.chart)
+			assert.Equal(t, test.expectedOutput, path)
 		})
 	}
 }
@@ -187,7 +187,7 @@ func TestRegistryLoginCommand(t *testing.T) {
 			host: "registry-1.docker.io",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 				Authentication: image.HelmAuthentication{
 					Username: "user",
 					Password: "pass",
@@ -209,7 +209,7 @@ func TestRegistryLoginCommand(t *testing.T) {
 			host: "registry-1.docker.io",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 				Authentication: image.HelmAuthentication{
 					Username: "user",
 					Password: "pass",
@@ -233,7 +233,7 @@ func TestRegistryLoginCommand(t *testing.T) {
 			host: "registry-1.docker.io",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 				Authentication: image.HelmAuthentication{
 					Username: "user",
 					Password: "pass",
@@ -257,7 +257,7 @@ func TestRegistryLoginCommand(t *testing.T) {
 			host: "registry-1.docker.io",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 				Authentication: image.HelmAuthentication{
 					Username: "user",
 					Password: "pass",
@@ -302,10 +302,11 @@ func TestPullCommand(t *testing.T) {
 		expectedArgs []string
 	}{
 		{
-			name: "OCI repository",
+			name:  "OCI repository",
+			chart: "apache",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 			},
 			version: "10.5.2",
 			destDir: "charts",
@@ -339,10 +340,11 @@ func TestPullCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "OCI repository without optional args",
+			name:  "OCI repository without optional args",
+			chart: "apache",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 			},
 			expectedArgs: []string{
 				"helm",
@@ -402,10 +404,11 @@ func TestPullCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "OCI repository with auth and skip TLS verify",
+			name:  "OCI repository with auth and skip TLS verify",
+			chart: "apache",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 				Authentication: image.HelmAuthentication{
 					Username: "user",
 					Password: "pass",
@@ -420,10 +423,11 @@ func TestPullCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "OCI repository with auth and plain HTTP",
+			name:  "OCI repository with auth and plain HTTP",
+			chart: "apache",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 				Authentication: image.HelmAuthentication{
 					Username: "user",
 					Password: "pass",
@@ -458,10 +462,11 @@ func TestPullCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "OCI repository with auth and a ca file",
+			name:  "OCI repository with auth and a ca file",
+			chart: "apache",
 			repo: &image.HelmRepository{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 				Authentication: image.HelmAuthentication{
 					Username: "user",
 					Password: "pass",

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -201,7 +201,7 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "suse-edge.crt", kubernetes.Helm.Repositories[0].CAFile)
 
 	assert.Equal(t, "bitnami", kubernetes.Helm.Repositories[1].Name)
-	assert.Equal(t, "oci://registry-1.docker.io/bitnamicharts/apache", kubernetes.Helm.Repositories[1].URL)
+	assert.Equal(t, "oci://registry-1.docker.io/bitnamicharts", kubernetes.Helm.Repositories[1].URL)
 	assert.Equal(t, "user", kubernetes.Helm.Repositories[1].Authentication.Username)
 	assert.Equal(t, "pass", kubernetes.Helm.Repositories[1].Authentication.Password)
 	assert.Equal(t, false, kubernetes.Helm.Repositories[1].PlainHTTP)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -115,7 +115,7 @@ kubernetes:
         url: https://suse-edge.github.io/charts
         caFile: suse-edge.crt
       - name: bitnami
-        url: oci://registry-1.docker.io/bitnamicharts/apache
+        url: oci://registry-1.docker.io/bitnamicharts
         plainHTTP: false
         skipTLSVerify: true
         authentication:

--- a/pkg/image/validation/kubernetes_test.go
+++ b/pkg/image/validation/kubernetes_test.go
@@ -51,7 +51,7 @@ func TestValidateKubernetes(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -87,7 +87,7 @@ func TestValidateKubernetes(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -434,7 +434,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 							Authentication: image.HelmAuthentication{
 								Username: "user",
 								Password: "pass",
@@ -473,7 +473,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -549,7 +549,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -572,7 +572,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -599,7 +599,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -622,7 +622,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -645,7 +645,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -671,7 +671,7 @@ func TestValidateHelmCharts(t *testing.T) {
 						},
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 						},
 					},
 				},
@@ -715,7 +715,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "invalid.repo.io/bitnami/apache",
+							URL:  "invalid.repo.io/bitnami",
 						},
 					},
 				},
@@ -737,7 +737,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 							Authentication: image.HelmAuthentication{
 								Username: "user",
 								Password: "",
@@ -763,7 +763,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name: "apache-repo",
-							URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:  "oci://registry-1.docker.io/bitnamicharts",
 							Authentication: image.HelmAuthentication{
 								Username: "",
 								Password: "pass",
@@ -789,7 +789,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name:          "apache-repo",
-							URL:           "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:           "oci://registry-1.docker.io/bitnamicharts",
 							SkipTLSVerify: true,
 							PlainHTTP:     true,
 						},
@@ -934,7 +934,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name:   "apache-repo",
-							URL:    "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:    "oci://registry-1.docker.io/bitnamicharts",
 							CAFile: "nonexistent-apache.crt",
 						},
 					},
@@ -957,7 +957,7 @@ func TestValidateHelmCharts(t *testing.T) {
 					Repositories: []image.HelmRepository{
 						{
 							Name:   "apache-repo",
-							URL:    "oci://registry-1.docker.io/bitnamicharts/apache",
+							URL:    "oci://registry-1.docker.io/bitnamicharts",
 							CAFile: "invalid-cert",
 						},
 					},

--- a/pkg/registry/helm_test.go
+++ b/pkg/registry/helm_test.go
@@ -60,7 +60,7 @@ func TestHelmCharts_ValuesFileNotFoundError(t *testing.T) {
 		Repositories: []image.HelmRepository{
 			{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 			},
 		},
 	}
@@ -80,7 +80,7 @@ func TestHandleChart_MissingValuesDir(t *testing.T) {
 	}
 	helmRepo := &image.HelmRepository{
 		Name: "apache-repo",
-		URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+		URL:  "oci://registry-1.docker.io/bitnamicharts",
 	}
 
 	chart, err := handleChart(helmChart, helmRepo, "oops!", "", "", nil)
@@ -119,7 +119,7 @@ func TestHandleChart_FailedTemplate(t *testing.T) {
 	}
 	helmRepo := &image.HelmRepository{
 		Name: "apache-repo",
-		URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+		URL:  "oci://registry-1.docker.io/bitnamicharts",
 	}
 
 	helmClient := mockHelmClient{
@@ -151,7 +151,7 @@ func TestHandleChart_FailedGetChartContent(t *testing.T) {
 	}
 	helmRepo := &image.HelmRepository{
 		Name: "apache-repo",
-		URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+		URL:  "oci://registry-1.docker.io/bitnamicharts",
 	}
 
 	helmClient := mockHelmClient{
@@ -196,7 +196,7 @@ func TestDownloadChart_FailedAddingRepo(t *testing.T) {
 func TestDownloadChart_ValidRegistryLogin(t *testing.T) {
 	helmChart := &image.HelmChart{}
 	helmRepo := &image.HelmRepository{
-		URL: "oci://registry-1.docker.io/bitnamicharts/apache",
+		URL: "oci://registry-1.docker.io/bitnamicharts",
 		Authentication: image.HelmAuthentication{
 			Username: "valid",
 			Password: "login",
@@ -223,7 +223,7 @@ func TestDownloadChart_ValidRegistryLogin(t *testing.T) {
 func TestDownloadChart_FailedRegistryLogin(t *testing.T) {
 	helmChart := &image.HelmChart{}
 	helmRepo := &image.HelmRepository{
-		URL: "oci://registry-1.docker.io/bitnamicharts/apache",
+		URL: "oci://registry-1.docker.io/bitnamicharts",
 		Authentication: image.HelmAuthentication{
 			Username: "wrong",
 			Password: "creds",
@@ -274,7 +274,7 @@ func TestDownloadChart(t *testing.T) {
 	}
 	helmRepo := &image.HelmRepository{
 		Name: "apache-repo",
-		URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+		URL:  "oci://registry-1.docker.io/bitnamicharts",
 	}
 
 	helmClient := mockHelmClient{
@@ -306,7 +306,7 @@ func TestHelmCharts(t *testing.T) {
 		Repositories: []image.HelmRepository{
 			{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 			},
 		},
 	}
@@ -386,7 +386,7 @@ func TestMapChartRepos(t *testing.T) {
 		Repositories: []image.HelmRepository{
 			{
 				Name: "apache-repo",
-				URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+				URL:  "oci://registry-1.docker.io/bitnamicharts",
 			},
 			{
 				Name: "suse-edge",
@@ -398,7 +398,7 @@ func TestMapChartRepos(t *testing.T) {
 	expectedMap := map[string]*image.HelmRepository{
 		"apache-repo": {
 			Name: "apache-repo",
-			URL:  "oci://registry-1.docker.io/bitnamicharts/apache",
+			URL:  "oci://registry-1.docker.io/bitnamicharts",
 		},
 		"suse-edge": {
 			Name: "suse-edge",


### PR DESCRIPTION
* Fix OCI repository URL handling



* Use url.JoinPath to construct the repository name



* Update release notes



* Set release notes for v1.0.1



---------