### PR TITLE
Adding support for enabling FIPS mode via an operating system boolean

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,8 @@
 
 ### Image Definition Changes
 
+* Introduced a dedicated FIPS mode option, adding the required packages, kernel arguments, and crypto selection
+
 ### Image Configuration Directory Changes
 
 ## Bug Fixes

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -75,6 +75,7 @@ operatingSystem:
   kernelArgs:
   - arg1
   - arg2
+  enableFIPS: true
   groups:
     - name: group1
     - name: group2
@@ -153,6 +154,7 @@ The remainder of the operating system customizations may be applied regardless o
   parameter is omitted. If this option is set, the default entries will need to be manually added if they are
   still in use.
 * `kernelArgs` - Provides a list of flags that should be passed to the kernel on boot.
+* `enableFIPS` - Specifies whether to setup the operating system for FIPS mode (Default: false)
 * `groups` - Defines a list of operating system groups to create. This will not fail if the 
 group already exists. Each entry is made up of the following fields:
   * `name` - Required; Name of the group to create.

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -129,6 +129,10 @@ func (c *Combustion) Configure(ctx *image.Context) error {
 			runnable: configureSystemd,
 		},
 		{
+			name:     fipsComponentName,
+			runnable: configureFips,
+		},
+		{
 			name:     elementalComponentName,
 			runnable: configureElemental,
 		},

--- a/pkg/combustion/fips.go
+++ b/pkg/combustion/fips.go
@@ -1,0 +1,49 @@
+package combustion
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+	"github.com/suse-edge/edge-image-builder/pkg/log"
+)
+
+const (
+	fipsComponentName = "fips"
+	fipsScriptName    = "15-fips-setup.sh"
+)
+
+var (
+	//go:embed templates/15-fips-setup.sh
+	fipsScript     string
+	FipsPackages   = []string{"patterns-base-fips"}
+	FipsKernelArgs = []string{"fips=1"}
+)
+
+func configureFips(ctx *image.Context) ([]string, error) {
+	fips := ctx.ImageDefinition.OperatingSystem.EnableFips
+	if !fips {
+		log.AuditComponentSkipped(fipsComponentName)
+		return nil, nil
+	}
+
+	if err := writeFipsCombustionScript(ctx); err != nil {
+		log.AuditComponentFailed(fipsComponentName)
+		return nil, err
+	}
+
+	log.AuditComponentSuccessful(fipsComponentName)
+	return []string{fipsScriptName}, nil
+}
+
+func writeFipsCombustionScript(ctx *image.Context) error {
+	fipsScriptFilename := filepath.Join(ctx.CombustionDir, fipsScriptName)
+
+	if err := os.WriteFile(fipsScriptFilename, []byte(fipsScript), fileio.ExecutablePerms); err != nil {
+		return fmt.Errorf("writing file %s: %w", fipsScriptFilename, err)
+	}
+	return nil
+}

--- a/pkg/combustion/fips_test.go
+++ b/pkg/combustion/fips_test.go
@@ -1,0 +1,62 @@
+package combustion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/suse-edge/edge-image-builder/pkg/fileio"
+	"github.com/suse-edge/edge-image-builder/pkg/image"
+)
+
+func TestConfigureFips_NoConf(t *testing.T) {
+	// Setup
+	var ctx image.Context
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{},
+	}
+
+	// Test
+	scripts, err := configureFips(&ctx)
+
+	// Verify
+	require.NoError(t, err)
+	assert.Nil(t, scripts)
+}
+
+func TestConfigureFips_Enabled(t *testing.T) {
+	// Setup
+	ctx, teardown := setupContext(t)
+	defer teardown()
+
+	ctx.ImageDefinition = &image.Definition{
+		OperatingSystem: image.OperatingSystem{
+			EnableFips: true,
+		},
+	}
+
+	// Test
+	scripts, err := configureFips(ctx)
+
+	// Verify
+	require.NoError(t, err)
+
+	require.Len(t, scripts, 1)
+	assert.Equal(t, fipsScriptName, scripts[0])
+
+	expectedFilename := filepath.Join(ctx.CombustionDir, fipsScriptName)
+	foundBytes, err := os.ReadFile(expectedFilename)
+	require.NoError(t, err)
+
+	stats, err := os.Stat(expectedFilename)
+	require.NoError(t, err)
+	assert.Equal(t, fileio.ExecutablePerms, stats.Mode())
+
+	foundContents := string(foundBytes)
+
+	// - Ensure that we have the fips setup script defined
+	assert.Contains(t, foundContents, "fips-mode-setup --enable", "fips setup script missing")
+}

--- a/pkg/combustion/templates/15-fips-setup.sh
+++ b/pkg/combustion/templates/15-fips-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+fips-mode-setup --enable

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -76,6 +76,7 @@ type OperatingSystem struct {
 	Time             Time                   `yaml:"time"`
 	Proxy            Proxy                  `yaml:"proxy"`
 	Keymap           string                 `yaml:"keymap"`
+	EnableFips       bool                   `yaml:"enableFIPS"`
 }
 
 type IsoConfiguration struct {

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -37,6 +37,10 @@ func TestParse(t *testing.T) {
 	}
 	assert.Equal(t, expectedKernelArgs, definition.OperatingSystem.KernelArgs)
 
+	// Operating System -> FIPS
+	enableFIPS := definition.OperatingSystem.EnableFips
+	assert.Equal(t, true, enableFIPS)
+
 	// Operating System -> Groups
 	groupConfigs := definition.OperatingSystem.Groups
 	require.Len(t, groupConfigs, 2)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -29,6 +29,7 @@ operatingSystem:
     - alpha=foo
     - beta=bar
     - baz
+  enableFIPS: true
   systemd:
     enable:
       - enable0

--- a/pkg/image/validation/os.go
+++ b/pkg/image/validation/os.go
@@ -46,6 +46,12 @@ func validateKernelArgs(os *image.OperatingSystem) []FailedValidation {
 					UserMessage: "Kernel arguments must be specified as 'key=value'.",
 				})
 			}
