### PR TITLE
[Release 1.0] Only extract container images from specific Kubernetes objects when parsing Helm charts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 
 ## Bug Fixes
 
+* [#442](https://github.com/suse-edge/edge-image-builder/issues/442) - Only get images from specific Kubernetes objects
+
 ---
 
 # v1.0.1

--- a/pkg/registry/manifests.go
+++ b/pkg/registry/manifests.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/suse-edge/edge-image-builder/pkg/http"
@@ -85,6 +86,21 @@ func readManifest(manifestPath string) ([]map[string]any, error) {
 }
 
 func storeManifestImages(resource map[string]any, images map[string]bool) {
+	var k8sKinds = []string{
+		"Pod",
+		"Deployment",
+		"StatefulSet",
+		"DaemonSet",
+		"ReplicaSet",
+		"Job",
+		"CronJob",
+	}
+
+	kind, _ := resource["kind"].(string)
+	if !slices.Contains(k8sKinds, kind) {
+		return
+	}
+
 	var findImages func(data any)
 
 	findImages = func(data any) {

--- a/pkg/registry/manifests_test.go
+++ b/pkg/registry/manifests_test.go
@@ -92,6 +92,29 @@ func TestStoreManifestImages(t *testing.T) {
 	assert.ElementsMatch(t, expectedImages, allImages)
 }
 
+func TestStoreManifestImages_InvalidKinds(t *testing.T) {
+	// Setup
+	var extractedImagesSet = make(map[string]bool)
+	manifestData := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "InvalidKind",
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{
+					"name":  "nginx",
+					"image": "nginx:1.14.2",
+				},
+			},
+		},
+	}
+
+	// Test
+	storeManifestImages(manifestData, extractedImagesSet)
+
+	// Verify
+	assert.Equal(t, map[string]bool{}, extractedImagesSet)
+}
+
 func TestStoreManifestImages_EmptyManifest(t *testing.T) {
 	// Setup
 	var extractedImagesSet = make(map[string]bool)

--- a/pkg/registry/testdata/sample-crd.yaml
+++ b/pkg/registry/testdata/sample-crd.yaml
@@ -1,5 +1,5 @@
 apiVersion: "custom.example.com/v1"
-kind: ComplexApplication
+kind: Deployment
 metadata:
   name: my-complex-app
   labels:


### PR DESCRIPTION
- Backport #446 