### PR TITLE
made go base image version more explicit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ----- EIB Builder Image -----
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.22-1.11.6
 
 # Dependency uses by line
 # 1. Podman Go library


### PR DESCRIPTION
It turns out that `golang:1.22` is a rolling release. A recent change/upgrade to this image caused our 1.0.z stream to stop building. This PR pins the go base image to a very specific version which is compatible with the rest of EIB 1.0.z.

closes: #537 