### PR TITLE
Implementing aarch64 image build capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ FROM opensuse/leap:15.5
 # 4. RPM resolution logic
 # 5. Embedded artefact registry
 # 6. Network configuration
+# 7. RAW image modification on aarch64
 RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:EdgeImageBuilder/SLE-15-SP5/isv:SUSE:Edge:EdgeImageBuilder.repo && \
     zypper --gpg-auto-import-keys refresh && \
     zypper install -y \
@@ -35,8 +36,21 @@ RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:Edge
     podman \
     createrepo_c \
     helm hauler \
-    nm-configurator && \
-    zypper clean -a
+    nm-configurator
+
+# Make adjustments for running guestfish and image modifications on aarch64
+# guestfish looks for very specific locations on the filesystem for UEFI firmware
+# and also expects the boot kernel to be a portable executable (PE), not ELF.
+RUN if [[ $(uname -m) == "aarch64" ]]; then \
+	zypper install -y qemu-uefi-aarch64; \
+	mkdir -p /usr/share/edk2/aarch64; \
+	cp /usr/share/qemu/aavmf-aarch64-code.bin /usr/share/edk2/aarch64/QEMU_EFI-pflash.raw; \
+	cp /usr/share/qemu/aavmf-aarch64-vars.bin /usr/share/edk2/aarch64/vars-template-pflash.raw; \
+	mv /boot/vmlinux* /boot/backup-vmlinux; \
+fi
+
+# Clean up the repos to reduce size
+RUN zypper clean -a
 
 COPY --from=0 /src/eib /bin/eib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ FROM opensuse/leap:15.5
 # 4. RPM resolution logic
 # 5. Embedded artefact registry
 # 6. Network configuration
-# 7. RAW image modification on aarch64
 RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:EdgeImageBuilder/SLE-15-SP5/isv:SUSE:Edge:EdgeImageBuilder.repo && \
     zypper --gpg-auto-import-keys refresh && \
     zypper install -y \
@@ -36,7 +35,8 @@ RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:Edge
     podman \
     createrepo_c \
     helm hauler \
-    nm-configurator
+    nm-configurator && \
+    zypper clean -a
 
 # Make adjustments for running guestfish and image modifications on aarch64
 # guestfish looks for very specific locations on the filesystem for UEFI firmware
@@ -47,10 +47,8 @@ RUN if [[ $(uname -m) == "aarch64" ]]; then \
 	cp /usr/share/qemu/aavmf-aarch64-code.bin /usr/share/edk2/aarch64/QEMU_EFI-pflash.raw; \
 	cp /usr/share/qemu/aavmf-aarch64-vars.bin /usr/share/edk2/aarch64/vars-template-pflash.raw; \
 	mv /boot/vmlinux* /boot/backup-vmlinux; \
+	zypper clean -a; \
 fi
-
-# Clean up the repos to reduce size
-RUN zypper clean -a
 
 COPY --from=0 /src/eib /bin/eib
 

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -78,7 +78,7 @@ func TestWriteModifyScript(t *testing.T) {
 				"btrfs filesystem label / INSTALL",
 				"sed -i '/ignition.platform/ s/$/ alpha beta /' /tmp/grub.cfg",
 				"truncate -s 64G",
-				"virt-resize --expand /dev/sda3",
+				"virt-resize --expand $ROOT_PART",
 			},
 			expectedMissing: []string{},
 		},

--- a/pkg/rpm/resolver/templates/prepare-tarball.sh.tpl
+++ b/pkg/rpm/resolver/templates/prepare-tarball.sh.tpl
@@ -10,6 +10,11 @@ set -euo pipefail
 WORK_DIR={{.WorkDir}}
 IMG_PATH={{.ImgPath}}
 
+# Make the necessarry adaptations for aarch64
+if [[ $(uname -m) == "aarch64" ]]; then
+	export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
+fi
+
 {{ if eq .ImgType "iso" -}}
 xorriso -osirrox on -indev $IMG_PATH extract / $WORK_DIR/iso-root/
 

--- a/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
+++ b/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
@@ -12,7 +12,7 @@ set -euo pipefail
 
 {{ if ne .RegCode "" }}
 suseconnect -r {{ .RegCode }}
-SLE_SP=$(cat /etc/rpm/macros.sle | awk '/sle/ {print $2};' | cut -c4) && suseconnect -p PackageHub/15.$SLE_SP/x86_64
+SLE_SP=$(cat /etc/rpm/macros.sle | awk '/sle/ {print $2};' | cut -c4) && suseconnect -p PackageHub/15.$SLE_SP/$(uname -m)
 zypper ref
 trap "suseconnect -d" EXIT
 {{ end -}}


### PR DESCRIPTION
In this PR I introduce the ability to use an aarch64 system with EIB, that allows the user to generate either RAW or ISO images with the *same* architecture, i.e. it's not possible to cross-build with these patches (e.g. x86_64 image on aarch64, or vice versa) as it's a) not possible to currently use the target architecture for the type of images that we cache, nor the hauler/nmc binary architectures, and b) not possible to currently spin up guestfish with a different qemu architecture to be able to run the image modification tools, but I think this is a good step forward to enabling customers to build aarch64 images at this time.

Note that we will need to rebase on `leap:15.6` for ISO images, as the aarch64 ISO's need a newer version of `xorriso` to be able to repack the aarch64 ISO. I've tested these changes on both aarch64 and x86_64 based systems for both raw and iso (albeit with the previous comment in mind, I tested that pathway on 15.6).

Credit for this largely goes to @dbw7 and @diconico07 for their prior investigation and inputs.

Fixes: #193 