### PR TITLE
Manually create RPM cache directory

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 
 ## Bug Fixes
 
+* [#594](https://github.com/suse-edge/edge-image-builder/issues/594) - Package install breaks package resolution if packages is already installed on root OS
+
 ---
 
 # v1.1.0

--- a/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
+++ b/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl
@@ -38,6 +38,8 @@ rpm --import {{ .LocalGPGList }}
 rpm -Kv {{ .LocalRPMList }}
 {{ end -}}
 
+mkdir -p {{.CacheDir}}
+
 zypper \
   --pkg-cache-dir {{.CacheDir}} \
   --gpg-auto-import-keys \


### PR DESCRIPTION
closes: #594 

This PR offers the simplest approach in fixing the problem described in #594 by making sure that the `/tmp/rpm-repo` directory exists before executing the [zypper install](https://github.com/suse-edge/edge-image-builder/blob/main/pkg/rpm/resolver/templates/rpm-resolution.sh.tpl#L41) command.

This will ensure that we will not break the RPM resolution process if the RPM packages that have been specified for install are already present on the machine.

We might also want to think if we want a more sophisticated approach, where instead of just creating the directory beforehand we:

1. Validate the package versions that have been set for installation against the packages that have already been installed on the `base-image`
2. Only proceed to package resolution if the desired package versions are _**greater than**_ the package versions on the `base-image`

I opted for the more simple "just create the directory beforehand" approach, as validating the packages will be a complex and taxing process that will have its own set of problems.

If we decide that we want the more sophisticated approach, we can close this PR and tackle this problem whenever we get some free cycles. 