### PR TITLE
Fix stale cache

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@
 * [#593](https://github.com/suse-edge/edge-image-builder/issues/593) - OS files script should mount /var
 * [#594](https://github.com/suse-edge/edge-image-builder/issues/594) - Package installation breaks package resolution if packages are already installed on root OS
 * [#632](https://github.com/suse-edge/edge-image-builder/issues/632) - Create the required Elemental Agent directory structure during Combustion
+* [#625](https://github.com/suse-edge/edge-image-builder/issues/625) - Cache is stale for images tagged `:latest`
 
 ---
 

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/suse-edge/edge-image-builder/pkg/podman"
+
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 	"github.com/suse-edge/edge-image-builder/pkg/log"
@@ -54,6 +56,14 @@ type embeddedRegistry interface {
 	HelmCharts() ([]*registry.HelmCRD, error)
 }
 
+type imageDigester interface {
+	Inspect(img string, arch string) (string, error)
+}
+
+type ImageDigester struct {
+	Podman *podman.Podman
+}
+
 type Combustion struct {
 	NetworkConfigGenerator       networkConfigGenerator
 	NetworkConfiguratorInstaller networkConfiguratorInstaller
@@ -62,6 +72,7 @@ type Combustion struct {
 	RPMResolver                  rpmResolver
 	RPMRepoCreator               rpmRepoCreator
 	Registry                     embeddedRegistry
+	ImageDigester                imageDigester
 }
 
 // Configure iterates over all separate Combustion components and configures them independently.
@@ -228,4 +239,8 @@ func logComponentStatus(component string, err error) {
 
 func prependArtefactPath(path string) string {
 	return filepath.Join("$ARTEFACTS_DIR", path)
+}
+
+func (d *ImageDigester) Inspect(img string, arch string) (string, error) {
+	return d.Podman.Inspect(img, arch)
 }

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -55,7 +55,7 @@ type embeddedRegistry interface {
 }
 
 type imageDigester interface {
-	ImageDigest(img string, arch string) (string, error)
+	ImageDigest(img, arch string) (string, error)
 }
 
 type Combustion struct {

--- a/pkg/combustion/combustion.go
+++ b/pkg/combustion/combustion.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/suse-edge/edge-image-builder/pkg/podman"
-
 	"github.com/suse-edge/edge-image-builder/pkg/fileio"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 	"github.com/suse-edge/edge-image-builder/pkg/log"
@@ -57,11 +55,7 @@ type embeddedRegistry interface {
 }
 
 type imageDigester interface {
-	Inspect(img string, arch string) (string, error)
-}
-
-type ImageDigester struct {
-	Podman *podman.Podman
+	ImageDigest(img string, arch string) (string, error)
 }
 
 type Combustion struct {
@@ -239,8 +233,4 @@ func logComponentStatus(component string, err error) {
 
 func prependArtefactPath(path string) string {
 	return filepath.Join("$ARTEFACTS_DIR", path)
-}
-
-func (d *ImageDigester) Inspect(img string, arch string) (string, error) {
-	return d.Podman.Inspect(img, arch)
 }

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -238,7 +238,7 @@ func (c *Combustion) populateRegistry(ctx *image.Context, images []string) error
 		if strings.Contains(img, ":latest") {
 			var digest string
 			digest, err = c.ImageDigester.ImageDigest(img, arch)
-			if err != nil || digest == "" {
+			if err != nil {
 				zap.S().Warnf("Failed getting digest for %s: %s", img, err)
 				cacheImage = false
 			} else {

--- a/pkg/combustion/registry.go
+++ b/pkg/combustion/registry.go
@@ -237,7 +237,7 @@ func (c *Combustion) populateRegistry(ctx *image.Context, images []string) error
 		convertedImageName := fmt.Sprintf("%s-%s", convertedImage, registryTarSuffix)
 		if strings.Contains(img, ":latest") {
 			var digest string
-			digest, err = c.ImageDigester.Inspect(img, arch)
+			digest, err = c.ImageDigester.ImageDigest(img, arch)
 			if err != nil || digest == "" {
 				zap.S().Warnf("Failed getting digest for %s: %s", img, err)
 

--- a/pkg/container/image_digester.go
+++ b/pkg/container/image_digester.go
@@ -1,0 +1,36 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/image/v5/manifest"
+)
+
+type imageInspector interface {
+	Inspect(image, arch string) (*manifest.Schema2List, error)
+}
+
+type ImageDigester struct {
+	ImageInspector imageInspector
+}
+
+func (d *ImageDigester) ImageDigest(img string, arch string) (string, error) {
+	schemas, err := d.ImageInspector.Inspect(img, arch)
+	if err != nil {
+		return "", fmt.Errorf("inspecting image: %w", err)
+	}
+
+	for _, m := range schemas.Manifests {
+		if m.Platform.OS == "linux" && m.Platform.Architecture == arch {
+			digest := m.Digest.String()
+			// This is done to remove "sha256:" from the digest
+			if parts := strings.Split(digest, "sha256:"); len(parts) == 2 {
+				digest = parts[1]
+			}
+			return digest, nil
+		}
+	}
+
+	return "", nil
+}

--- a/pkg/container/image_digester.go
+++ b/pkg/container/image_digester.go
@@ -32,5 +32,5 @@ func (d *ImageDigester) ImageDigest(img string, arch string) (string, error) {
 		}
 	}
 
-	return "", nil
+	return "", fmt.Errorf("image is not built for linux/%s", arch)
 }

--- a/pkg/container/image_digester.go
+++ b/pkg/container/image_digester.go
@@ -8,7 +8,7 @@ import (
 )
 
 type imageInspector interface {
-	Inspect(image, arch string) (*manifest.Schema2List, error)
+	Inspect(image string) (*manifest.Schema2List, error)
 }
 
 type ImageDigester struct {
@@ -16,7 +16,7 @@ type ImageDigester struct {
 }
 
 func (d *ImageDigester) ImageDigest(img string, arch string) (string, error) {
-	schemas, err := d.ImageInspector.Inspect(img, arch)
+	schemas, err := d.ImageInspector.Inspect(img)
 	if err != nil {
 		return "", fmt.Errorf("inspecting image: %w", err)
 	}

--- a/pkg/container/image_digester_test.go
+++ b/pkg/container/image_digester_test.go
@@ -1,0 +1,107 @@
+package container
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containers/image/v5/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockImageInspector struct {
+	inspect func(image, arch string) (*manifest.Schema2List, error)
+}
+
+func (m mockImageInspector) Inspect(img, arch string) (*manifest.Schema2List, error) {
+	if m.inspect != nil {
+		return m.inspect(img, arch)
+	}
+
+	panic("not implemented")
+}
+
+func TestImageDigestValid(t *testing.T) {
+	helloWorldManifest := &manifest.Schema2List{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.docker.distribution.manifest.list.v2+json",
+		Manifests: []manifest.Schema2ManifestDescriptor{
+			{
+				Schema2Descriptor: manifest.Schema2Descriptor{
+					MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+					Size:      1156,
+					Digest:    "sha256:3dfc05677ed97fdf620a3af556d6fe44ec3747262cbf1b4c0c20eed284fd7290",
+					URLs:      []string{},
+				},
+				Platform: manifest.Schema2PlatformSpec{
+					Architecture: "amd64",
+					OS:           "linux",
+					OSVersion:    "",
+					OSFeatures:   []string{},
+					Variant:      "",
+					Features:     []string{},
+				},
+			},
+			{
+				Schema2Descriptor: manifest.Schema2Descriptor{
+					MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+					Size:      1156,
+					Digest:    "sha256:7c831ce05c671702726fc2951fe85048b0b9559f4105b80363424aa935bff2d1",
+					URLs:      []string{},
+				},
+				Platform: manifest.Schema2PlatformSpec{
+					Architecture: "arm64",
+					OS:           "linux",
+					OSVersion:    "",
+					OSFeatures:   []string{},
+					Variant:      "",
+					Features:     []string{},
+				},
+			},
+		},
+	}
+
+	expectedDigest := "3dfc05677ed97fdf620a3af556d6fe44ec3747262cbf1b4c0c20eed284fd7290"
+
+	d := ImageDigester{
+		ImageInspector: mockImageInspector{
+			inspect: func(image, arch string) (*manifest.Schema2List, error) {
+				return helloWorldManifest, nil
+			},
+		},
+	}
+
+	digest, err := d.ImageDigest("hello-world:latest", "amd64")
+	require.NoError(t, err)
+	assert.Equal(t, expectedDigest, digest)
+}
+
+func TestImageDigestNoSchemaFound(t *testing.T) {
+	helloWorldManifest := &manifest.Schema2List{}
+
+	d := ImageDigester{
+		ImageInspector: mockImageInspector{
+			inspect: func(image, arch string) (*manifest.Schema2List, error) {
+				return helloWorldManifest, nil
+			},
+		},
+	}
+
+	digest, err := d.ImageDigest("hello-world:latest", "amd64")
+	require.NoError(t, err)
+	assert.Empty(t, digest)
+}
+
+func TestImageDigestError(t *testing.T) {
+	d := ImageDigester{
+		ImageInspector: mockImageInspector{
+			inspect: func(image, arch string) (*manifest.Schema2List, error) {
+				return nil, fmt.Errorf("image not found")
+			},
+		},
+	}
+
+	digest, err := d.ImageDigest("hello-world:latest", "amd64")
+	require.ErrorContains(t, err, "image not found")
+	assert.Empty(t, digest)
+}

--- a/pkg/container/image_digester_test.go
+++ b/pkg/container/image_digester_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 type mockImageInspector struct {
-	inspect func(image, arch string) (*manifest.Schema2List, error)
+	inspect func(image string) (*manifest.Schema2List, error)
 }
 
-func (m mockImageInspector) Inspect(img, arch string) (*manifest.Schema2List, error) {
+func (m mockImageInspector) Inspect(img string) (*manifest.Schema2List, error) {
 	if m.inspect != nil {
-		return m.inspect(img, arch)
+		return m.inspect(img)
 	}
 
 	panic("not implemented")
@@ -65,7 +65,7 @@ func TestImageDigestValid(t *testing.T) {
 
 	d := ImageDigester{
 		ImageInspector: mockImageInspector{
-			inspect: func(image, arch string) (*manifest.Schema2List, error) {
+			inspect: func(image string) (*manifest.Schema2List, error) {
 				return helloWorldManifest, nil
 			},
 		},
@@ -81,7 +81,7 @@ func TestImageDigestNoSchemaFound(t *testing.T) {
 
 	d := ImageDigester{
 		ImageInspector: mockImageInspector{
-			inspect: func(image, arch string) (*manifest.Schema2List, error) {
+			inspect: func(image string) (*manifest.Schema2List, error) {
 				return helloWorldManifest, nil
 			},
 		},
@@ -95,7 +95,7 @@ func TestImageDigestNoSchemaFound(t *testing.T) {
 func TestImageDigestError(t *testing.T) {
 	d := ImageDigester{
 		ImageInspector: mockImageInspector{
-			inspect: func(image, arch string) (*manifest.Schema2List, error) {
+			inspect: func(image string) (*manifest.Schema2List, error) {
 				return nil, fmt.Errorf("image not found")
 			},
 		},

--- a/pkg/container/image_digester_test.go
+++ b/pkg/container/image_digester_test.go
@@ -76,7 +76,7 @@ func TestImageDigestNoSchemaFound(t *testing.T) {
 	}
 
 	digest, err := d.ImageDigest("hello-world:latest", "amd64")
-	require.NoError(t, err)
+	require.EqualError(t, err, "image is not built for linux/amd64")
 	assert.Empty(t, digest)
 }
 

--- a/pkg/container/image_digester_test.go
+++ b/pkg/container/image_digester_test.go
@@ -31,15 +31,10 @@ func TestImageDigestValid(t *testing.T) {
 					MediaType: "application/vnd.docker.distribution.manifest.v2+json",
 					Size:      1156,
 					Digest:    "sha256:3dfc05677ed97fdf620a3af556d6fe44ec3747262cbf1b4c0c20eed284fd7290",
-					URLs:      []string{},
 				},
 				Platform: manifest.Schema2PlatformSpec{
 					Architecture: "amd64",
 					OS:           "linux",
-					OSVersion:    "",
-					OSFeatures:   []string{},
-					Variant:      "",
-					Features:     []string{},
 				},
 			},
 			{
@@ -47,15 +42,10 @@ func TestImageDigestValid(t *testing.T) {
 					MediaType: "application/vnd.docker.distribution.manifest.v2+json",
 					Size:      1156,
 					Digest:    "sha256:7c831ce05c671702726fc2951fe85048b0b9559f4105b80363424aa935bff2d1",
-					URLs:      []string{},
 				},
 				Platform: manifest.Schema2PlatformSpec{
 					Architecture: "arm64",
 					OS:           "linux",
-					OSVersion:    "",
-					OSFeatures:   []string{},
-					Variant:      "",
-					Features:     []string{},
 				},
 			},
 		},
@@ -77,12 +67,10 @@ func TestImageDigestValid(t *testing.T) {
 }
 
 func TestImageDigestNoSchemaFound(t *testing.T) {
-	helloWorldManifest := &manifest.Schema2List{}
-
 	d := ImageDigester{
 		ImageInspector: mockImageInspector{
 			inspect: func(image string) (*manifest.Schema2List, error) {
-				return helloWorldManifest, nil
+				return &manifest.Schema2List{}, nil
 			},
 		},
 	}
@@ -102,6 +90,6 @@ func TestImageDigestError(t *testing.T) {
 	}
 
 	digest, err := d.ImageDigest("hello-world:latest", "amd64")
-	require.ErrorContains(t, err, "image not found")
+	require.EqualError(t, err, "inspecting image: image not found")
 	assert.Empty(t, digest)
 }

--- a/pkg/eib/eib.go
+++ b/pkg/eib/eib.go
@@ -13,6 +13,7 @@ import (
 	"github.com/suse-edge/edge-image-builder/pkg/build"
 	"github.com/suse-edge/edge-image-builder/pkg/cache"
 	"github.com/suse-edge/edge-image-builder/pkg/combustion"
+	"github.com/suse-edge/edge-image-builder/pkg/container"
 	"github.com/suse-edge/edge-image-builder/pkg/helm"
 	"github.com/suse-edge/edge-image-builder/pkg/image"
 	"github.com/suse-edge/edge-image-builder/pkg/kubernetes"
@@ -166,10 +167,9 @@ func buildCombustion(ctx *image.Context, rootDir string) (*combustion.Combustion
 		}
 	}
 
-	imageDigester := &combustion.ImageDigester{
-		Podman: p,
+	combustionHandler.ImageDigester = &container.ImageDigester{
+		ImageInspector: p,
 	}
-	combustionHandler.ImageDigester = imageDigester
 
 	if !combustion.SkipRPMComponent(ctx) {
 		imgPath := filepath.Join(ctx.ImageConfigDir, "base-images", ctx.ImageDefinition.Image.BaseImage)

--- a/pkg/eib/eib.go
+++ b/pkg/eib/eib.go
@@ -158,37 +158,33 @@ func buildCombustion(ctx *image.Context, rootDir string) (*combustion.Combustion
 		NetworkConfiguratorInstaller: network.ConfiguratorInstaller{},
 	}
 
-	var p *podman.Podman
 	if !combustion.SkipRPMComponent(ctx) || combustion.IsEmbeddedArtifactRegistryConfigured(ctx) {
-		var err error
-		p, err = podman.New(ctx.BuildDir)
+		p, err := podman.New(ctx.BuildDir)
 		if err != nil {
 			return nil, fmt.Errorf("setting up Podman instance: %w", err)
 		}
-	}
 
-	combustionHandler.ImageDigester = &container.ImageDigester{
-		ImageInspector: p,
-	}
-
-	if !combustion.SkipRPMComponent(ctx) {
-		imgPath := filepath.Join(ctx.ImageConfigDir, "base-images", ctx.ImageDefinition.Image.BaseImage)
-		imgType := ctx.ImageDefinition.Image.ImageType
-		baseBuilder := resolver.NewTarballBuilder(ctx.BuildDir, imgPath, imgType, string(ctx.ImageDefinition.Image.Arch), p)
-
-		combustionHandler.RPMResolver = resolver.New(ctx.BuildDir, p, baseBuilder, "", string(ctx.ImageDefinition.Image.Arch))
-		combustionHandler.RPMRepoCreator = rpm.NewRepoCreator(ctx.BuildDir)
-	}
-
-	if combustion.IsEmbeddedArtifactRegistryConfigured(ctx) {
-		helmClient := helm.New(ctx.BuildDir, combustion.HelmCertsPath(ctx))
-
-		r, err := registry.New(ctx, combustion.KubernetesManifestsPath(ctx), helmClient, combustion.HelmValuesPath(ctx))
-		if err != nil {
-			return nil, fmt.Errorf("initialising embedded artifact registry: %w", err)
+		combustionHandler.ImageDigester = &container.ImageDigester{
+			ImageInspector: p,
 		}
 
-		combustionHandler.Registry = r
+		if !combustion.SkipRPMComponent(ctx) {
+			imgPath := filepath.Join(ctx.ImageConfigDir, "base-images", ctx.ImageDefinition.Image.BaseImage)
+			imgType := ctx.ImageDefinition.Image.ImageType
+			baseBuilder := resolver.NewTarballBuilder(ctx.BuildDir, imgPath, imgType, string(ctx.ImageDefinition.Image.Arch), p)
+
+			combustionHandler.RPMResolver = resolver.New(ctx.BuildDir, p, baseBuilder, "", string(ctx.ImageDefinition.Image.Arch))
+			combustionHandler.RPMRepoCreator = rpm.NewRepoCreator(ctx.BuildDir)
+		}
+
+		if combustion.IsEmbeddedArtifactRegistryConfigured(ctx) {
+			helmClient := helm.New(ctx.BuildDir, combustion.HelmCertsPath(ctx))
+
+			combustionHandler.Registry, err = registry.New(ctx, combustion.KubernetesManifestsPath(ctx), helmClient, combustion.HelmValuesPath(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("initialising embedded artifact registry: %w", err)
+			}
+		}
 	}
 
 	if ctx.ImageDefinition.Kubernetes.Version != "" {

--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -147,8 +147,8 @@ func (p *Podman) Copy(id, src, dest string) error {
 }
 
 // Inspect retrieves the full information for a particular container image.
-func (p *Podman) Inspect(img string, arch string) (*manifest.Schema2List, error) {
-	zap.S().Infof("Inspecting %s for linux/%s", img, arch)
+func (p *Podman) Inspect(img string) (*manifest.Schema2List, error) {
+	zap.S().Infof("Inspecting %s", img)
 
 	options := new(manifests.InspectOptions)
 	return manifests.Inspect(p.context, img, options)

--- a/pkg/podman/podman.go
+++ b/pkg/podman/podman.go
@@ -149,7 +149,6 @@ func (p *Podman) Copy(id, src, dest string) error {
 // Inspect returns the sha256 digest for a given container image on a specific architecture
 func (p *Podman) Inspect(img string, arch string) (string, error) {
 	zap.S().Infof("Inspecting %s for linux/%s", img, arch)
-
 	options := new(manifests.InspectOptions)
 	m, err := manifests.Inspect(p.context, img, options)
 	if err != nil {
@@ -157,18 +156,13 @@ func (p *Podman) Inspect(img string, arch string) (string, error) {
 	}
 
 	for i := range m.Manifests {
-		if m.Manifests[i].Platform.OS == "linux" && m.Manifests[i].Platform.Architecture == arch {
-			foundDigest := m.Manifests[i].Digest.String()
-
-			// This is done to remove "sha:" from the digest
-			digest := foundDigest
-			if strings.Contains(foundDigest, ":") {
-				parts := strings.Split(foundDigest, ":")
-				if len(parts) == 2 {
-					digest = parts[1]
-				}
+		manifest := &m.Manifests[i]
+		if manifest.Platform.OS == "linux" && manifest.Platform.Architecture == arch {
+			digest := manifest.Digest.String()
+			// This is done to remove "sha256:" from the digest
+			if parts := strings.Split(digest, "sha256:"); len(parts) == 2 {
+				digest = parts[1]
 			}
-
 			return digest, nil
 		}
 	}

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -32,6 +32,7 @@ type Podman interface {
 	Build(context, name string) error
 	Create(img string) (string, error)
 	Copy(id, src, dest string) error
+	Inspect(img, arc string) (string, error)
 }
 
 type BaseResolverImageBuilder interface {

--- a/pkg/rpm/resolver/resolver.go
+++ b/pkg/rpm/resolver/resolver.go
@@ -32,7 +32,6 @@ type Podman interface {
 	Build(context, name string) error
 	Create(img string) (string, error)
 	Copy(id, src, dest string) error
-	Inspect(img, arc string) (string, error)
 }
 
 type BaseResolverImageBuilder interface {


### PR DESCRIPTION
Closes #625 

For images tagged `latest`, before pulling the image we get the digest for the correct architecture and platform and append that digest to the name of the image to suit our cache implementation. This allows our caching to now properly handle images tagged `latest`. 

As a dependency to reduce the requirement for processing this programmatically, `jq` was added to the EIB container image.