### PR TITLE
Fix kernelArgs issue with LeapMicro 6.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,8 @@
 
 ## Bug Fixes
 
+* [#498](https://github.com/suse-edge/edge-image-builder/issues/498) - Fix kernelArgs issue with Leap Micro 6.0
+
 ---
 
 # v1.0.2

--- a/pkg/build/grub_test.go
+++ b/pkg/build/grub_test.go
@@ -27,9 +27,6 @@ func TestGenerateGRUBGuestfishCommands(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, commandString)
 
-	expectedFirstBoot := "sed -i '/ignition.platform/ s/$/ alpha beta /' /tmp/grub.cfg"
-	assert.Contains(t, commandString, expectedFirstBoot)
-
 	expectedDefault := "sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT=\"/ s/\"$/ alpha beta \"/' /tmp/grub"
 	assert.Contains(t, commandString, expectedDefault)
 }

--- a/pkg/build/raw_test.go
+++ b/pkg/build/raw_test.go
@@ -74,9 +74,7 @@ func TestWriteModifyScript(t *testing.T) {
 			expectedContains: []string{
 				fmt.Sprintf("guestfish --blocksize=$BLOCKSIZE --format=raw --rw -a %s", outputImageFilename),
 				fmt.Sprintf("copy-in %s", builder.context.CombustionDir),
-				"download /boot/grub2/grub.cfg /tmp/grub.cfg",
 				"btrfs filesystem label / INSTALL",
-				"sed -i '/ignition.platform/ s/$/ alpha beta /' /tmp/grub.cfg",
 				"truncate -s 64G",
 				"virt-resize --expand $ROOT_PART",
 			},
@@ -88,8 +86,6 @@ func TestWriteModifyScript(t *testing.T) {
 			renameFilesystem:  false,
 			expectedContains: []string{
 				fmt.Sprintf("guestfish --blocksize=$BLOCKSIZE --format=raw --rw -a %s", outputImageFilename),
-				"download /boot/grub2/grub.cfg /tmp/grub.cfg",
-				"sed -i '/ignition.platform/ s/$/ alpha beta /' /tmp/grub.cfg",
 			},
 			expectedMissing: []string{
 				fmt.Sprintf("copy-in %s", builder.context.CombustionDir),

--- a/pkg/build/templates/grub/guestfish-snippet.tpl
+++ b/pkg/build/templates/grub/guestfish-snippet.tpl
@@ -1,13 +1,9 @@
-# Configure GRUB for first boot
-# - Without this, the values wouldn't be used until after the first time the
-#   grub configuration is regenerated
-download /boot/grub2/grub.cfg /tmp/grub.cfg
-! sed -i '/ignition.platform/ s/$/ {{.KernelArgs}} /' /tmp/grub.cfg
-upload /tmp/grub.cfg /boot/grub2/grub.cfg
-
 # Configure GRUB defaults
-# - Without this, when `transactional-update grub.cfg` is run it will overwrite
-#   settings used in the above change
+# - So that the update below, and later`transactional-update grub.cfg` will persist the changes
 download /etc/default/grub /tmp/grub
 ! sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT="/ s/"$/ {{.KernelArgs}} "/' /tmp/grub
 upload /tmp/grub /etc/default/grub
+
+# Configure GRUB for first boot
+# - This re-generates the grub.cfg applying the /etc/default/grub above
+sh "grub2-mkconfig -o /boot/grub2/grub.cfg"


### PR DESCRIPTION
Due to changes in the grub cmdline the sed approach no longer works, so instead we can run grub2-mkconfig via guestfish which should re-generate the grub.cfg with the defaults applied

Closes: #498