### PR TITLE
Forward-Port: Support ISOs with SHA256 checksums (#698)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Edge Image Builder Releases
 
+# v1.2.0-rc1
+
+## Bug Fixes
+
+* [#699](https://github.com/suse-edge/edge-image-builder/issues/699) - SL Micro 6.0/6.1 images updated via KIWI fail to build due to a different checksum format
+
+---
+
 # v1.2.0-rc0
 
 ## General
@@ -39,6 +47,14 @@
 * [#632](https://github.com/suse-edge/edge-image-builder/issues/632) - Create the required Elemental Agent directory structure during Combustion
 * [#625](https://github.com/suse-edge/edge-image-builder/issues/625) - Cache is stale for images tagged `:latest`
 * [#632](https://github.com/suse-edge/edge-image-builder/issues/606) - Allow for duplicate Helm chart names
+
+---
+
+# v1.1.1
+
+## Bug Fixes
+
+* [#699](https://github.com/suse-edge/edge-image-builder/issues/699) - SL Micro 6.0 images updated via KIWI fail to build due to a different checksum format
 
 ---
 


### PR DESCRIPTION
This was placed into release-1.1, and not main. This also needs to go into main for Edge 3.3, which leverages SL Micro 6.1, which also now has the sha256 checksums.

cherry-picks ba4e9e159989000d3cd9a8a8bc4b2761ef2030fa