### PR TITLE
Fix: can't run on aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:Edge
     zypper --gpg-auto-import-keys refresh && \
     zypper install -y \
     xorriso squashfs  \
-    libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs guestfs-tools lvm2 \
+    libguestfs kernel-default e2fsprogs parted gptfdisk btrfsprogs guestfs-tools lvm2 qemu-ipxe \
     podman \
     createrepo_c \
     helm hauler \


### PR DESCRIPTION
Related issue: https://github.com/suse-edge/edge-image-builder/issues/193

Without qemu-ipxe package, guestfish can't determnid the kvm states. Which will result KVM enabled in guestfish qemu test step and the qemu server can't be started.