### PR TITLE
Adding Elemental Reset capabilities to nodes provisioned via EIB

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ## General
 
 * Added the ability to consume both 512/4096 byte sector size disk input base-images
+* Added the ability to leverage Elemental node reset for unmanaged operating systems
 
 ## API
 

--- a/pkg/combustion/elemental_test.go
+++ b/pkg/combustion/elemental_test.go
@@ -66,5 +66,5 @@ func TestWriteElementalCombustionScript(t *testing.T) {
 	assert.Contains(t, found, "/etc/systemd/system/elemental-reset.path")
 	assert.Contains(t, found, "/etc/systemd/system/elemental-reset.service")
 	assert.Contains(t, found, "mkdir -p /opt/edge/")
-	assert.Contains(t, found, "cat <<- EOF > /opt/edge/node_cleanup.sh")
+	assert.Contains(t, found, "cat <<- \\EOF > /opt/edge/node_cleanup.sh")
 }

--- a/pkg/combustion/elemental_test.go
+++ b/pkg/combustion/elemental_test.go
@@ -63,4 +63,8 @@ func TestWriteElementalCombustionScript(t *testing.T) {
 	require.NoError(t, err)
 	found := string(foundBytes)
 	assert.Contains(t, found, "/usr/sbin/elemental-register --debug --config-path /etc/elemental/config.yaml --state-path /etc/elemental/state.yaml --install --no-toolkit")
+	assert.Contains(t, found, "/etc/systemd/system/elemental-reset.path")
+	assert.Contains(t, found, "/etc/systemd/system/elemental-reset.service")
+	assert.Contains(t, found, "mkdir -p /opt/edge/")
+	assert.Contains(t, found, "cat <<- EOF > /opt/edge/node_cleanup.sh")
 }

--- a/pkg/combustion/elemental_test.go
+++ b/pkg/combustion/elemental_test.go
@@ -66,5 +66,5 @@ func TestWriteElementalCombustionScript(t *testing.T) {
 	assert.Contains(t, found, "/etc/systemd/system/elemental-reset.path")
 	assert.Contains(t, found, "/etc/systemd/system/elemental-reset.service")
 	assert.Contains(t, found, "mkdir -p /opt/edge/")
-	assert.Contains(t, found, "cat <<- \\EOF > /opt/edge/node_cleanup.sh")
+	assert.Contains(t, found, "cat <<- \\EOF > /opt/edge/elemental_node_cleanup.sh")
 }

--- a/pkg/combustion/templates/31-elemental-register.sh.tpl
+++ b/pkg/combustion/templates/31-elemental-register.sh.tpl
@@ -155,3 +155,5 @@ rm -f /etc/elemental/state.yaml
 # by restarting the Elemental registration service via systemd
 systemctl restart elemental-register-systemd.service
 EOF
+
+chmod a+x /opt/edge/node_cleanup.sh

--- a/pkg/combustion/templates/31-elemental-register.sh.tpl
+++ b/pkg/combustion/templates/31-elemental-register.sh.tpl
@@ -63,7 +63,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/edge/node_cleanup.sh -u
+ExecStart=/opt/edge/elemental_node_cleanup.sh -u
 ExecStartPost=/usr/bin/rm -f /var/lib/elemental/.unmanaged_reset
 EOF
 
@@ -72,7 +72,7 @@ systemctl enable elemental-register-systemd.service || true
 systemctl enable elemental-system-agent.service || true
 
 mkdir -p /opt/edge/
-cat <<- \EOF > /opt/edge/node_cleanup.sh
+cat <<- \EOF > /opt/edge/elemental_node_cleanup.sh
 #!/usr/bin/env bash
 # SUSE Edge Elemental Node Reset Script
 # Copyright 2024 SUSE Software Solutions
@@ -156,4 +156,4 @@ rm -f /etc/elemental/state.yaml
 systemctl restart elemental-register-systemd.service
 EOF
 
-chmod a+x /opt/edge/node_cleanup.sh
+chmod a+x /opt/edge/elemental_node_cleanup.sh

--- a/pkg/combustion/templates/31-elemental-register.sh.tpl
+++ b/pkg/combustion/templates/31-elemental-register.sh.tpl
@@ -72,7 +72,7 @@ systemctl enable elemental-register-systemd.service || true
 systemctl enable elemental-system-agent.service || true
 
 mkdir -p /opt/edge/
-cat <<- EOF > /opt/edge/node_cleanup.sh
+cat <<- \EOF > /opt/edge/node_cleanup.sh
 #!/usr/bin/env bash
 # SUSE Edge Elemental Node Reset Script
 # Copyright 2024 SUSE Software Solutions
