### PR TITLE
Enable Dependabot for Dockerfile

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,9 @@ updates:
       - "kind/dependabot"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    labels:
+      - "kind/dependabot"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:Edge
 COPY --from=0 /src/eib /bin/eib
 COPY config/artifacts.yaml artifacts.yaml
 
+# Test eib executable to verify glibc compatibility on openSUSE Leap
+RUN /bin/eib version
+
 ENTRYPOINT ["/bin/eib"]


### PR DESCRIPTION
Adds a "docker" ecosystem to Dependabot to automatically create pull requests for base container image updates.
Also adds a RUN instruction to the Dockerfile to verify the compatibility between the Golang BCI and the Leap image. Such incompatibilities can occur due to glibc version mismatches, like in #483.