### PR TITLE
Container Image Caching

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 * Artifact sources origin and metadata are now extracted from a configuration file (`config/artifacts.yaml`)
 * Dropped `-chart` suffix from installed Helm chart names
 * Added ability to build aarch64 images on an aarch64 host machine
+* Added caching for container images
 
 ## API
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -17,12 +17,7 @@ type Cache struct {
 	cacheDir string
 }
 
-func New(rootDir string) (*Cache, error) {
-	cacheDir := filepath.Join(rootDir, "cache")
-	if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
-		return nil, fmt.Errorf("creating a cache directory: %w", err)
-	}
-
+func New(cacheDir string) (*Cache, error) {
 	return &Cache{cacheDir: cacheDir}, nil
 }
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func setup(t *testing.T) (cache *Cache, teardown func()) {
-	cache, err := New("test-cache")
+	cacheDir := "test-cache"
+	assert.NoError(t, os.MkdirAll(cacheDir, os.ModePerm))
+
+	cache, err := New(cacheDir)
 	require.NoError(t, err)
 
 	return cache, func() {

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -62,7 +62,6 @@ type Combustion struct {
 	RPMResolver                  rpmResolver
 	RPMRepoCreator               rpmRepoCreator
 	Registry                     embeddedRegistry
-	CacheDir                     string
 }
 
 // Configure iterates over all separate Combustion components and configures them independently.

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -62,6 +62,7 @@ type Combustion struct {
 	RPMResolver                  rpmResolver
 	RPMRepoCreator               rpmRepoCreator
 	Registry                     embeddedRegistry
+	CacheDir                     string
 }
 
 // Configure iterates over all separate Combustion components and configures them independently.

--- a/pkg/eib/eib.go
+++ b/pkg/eib/eib.go
@@ -126,6 +126,12 @@ func appendHelm(ctx *image.Context) {
 }
 
 func buildCombustion(ctx *image.Context, rootDir string) (*combustion.Combustion, error) {
+	cacheDir := filepath.Join(rootDir, "cache")
+	if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("creating a cache directory: %w", err)
+	}
+	ctx.CacheDir = cacheDir
+
 	combustionHandler := &combustion.Combustion{
 		NetworkConfigGenerator:       network.ConfigGenerator{},
 		NetworkConfiguratorInstaller: network.ConfiguratorInstaller{},
@@ -157,7 +163,7 @@ func buildCombustion(ctx *image.Context, rootDir string) (*combustion.Combustion
 	}
 
 	if ctx.ImageDefinition.Kubernetes.Version != "" {
-		c, err := cache.New(rootDir)
+		c, err := cache.New(cacheDir)
 		if err != nil {
 			return nil, fmt.Errorf("initialising cache instance: %w", err)
 		}

--- a/pkg/fileio/file_io.go
+++ b/pkg/fileio/file_io.go
@@ -130,3 +130,16 @@ func createFileWithPerms(dest string, perms os.FileMode) (*os.File, error) {
 
 	return file, nil
 }
+
+func FileExists(filePath string) bool {
+	if _, err := os.Stat(filePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false
+		}
+
+		zap.S().Warnf("Searching for file at (%s) failed: %s", filePath, err)
+		return false
+	}
+
+	return true
+}

--- a/pkg/image/context.go
+++ b/pkg/image/context.go
@@ -20,6 +20,8 @@ type Context struct {
 	ImageDefinition *Definition
 	// ArtifactSources contains the information necessary for the deployment of external artifacts.
 	ArtifactSources *ArtifactSources
+	// CacheDir contains all of the artifacts that are cached for the build process.
+	CacheDir string
 }
 
 type ArtifactSources struct {


### PR DESCRIPTION
Closes #479 

Container images for air-gapping manifests and Helm charts are now cached to greatly decrease build times.