### PR TITLE
Replace sed expression for InstallDevice to support unattended install on SL Micro 6

### DIFF
--- a/pkg/build/templates/rebuild-iso.sh.tpl
+++ b/pkg/build/templates/rebuild-iso.sh.tpl
@@ -32,7 +32,7 @@ NEW_SQUASH_FILE=${RAW_EXTRACT_DIR}/${SQUASH_BASENAME}
 # Select the desired install device - assumes data destruction and makes the installation fully unattended by enabling GRUB timeout
 {{ if ne .InstallDevice "" -}}
 echo -e "set timeout=3\nset timeout_style=menu\n$(cat ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg)" > ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg
-sed -i '/ignition.platform/ s|$| rd.kiwi.oem.installdevice={{.InstallDevice}} |' ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg
+sed -i '/root=install:CDLABEL=INSTALL/ s|$| rd.kiwi.oem.installdevice={{.InstallDevice}} |' ${ISO_EXTRACT_DIR}/boot/grub2/grub.cfg
 {{ end -}}
 
 


### PR DESCRIPTION
Replaces the sed expression for appending the rd.kiwi.oem.installdevice kernel parameter for unattended install.

fixes #487

Note: the edge-image-builder code base contains the 'ignition.platform' sed expression in other places. These create other incompatibilities with SL Micro 6. KernelArgs is one example. This contribution only covers the InstallDevice issue.

