### PR TITLE
Update handling for Hauler v1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM opensuse/leap:15.6
 # 5. Embedded artefact registry
 # 6. Network configuration
 # 7. SUSE registry certificates
-RUN zypper addrepo https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Factory:/Devel/standard/isv:SUSE:Edge:Factory:Devel.repo && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Factory/standard/isv:SUSE:Edge:Factory.repo && \
     zypper addrepo https://download.opensuse.org/repositories/SUSE:CA/15.6/SUSE:CA.repo && \
     zypper --gpg-auto-import-keys refresh && \
     zypper install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM opensuse/leap:15.6
 # 5. Embedded artefact registry
 # 6. Network configuration
 # 7. SUSE registry certificates
-RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:Edge:EdgeImageBuilder/Leap-15.6/isv:SUSE:Edge:EdgeImageBuilder.repo && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Factory:/Devel/standard/isv:SUSE:Edge:Factory:Devel.repo && \
     zypper addrepo https://download.opensuse.org/repositories/SUSE:CA/15.6/SUSE:CA.repo && \
     zypper --gpg-auto-import-keys refresh && \
     zypper install -y \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,8 @@
 
 * Added `kubernetes.network.apiVIP6` field to enable cluster LoadBalancer based on IPv6 address
 * Added the `enableExtras` flag to enable the SUSE Linux Extras repository during RPM resolution.
+* Dependency upgrades
+  * Embedded registry is now utilizing Hauler v1.2.1 (upgraded from v1.0.7)
 
 ### Image Configuration Directory Changes
 

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -30,7 +30,7 @@ func TestWriteRegistryScript(t *testing.T) {
 	assert.Contains(t, found, "cp $ARTEFACTS_DIR/registry/hauler /opt/hauler/hauler")
 	assert.Contains(t, found, "cp $ARTEFACTS_DIR/registry/*-registry.tar.zst /opt/hauler/")
 	assert.Contains(t, found, "systemctl enable eib-embedded-registry.service")
-	assert.Contains(t, found, "ExecStartPre=/bin/sh -c '/opt/hauler/hauler store load *-registry.tar.zst'")
+	assert.Contains(t, found, "ExecStartPre=/bin/bash -c \"for file in /opt/hauler/*-registry.tar.zst; do [ -f \\\"\\$file\\\" ] && /opt/hauler/hauler store load -f \\\"\\$file\\\" --tempdir /opt/hauler; done\"\n")
 	assert.Contains(t, found, "ExecStart=/opt/hauler/hauler store serve registry -p 6545")
 }
 

--- a/pkg/combustion/templates/26-embedded-registry.sh.tpl
+++ b/pkg/combustion/templates/26-embedded-registry.sh.tpl
@@ -14,7 +14,7 @@ After=network.target
 Type=simple
 User=root
 WorkingDirectory=/opt/hauler
-ExecStartPre=/bin/sh -c '/opt/hauler/hauler store load *-{{ .RegistryTarSuffix }}'
+ExecStartPre=/bin/bash -c "for file in /opt/hauler/*-{{ .RegistryTarSuffix }}; do [ -f \"\$file\" ] && /opt/hauler/hauler store load -f \"\$file\" --tempdir /opt/hauler; done"
 ExecStart=/opt/hauler/hauler store serve registry -p {{ .RegistryPort }}
 Restart=on-failure
 


### PR DESCRIPTION
Closes #638

To be merged when the new version of Hauler is available in `https://download.opensuse.org/repositories/isv:SUSE:Edge:EdgeImageBuilder/Leap-15.6/isv:SUSE:Edge:EdgeImageBuilder.repo` .

Maintains the original, low memory, Hauler usage with the new Hauler command format.