### PR TITLE
Add image build workflow on prs and pushes

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -1,0 +1,14 @@
+on: [ push, pull_request ]
+name: Build Image
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build the image
+        run: docker build -t eib:dev .


### PR DESCRIPTION
This commit introduces a new workflow to attempt building EIB container image for prs and pushes to verify the image is buildable.