### PR TITLE
explicitly mount and unmount /var for os files handling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 
 ## Bug Fixes
 
+* [#593](https://github.com/suse-edge/edge-image-builder/issues/593) - OS files script should mount /var
 * [#594](https://github.com/suse-edge/edge-image-builder/issues/594) - Package install breaks package resolution if packages is already installed on root OS
 
 ---

--- a/pkg/combustion/osfiles_test.go
+++ b/pkg/combustion/osfiles_test.go
@@ -48,7 +48,9 @@ func TestConfigureOSFiles(t *testing.T) {
 	expectedCombustionScript := filepath.Join(ctx.CombustionDir, osFilesScriptName)
 	contents, err := os.ReadFile(expectedCombustionScript)
 	require.NoError(t, err)
+	assert.Contains(t, string(contents), "mount /var")
 	assert.Contains(t, string(contents), "cp -R")
+	assert.Contains(t, string(contents), "umount /var")
 
 	// -- Files
 	expectedFile := filepath.Join(ctx.CombustionDir, osFilesConfigDir, "etc", "ssh", "test-config-file")

--- a/pkg/combustion/templates/19-copy-os-files.sh
+++ b/pkg/combustion/templates/19-copy-os-files.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
+mount /var
 cp -R ./os-files/* /
+umount /var


### PR DESCRIPTION
closes: #593 

We may want to investigate a global setting of mounts, for example in the `script` file for combustion itself. Given the time constraint on 1.2, I didn't want to introduce extra risk by applying it at a global level like that. This fix solves #593 and we can address a more generalized approach when we have more time to think through the implications and properly regression test.