### PR TITLE
corrected rangeValCopy linter error

### DIFF
--- a/pkg/image/validation/kubernetes.go
+++ b/pkg/image/validation/kubernetes.go
@@ -174,11 +174,10 @@ func validateHelm(k8s *image.Kubernetes, valuesDir, certsDir string) []FailedVal
 	}
 
 	seenHelmRepos := make(map[string]bool)
-	for _, chart := range k8s.Helm.Charts {
-		c := chart
-		failures = append(failures, validateChart(&c, helmRepositoryNames, valuesDir)...)
+	for i := range k8s.Helm.Charts {
+		failures = append(failures, validateChart(&k8s.Helm.Charts[i], helmRepositoryNames, valuesDir)...)
 
-		seenHelmRepos[chart.RepositoryName] = true
+		seenHelmRepos[k8s.Helm.Charts[i].RepositoryName] = true
 	}
 
 	for _, repo := range k8s.Helm.Repositories {
@@ -405,12 +404,12 @@ func validateHelmChartValues(chartName, valuesFile, valuesDir string) string {
 func validateHelmChartDuplicates(charts []image.HelmChart) string {
 	seenHelmCharts := make(map[string]bool)
 
-	for _, chart := range charts {
-		if _, exists := seenHelmCharts[chart.Name]; exists {
-			return fmt.Sprintf("The 'helmCharts' field contains duplicate entries: %s", chart.Name)
+	for i := range charts {
+		if _, exists := seenHelmCharts[charts[i].Name]; exists {
+			return fmt.Sprintf("The 'helmCharts' field contains duplicate entries: %s", charts[i].Name)
 		}
 
-		seenHelmCharts[chart.Name] = true
+		seenHelmCharts[charts[i].Name] = true
 	}
 
 	return ""

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -122,20 +122,19 @@ func storeHelmCharts(ctx *image.Context, helmClient helmClient) ([]*helmChart, e
 
 	var charts []*helmChart
 
-	for _, chart := range helm.Charts {
-		c := chart
-		repository, ok := chartRepositories[c.RepositoryName]
+	for i := range helm.Charts {
+		repository, ok := chartRepositories[helm.Charts[i].RepositoryName]
 		if !ok {
-			return nil, fmt.Errorf("repository not found for chart %s", c.Name)
+			return nil, fmt.Errorf("repository not found for chart %s", helm.Charts[i].Name)
 		}
 
-		localPath, err := downloadChart(helmClient, &c, repository, helmDir)
+		localPath, err := downloadChart(helmClient, &helm.Charts[i], repository, helmDir)
 		if err != nil {
 			return nil, fmt.Errorf("downloading chart: %w", err)
 		}
 
 		charts = append(charts, &helmChart{
-			HelmChart:     c,
+			HelmChart:     helm.Charts[i],
 			localPath:     localPath,
 			repositoryURL: repository.URL,
 		})
@@ -149,11 +148,10 @@ func storeHelmCharts(ctx *image.Context, helmClient helmClient) ([]*helmChart, e
 func mapChartsToRepos(helm *image.Helm) map[string]*image.HelmRepository {
 	chartRepoMap := make(map[string]*image.HelmRepository)
 
-	for _, chart := range helm.Charts {
-		for _, repo := range helm.Repositories {
-			if chart.RepositoryName == repo.Name {
-				r := repo
-				chartRepoMap[chart.RepositoryName] = &r
+	for i := range helm.Charts {
+		for j := range helm.Repositories {
+			if helm.Charts[i].RepositoryName == helm.Repositories[j].Name {
+				chartRepoMap[helm.Charts[i].RepositoryName] = &helm.Repositories[j]
 			}
 		}
 	}


### PR DESCRIPTION
#546 upgrades to a new go base image for EIB. In doing so, the linter seems to be updated, which is causing failures. I've also seen these failures locally on a recent machine rebuild, also due to the new linter.

This fix changes the iteration to use the index to look up the objects instead of making a copy of each element during the iteration. It passes on my local linter, and if this doesn't break anything in the GitHub CI, we can land it and see if it unblocked #546.