### PR TITLE
Add SUSE CA Certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ FROM opensuse/leap:15.6
 # 4. RPM resolution logic
 # 5. Embedded artefact registry
 # 6. Network configuration
+# 7. SUSE registry certificates
 RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:EdgeImageBuilder/Leap-15.6/isv:SUSE:Edge:EdgeImageBuilder.repo && \
+    zypper addrepo https://download.opensuse.org/repositories/SUSE:CA/15.6/SUSE:CA.repo && \
     zypper --gpg-auto-import-keys refresh && \
     zypper install -y \
     xorriso squashfs  \
@@ -35,7 +37,8 @@ RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:Edge
     podman \
     createrepo_c \
     helm hauler \
-    nm-configurator && \
+    nm-configurator \
+    ca-certificates-suse && \
     zypper clean -a
 
 # Make adjustments for running guestfish and image modifications on aarch64


### PR DESCRIPTION
Closes #367

I tested this by adding the `registry.suse.de` EIB container to the embedded artifact registry. Before making the change to the Dockerfile it would get a certificate error, after editing the Dockerfile it would work fine.