+
+			if (key == "fips" && value == "1") && !os.EnableFips {
+				failures = append(failures, FailedValidation{
+					UserMessage: "FIPS mode has been specified via kernel arguments, please use the 'enableFIPS: true' option instead.",
+				})
+			}
 		}
 
 		if _, exists := seenKeys[key]; exists {

--- a/pkg/image/validation/validation_test.go
+++ b/pkg/image/validation/validation_test.go
@@ -40,7 +40,7 @@ func TestValidateDefinition(t *testing.T) {
 				},
 			},
 		},
-		`one error from each`: {
+		`invalid in each`: {
 			Definition: image.Definition{
 				APIVersion: "1.0",
 				Image: image.Image{
@@ -49,7 +49,7 @@ func TestValidateDefinition(t *testing.T) {
 					OutputImageName: "output.iso",
 				},
 				OperatingSystem: image.OperatingSystem{
-					KernelArgs: []string{"foo="},
+					KernelArgs: []string{"foo=", "fips=1"},
 				},
 				EmbeddedArtifactRegistry: image.EmbeddedArtifactRegistry{
 					ContainerImages: []image.ContainerImage{
@@ -78,6 +78,7 @@ func TestValidateDefinition(t *testing.T) {
 				},
 				osComponent: {
 					"Kernel arguments must be specified as 'key=value'.",
+					"FIPS mode has been specified via kernel arguments, please use the 'enableFIPS: true' option instead.",
 				},
 				registryComponent: {
 					"The 'name' field is required for each entry in 'images'.",

--- a/pkg/image/validation/version.go
+++ b/pkg/image/validation/version.go
@@ -27,5 +27,11 @@ func validateVersion(ctx *image.Context) []FailedValidation {
 		})
 	}
 
+	if definition.APIVersion == "1.0" && definition.OperatingSystem.EnableFips {
+		failures = append(failures, FailedValidation{
+			UserMessage: "Automated FIPS configuration is not supported in EIB version 1.0, please use EIB version >= 1.1",
+		})
+	}
+
 	return failures
 }

--- a/pkg/image/validation/version_test.go
+++ b/pkg/image/validation/version_test.go
@@ -35,6 +35,17 @@ func TestValidateVersion(t *testing.T) {
 				"Helm chart APIVersions field is not supported in EIB version 1.0, must use EIB version 1.1",
 			},
 		},
+		`invalid version with FIPS enabled`: {
+			ImageDefinition: image.Definition{
+				APIVersion: "1.0",
+				OperatingSystem: image.OperatingSystem{
+					EnableFips: true,
+				},
+			},
+			ExpectedFailedMessages: []string{
+				"Automated FIPS configuration is not supported in EIB version 1.0, please use EIB version >= 1.1",
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
In this PR we add support for enabling FIPS functionality with a single boolean in the image definition. In SLE Micro 5.5 it was sufficient to simply add `fips=1` to the kernel cmdline as the default image shipped with the required components, however in SL Micro 6.0 we have to perform some additional steps, at which point it's more convenient to have a single boolean. This boolean takes care of the following steps:

1. Ensures that the `patterns-base-fips` package is installed through RPM dependency resolution
2. Adds the `fips=1` kernel command line argument to the list
3. Runs the FIPS setup script at firstboot to ensure that the FIPS crypto is enabled

The resulting system has the kernel command line option, and persists reboots:

```
node1:~ # cat /proc/cmdline
BOOT_IMAGE=/boot/vmlinuz-6.4.0-17-default root=UUID=b5811ddf-7bcf-4b4d-9b67-c078c9d3657e rd.timeout=60 rd.retry=45 console=ttyS0,115200 console=tty0 security=selinux selinux=1 quiet net.ifnames=0 fips=1
node1:~ # grep fips /boot/grub2/grub.cfg
	linux	/boot/vmlinuz-6.4.0-17-default root=UUID=b5811ddf-7bcf-4b4d-9b67-c078c9d3657e  ${extra_cmdline} console=ttyS0,115200 console=tty0 security=selinux selinux=1 quiet net.ifnames=0 fips=1
		linux	/boot/vmlinuz-6.4.0-17-default root=UUID=b5811ddf-7bcf-4b4d-9b67-c078c9d3657e  ${extra_cmdline} console=ttyS0,115200 console=tty0 security=selinux selinux=1 quiet net.ifnames=0 fips=1
```

It installs the following dependent packages within the `patterns-base-fips`:

```
├── SUSE_Linux_Micro_6.0_x86_64:SL-Micro-6.0-Pool
│   └── x86_64
│       ├── dracut-fips-059+suse.557.g8a62bf73-1.8.x86_64.rpm
│       ├── libkcapi1-1.4.0-1.44.x86_64.rpm
│       ├── libkcapi-tools-1.4.0-1.44.x86_64.rpm
│       ├── libopenssl-3-fips-provider-3.1.4-5.6.x86_64.rpm
│       ├── openssh-fips-9.6p1-1.4.x86_64.rpm
│       └── patterns-base-fips-6.0-1.1.x86_64.rpm
```

It also has the FIPS crypto selection set correctly:

```
node1:~ # cat /proc/sys/crypto/fips_enabled
1

node1:~ # fips-mode-setup --check
FIPS mode is enabled.
Initramfs fips module is enabled.
The current crypto policy (FIPS) is based on the FIPS policy.
```