### PR TITLE
Custom tempdir for EAR

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 * Added single-stack IPv6 and dual-stack networking support for Kubernetes
 * SUSEConnect now properly activates the SL Micro "Extras" module
-* Improved documentation for Embedded Artifact Registry
+* Improved Embedded Artifact Registry handling to no longer be memory bound
 
 ## API
 

--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -371,12 +371,6 @@ embeddedArtifactRegistry:
 * `images` - Defines a list of container images to download and host on the node.
   * `name` - Required; Specifies the name, with a tag or digest, of a container image to be pulled and stored.
 
-> **_NOTE_**: The operation of loading container images into the registry requires copying the uncompressed image into
-> `/tmp`, which, during combustion, has a capacity of half of the system's memory. This means that if you have 9GB of
-> RAM and one of the container images is 5GB uncompressed, the registry will fail to load the image
-> citing a `no space left on device` error. The current solution is to ensure that your system has more RAM than double 
-> the size of your largest container image.
-
 # Image Configuration Directory
 
 The Image Configuration Directory contains all the files necessary for EIB to build an image.

--- a/pkg/combustion/registry_test.go
+++ b/pkg/combustion/registry_test.go
@@ -30,7 +30,7 @@ func TestWriteRegistryScript(t *testing.T) {
 	assert.Contains(t, found, "cp $ARTEFACTS_DIR/registry/hauler /opt/hauler/hauler")
 	assert.Contains(t, found, "cp $ARTEFACTS_DIR/registry/*-registry.tar.zst /opt/hauler/")
 	assert.Contains(t, found, "systemctl enable eib-embedded-registry.service")
-	assert.Contains(t, found, "ExecStartPre=/bin/sh -c '/opt/hauler/hauler store load *-registry.tar.zst'")
+	assert.Contains(t, found, "ExecStartPre=/bin/sh -c '/opt/hauler/hauler store load *-registry.tar.zst --tempdir /opt/hauler'")
 	assert.Contains(t, found, "ExecStart=/opt/hauler/hauler store serve registry -p 6545")
 }
 

--- a/pkg/combustion/templates/26-embedded-registry.sh.tpl
+++ b/pkg/combustion/templates/26-embedded-registry.sh.tpl
@@ -14,7 +14,7 @@ After=network.target
 Type=simple
 User=root
 WorkingDirectory=/opt/hauler
-ExecStartPre=/bin/sh -c '/opt/hauler/hauler store load *-{{ .RegistryTarSuffix }}'
+ExecStartPre=/bin/sh -c '/opt/hauler/hauler store load *-{{ .RegistryTarSuffix }} --tempdir /opt/hauler'
 ExecStart=/opt/hauler/hauler store serve registry -p {{ .RegistryPort }}
 Restart=on-failure
 


### PR DESCRIPTION
This was a huge oversight. A solution to the RAM issue was introduced in `v1.0.2` that I completely missed. This change now allows Hauler to create the temporary directory that containers are loaded into in `/opt/hauler` as opposed to `/tmp`.

I have tested both versions of this and found that the final storage usage of `/opt/hauler` remains the same regardless of using `/tmp` or `/opt/hauler` as `--tempdir`.