### PR TITLE
[DOCS] Building Images OS Config missing createHomeDir in Example #656

### DIFF
--- a/docs/building-images.md
+++ b/docs/building-images.md
@@ -85,6 +85,7 @@ operatingSystem:
     - name: group2
   users:
   - username: user1
+    createHomeDir: true
     encryptedPassword: 123
     sshKeys:
       - user1Key1
@@ -98,6 +99,7 @@ operatingSystem:
     secondaryGroups:
       - group3
   - username: user3
+    createHomeDir: true
     sshKeys:
       - user3Key
   systemd:


### PR DESCRIPTION
PR updates `docs/building-images.md` in the example code block and adds `createHomeDir: true` where ssh-keys are added. Fixes #656