### PR TITLE
explicitly mount and unmount /usr/local for os files handling

### DIFF
--- a/pkg/combustion/templates/19-copy-os-files.sh
+++ b/pkg/combustion/templates/19-copy-os-files.sh
@@ -2,5 +2,7 @@
 set -euo pipefail
 
 mount /var
+mount /usr/local
 cp -R ./os-files/* /
 umount /var
+umount /usr/local


### PR DESCRIPTION
Similar to https://github.com/suse-edge/edge-image-builder/issues/593, files in os-files/usr/local are not copied properly