@@ -95,42 +95,24 @@ cat <<- EOF > /opt/edge/node_cleanup.sh
 #          persistent data. There is also an unattended switch for automated
 #          reset. You have been warned!
 
-usage(){
-	cat <<-EOF
-================================================================
-SUSE Edge Node Cleanup Script (for Elemental registered systems)
-================================================================
-	Usage: ${0} [-u]
-
-	Options:
-	 -u		Runs in unattended mode and doesn't request confirmation. Data loss warning!
-	EOF
-}
-
 UNATTENDED=false
 
-while getopts 'h:u' OPTION; do
-	case "${OPTION}" in
-		u)
-			UNATTENDED=true
-			;;
-		h)
-			usage && exit 0
-			;;
-		?)
-			usage && exit 2
-			;;
-	esac
+while getopts 'u' OPTION; do
+    case "${OPTION}" in
+        u)
+            UNATTENDED=true
+            ;;
+    esac
 done
 
 if [ $UNATTENDED = "false" ] ;
 then
-	echo "============================================"
-	echo "SUSE Edge Node Cleanup for Elemental Systems"
-	echo -e "============================================\n"
-	echo -n "WARNING: This script will remove all Kubernetes files and will"
-	echo -e " cause data loss!\n"
-	while true; do
+    echo "============================================"
+    echo "SUSE Edge Node Cleanup for Elemental Systems"
+    echo -e "============================================\n"
+    echo -n "WARNING: This script will remove all Kubernetes files and will"
+    echo -e " cause data loss!\n"
+    while true; do
             read -p "Are you sure you wish to proceed [y/N]? " yn
             case $yn in
                 [Yy] ) break;;
@@ -149,8 +131,8 @@ systemctl kill --signal=SIGKILL rancher-system-agent
 # Kill and uninstall all rke2 services
 if [ -x /opt/rke2/bin/rke2-uninstall.sh ];
 then
-	/opt/rke2/bin/rke2-killall.sh
-	/opt/rke2/bin/rke2-uninstall.sh
+    /opt/rke2/bin/rke2-killall.sh
+    /opt/rke2/bin/rke2-uninstall.sh
 fi
 
 # Kill and uninstall all k3s services
@@ -160,8 +142,8 @@ if command -v k3s-uninstall.sh &> /dev/null; then k3s-uninstall.sh; fi
 # Remove the rancher-system-agent as this gets reinstalled via Elemental
 if [ -x /opt/rancher-system-agent/bin/rancher-system-agent-uninstall.sh ];
 then
-	sh /opt/rancher-system-agent/bin/rancher-system-agent-uninstall.sh
-	rm -rf /opt/rancher-system-agent
+    sh /opt/rancher-system-agent/bin/rancher-system-agent-uninstall.sh
+    rm -rf /opt/rancher-system-agent
 fi
 
 # Clean up all old configuration directories and Elemental state

--- a/pkg/combustion/templates/31-elemental-register.sh.tpl
+++ b/pkg/combustion/templates/31-elemental-register.sh.tpl
@@ -47,5 +47,129 @@ Environment="CATTLE_AGENT_CONFIG=/etc/rancher/elemental/agent/config.yaml"
 ExecStart=/usr/sbin/elemental-system-agent sentinel
 EOF
 
+cat <<- EOF > /etc/systemd/system/elemental-reset.path
+[Path]
+PathModified=/var/lib/elemental/.unmanaged_reset
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<- EOF > /etc/systemd/system/elemental-reset.service
+[Unit]
+Description=Elemental Reset for Unmanaged Hosts
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/edge/node_cleanup.sh -u
+ExecStartPost=/usr/bin/rm -f /var/lib/elemental/.unmanaged_reset
+EOF
+
+systemctl enable elemental-reset.path || true
 systemctl enable elemental-register-systemd.service || true
 systemctl enable elemental-system-agent.service || true
