### PR TITLE
Create the required Elemental Agent directory structure during Combustion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@
 * [#591](https://github.com/suse-edge/edge-image-builder/issues/591) - Allow additional module registration during package resolution
 * [#593](https://github.com/suse-edge/edge-image-builder/issues/593) - OS files script should mount /var
 * [#594](https://github.com/suse-edge/edge-image-builder/issues/594) - Package installation breaks package resolution if packages are already installed on root OS
+* [#632](https://github.com/suse-edge/edge-image-builder/issues/632) - Create the required Elemental Agent directory structure during Combustion
 
 ---
 

--- a/pkg/combustion/templates/31-elemental-register.sh.tpl
+++ b/pkg/combustion/templates/31-elemental-register.sh.tpl
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+mkdir -p /etc/rancher/elemental/agent
 mkdir -p /etc/elemental
 cp ./{{ .ConfigFile }} /etc/elemental/config.yaml
 
@@ -75,12 +76,12 @@ mkdir -p /opt/edge/
 cat <<- \EOF > /opt/edge/elemental_node_cleanup.sh
 #!/usr/bin/env bash
 # SUSE Edge Elemental Node Reset Script
-# Copyright 2024 SUSE Software Solutions
+# Copyright 2025 SUSE Software Solutions
 
 # This script attempts to cleanup a node that has been deployed via Edge Image
 # Builder with the integrations for Elemental registration; in other words,
-# vanilla SLE Micro 5.5, *not* SLE Micro for Rancher (also known as Elemental
-# Teal), that has used the "--no-toolkit" registration option.
+# vanilla SUSE Linux Micro, *not* SLE Micro for Rancher (also known as
+# Elemental Teal), that has used the "--no-toolkit" registration option.
 #
 # The default behaviour in Rancher/Elemental is that in the event that a
 # cluster is deleted in Rancher, the Kubernetes cluster running on a node (or


### PR DESCRIPTION
In this PR we create the required /etc/rancher/elemental/agent directory structure during the initial Elemental setup code. A config file is checked within the systemd startup condition, and it seemingly fails if this directory isn't already in-place. This seems to only be an issue in SL Micro 6.1, but it shouldn't harm for previous versions of Micro.

Fixes #632