### PR TITLE
allow duplicate helm chart names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 * Improved Validation for `operatingSystem.enableFIPS` flag
 * Added the ability to build RAW Encrypted Images
 * Improved Embedded Artifact Registry handling to no longer be memory bound
+* Improved Helm chart handling to allow deploying multiple Helm charts with the same chart name
 * Dependency upgrades
   * Go module version is now upgraded from `1.22` to `1.24`
   * Updated MetalLB from `0.14.9` to `0.1.0+up0.14.9`
@@ -22,6 +23,7 @@
 * Added the `operatingSystem.enableExtras` flag to enable the SUSE Linux Extras repository during RPM resolution.
 * Added the `operatingSystem.rawConfiguration.luksKey` field for specifying the LINUX UNIFIED KEY SETUP for modifying RAW Encrypted images
 * Added the `operatingSystem.rawConfiguration.expandEncryptedPartition` field to specify if the LUKS encrypted partition should be expanded during build time
+* Added the `kubernetes.helm.charts.releaseName` field to allow for deploying multiple instances of the same Helm chart.
 
 ### Image Configuration Directory Changes
 
@@ -32,6 +34,7 @@
 * [#594](https://github.com/suse-edge/edge-image-builder/issues/594) - Package installation breaks package resolution if packages are already installed on root OS
 * [#632](https://github.com/suse-edge/edge-image-builder/issues/632) - Create the required Elemental Agent directory structure during Combustion
 * [#625](https://github.com/suse-edge/edge-image-builder/issues/625) - Cache is stale for images tagged `:latest`
+* [#632](https://github.com/suse-edge/edge-image-builder/issues/606) - Allow for duplicate Helm chart names
 
 ---
 

--- a/pkg/image/definition.go
+++ b/pkg/image/definition.go
@@ -218,6 +218,7 @@ type Helm struct {
 
 type HelmChart struct {
 	Name                  string   `yaml:"name"`
+	ReleaseName           string   `yaml:"releaseName"`
 	RepositoryName        string   `yaml:"repositoryName"`
 	Version               string   `yaml:"version"`
 	TargetNamespace       string   `yaml:"targetNamespace"`

--- a/pkg/image/definition_test.go
+++ b/pkg/image/definition_test.go
@@ -200,6 +200,7 @@ func TestParse(t *testing.T) {
 
 	// Helm Charts
 	assert.Equal(t, "apache", kubernetes.Helm.Charts[0].Name)
+	assert.Equal(t, "apache-server", kubernetes.Helm.Charts[0].ReleaseName)
 	assert.Equal(t, "bitnami", kubernetes.Helm.Charts[0].RepositoryName)
 	assert.Equal(t, "10.7.0", kubernetes.Helm.Charts[0].Version)
 	assert.Equal(t, "web", kubernetes.Helm.Charts[0].TargetNamespace)

--- a/pkg/image/testdata/full-valid-example.yaml
+++ b/pkg/image/testdata/full-valid-example.yaml
@@ -106,6 +106,7 @@ kubernetes:
   helm:
     charts:
       - name: apache
+        releaseName: apache-server
         repositoryName: bitnami
         version: 10.7.0
         targetNamespace: web

--- a/pkg/registry/helm_crd.go
+++ b/pkg/registry/helm_crd.go
@@ -32,6 +32,8 @@ type HelmCRD struct {
 }
 
 func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent, repositoryURL string) *HelmCRD {
+	// Some OCI registries (incl. oci://registry.suse.com/edge) use a `-chart` suffix
+	// in the names of the charts which may conflict with .Release.Name references.
 	name := strings.TrimSuffix(chart.Name, "-chart")
 	if chart.ReleaseName != "" {
 		name = chart.ReleaseName
@@ -45,8 +47,6 @@ func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent, repositoryU
 			Namespace   string            `yaml:"namespace,omitempty"`
 			Annotations map[string]string `yaml:"annotations"`
 		}{
-			// Some OCI registries (incl. oci://registry.suse.com/edge) use a `-chart` suffix
-			// in the names of the charts which may conflict with .Release.Name references.
 			Name:      name,
 			Namespace: chart.InstallationNamespace,
 			Annotations: map[string]string{

--- a/pkg/registry/helm_crd.go
+++ b/pkg/registry/helm_crd.go
@@ -32,6 +32,11 @@ type HelmCRD struct {
 }
 
 func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent, repositoryURL string) *HelmCRD {
+	name := strings.TrimSuffix(chart.Name, "-chart")
+	if chart.ReleaseName != "" {
+		name = chart.ReleaseName
+	}
+
 	return &HelmCRD{
 		APIVersion: helmChartAPIVersion,
 		Kind:       helmChartKind,
@@ -42,7 +47,7 @@ func NewHelmCRD(chart *image.HelmChart, chartContent, valuesContent, repositoryU
 		}{
 			// Some OCI registries (incl. oci://registry.suse.com/edge) use a `-chart` suffix
 			// in the names of the charts which may conflict with .Release.Name references.
-			Name:      strings.TrimSuffix(chart.Name, "-chart"),
+			Name:      name,
 			Namespace: chart.InstallationNamespace,
 			Annotations: map[string]string{
 				"edge.suse.com/source":         helmChartSource,

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -121,29 +121,29 @@ func storeHelmCharts(ctx *image.Context, helmClient helmClient) ([]*helmChart, e
 	chartRepositories := mapChartsToRepos(helm)
 
 	var charts []*helmChart
-	seenHelmCharts := make(map[string]string)
+	helmChartPaths := make(map[string]string)
 
 	for i := range helm.Charts {
 		chart := helm.Charts[i]
-		chartConfig := fmt.Sprintf("%s-%s-%s", chart.RepositoryName, chart.Name, chart.Version)
+		chartID := fmt.Sprintf("%s-%s-%s", chart.RepositoryName, chart.Name, chart.Version)
 
 		repository, ok := chartRepositories[helm.Charts[i].RepositoryName]
 		if !ok {
 			return nil, fmt.Errorf("repository not found for chart %s", helm.Charts[i].Name)
 		}
 
-		if _, exists := seenHelmCharts[chartConfig]; !exists {
+		if _, exists := helmChartPaths[chartID]; !exists {
 			localPath, err := downloadChart(helmClient, &helm.Charts[i], repository, helmDir)
 			if err != nil {
 				return nil, fmt.Errorf("downloading chart: %w", err)
 			}
 
-			seenHelmCharts[chartConfig] = localPath
+			helmChartPaths[chartID] = localPath
 		}
 
 		charts = append(charts, &helmChart{
 			HelmChart:     helm.Charts[i],
-			localPath:     seenHelmCharts[chartConfig],
+			localPath:     helmChartPaths[chartID],
 			repositoryURL: repository.URL,
 		})
 


### PR DESCRIPTION
Closes #606 

It is a valid configuration to install multiple Helm charts to the same or different namespaces as long as the name of the release is different. In our case this would be the metadata name of the Helm charts.

This PR removes the validation that prevents defining multiple Helm charts with the same name and instead automatically appends a suffix to the metadata names to be unique.

E.g. if ‘cert-manager’ is defined twice, the metadata names in the Helm CRDs would become ‘cert-manager-1’, ‘cert-manager-2’ which deploy with no issue.

```
kube-system    job.batch/helm-install-cert-manager-1                     Complete   1/1           43s        16m
kube-system    job.batch/helm-install-cert-manager-2                     Complete   1/1           43s        16m
```

```
cert-manager                      deployment.apps/cert-manager-1                         1/1     1            1           16m
cert-manager                      deployment.apps/cert-manager-1-cainjector              1/1     1            1           16m
cert-manager                      deployment.apps/cert-manager-1-webhook                 1/1     1            1           16m
cert-manager                      deployment.apps/cert-manager-2                         1/1     1            1           16m
cert-manager                      deployment.apps/cert-manager-2-cainjector              1/1     1            1           16m
cert-manager                      deployment.apps/cert-manager-2-webhook                 1/1     1            1           16m
```

We will also now instead spit out a warning so that users are aware of this in case it is not intentional
```
WARNING: The Helm chart 'rancher' has been defined multiple times, while this is a valid configuration, please ensure this is intentional.
WARNING: The Helm chart 'cert-manager' has been defined multiple times, while this is a valid configuration, please ensure this is intentional.
```