+
+mkdir -p /opt/edge/
+cat <<- EOF > /opt/edge/node_cleanup.sh
+#!/usr/bin/env bash
+# SUSE Edge Elemental Node Reset Script
+# Copyright 2024 SUSE Software Solutions
+
+# This script attempts to cleanup a node that has been deployed via Edge Image
+# Builder with the integrations for Elemental registration; in other words,
+# vanilla SLE Micro 5.5, *not* SLE Micro for Rancher (also known as Elemental
+# Teal), that has used the "--no-toolkit" registration option.
+#
+# The default behaviour in Rancher/Elemental is that in the event that a
+# cluster is deleted in Rancher, the Kubernetes cluster running on a node (or
+# set of nodes) will not be automatically cleaned up; the cluster will be
+# orphaned and will remain running. Furthermore, the Elemental MachineInventory
+# will be removed, so it's no longer visible in the list of registered nodes.
+#
+# This script cleans up the installed Kubernetes cluster so no traces remain
+# and forces a re-registration with the original Elemental registration config.
+#
+# WARNING: This script *will* cause data loss as it removes all Kubernetes
+#          persistent data. There is also an unattended switch for automated
+#          reset. You have been warned!
+
+usage(){
+	cat <<-EOF
+================================================================
+SUSE Edge Node Cleanup Script (for Elemental registered systems)
+================================================================
+	Usage: ${0} [-u]
+
+	Options:
+	 -u		Runs in unattended mode and doesn't request confirmation. Data loss warning!
+	EOF
+}
+
+UNATTENDED=false
+
+while getopts 'h:u' OPTION; do
+	case "${OPTION}" in
+		u)
+			UNATTENDED=true
+			;;
+		h)
+			usage && exit 0
+			;;
+		?)
+			usage && exit 2
+			;;
+	esac
+done
+
+if [ $UNATTENDED = "false" ] ;
+then
+	echo "============================================"
+	echo "SUSE Edge Node Cleanup for Elemental Systems"
+	echo -e "============================================\n"
+	echo -n "WARNING: This script will remove all Kubernetes files and will"
+	echo -e " cause data loss!\n"
+	while true; do
+            read -p "Are you sure you wish to proceed [y/N]? " yn
+            case $yn in
+                [Yy] ) break;;
+                [Nn] ) exit;;
+                * ) exit 0;;
+            esac
+        done
+fi
+
+# If we reach this point, we're deleting data and re-registering.
+
+# Stop both the elemental and rancher-system-agents via systemd
+systemctl kill --signal=SIGKILL elemental-system-agent
+systemctl kill --signal=SIGKILL rancher-system-agent
+
+# Kill and uninstall all rke2 services
+if [ -x /opt/rke2/bin/rke2-uninstall.sh ];
+then
+	/opt/rke2/bin/rke2-killall.sh
+	/opt/rke2/bin/rke2-uninstall.sh
+fi
+
+# Kill and uninstall all k3s services
+if command -v k3s-killall.sh &> /dev/null; then k3s-killall.sh; fi
+if command -v k3s-uninstall.sh &> /dev/null; then k3s-uninstall.sh; fi
+
+# Remove the rancher-system-agent as this gets reinstalled via Elemental
+if [ -x /opt/rancher-system-agent/bin/rancher-system-agent-uninstall.sh ];
+then
+	sh /opt/rancher-system-agent/bin/rancher-system-agent-uninstall.sh
+	rm -rf /opt/rancher-system-agent
+fi
+
+# Clean up all old configuration directories and Elemental state
+rm -rf /etc/rancher
+rm -rf /var/lib/rancher
+rm -f /etc/elemental/state.yaml
+
+# Re-register the node via Elemental using the original Elemental config
+# by restarting the Elemental registration service via systemd
+systemctl restart elemental-register-systemd.service
+EOF


### PR DESCRIPTION
Currently, SLE Micro hosts that register against Elemental (and are provisioned via EIB) cannot utilise the `elemental.cattle.io/resettable: 'true'` capability to wipe Kubernetes cluster information and restore the machine to the inventory so it can be re-used. The current behaviour is that the node is deleted, and manual action needs to take place to clean up data and re-register the machine, which is undesirable.

In https://github.com/rancher/elemental-operator/pull/731 I've made a suggestion on how we can implement OS-agnostic system markers that can be watched to trigger any desired cleanup actions, bypassing the need to have Elemental be concerned with the type of OS being utilised. As part of Edge we should look for this marker and take appropriate action. In this PR we introduce a `systemd.path` unit that watches for the presence of `/var/lib/elemental/.unmanaged_reset` and executes a slightly stripped down version of https://github.com/suse-edge/misc/blob/main/elemental/edge-node-cleanup.sh. 

This PR is considered WIP because it relies on the elemental-operator patch landing, but some additional thoughts-

1. Should we make this pluggable, i.e. via an EIB switch to enable node reset, rather than having it enabled by default as this PR suggests?
2. Should we also reset the SLE Micro snapshot back to original state as part of the cleanup procedure? Currently we only care about Kubernetes data and uninstalling k3s/rke2.

Fixes: #450