### PR TITLE
Make embedded-registry script reentrant

### DIFF
--- a/pkg/combustion/templates/26-embedded-registry.sh.tpl
+++ b/pkg/combustion/templates/26-embedded-registry.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-mkdir /opt/hauler
+mkdir -p /opt/hauler
 cp {{ .RegistryDir }}/hauler /opt/hauler/hauler
 cp {{ .RegistryDir }}/*-{{ .RegistryTarSuffix }} /opt/hauler/
 


### PR DESCRIPTION
Make embedded-registry script reentrant since it would be failed if `/opt/hauler` already exists. 