### PR TITLE
Upgrade OpenSuse Leap from version 15.5 to version 15.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ----- EIB Builder Image -----
-FROM registry.suse.com/bci/golang:1.22-1.11.6
+FROM registry.suse.com/bci/golang:1.22-1.34.7
 
 # Dependency uses by line
 # 1. Podman Go library

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     go build ./cmd/eib
 
 # ----- Deliverable Image -----
-FROM opensuse/leap:15.5
+FROM opensuse/leap:15.6
 
 # Dependency uses by line
 # 1. ISO image building


### PR DESCRIPTION
Upgrade to OpenSuse Leap to version 15.6 and upgrade golang BCI to match the glibc-version (2.38).

closes #476